### PR TITLE
Modsourman 9 Initializing job executions

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -18,6 +18,7 @@
     <vertx.version>3.5.4</vertx.version>
     <junit.version>4.12</junit.version>
     <rest-assured.version>3.1.1</rest-assured.version>
+    <wiremock.version>2.19.0</wiremock.version>
     <ramlfiles_path>${basedir}/ramls</ramlfiles_path>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
   </properties>
@@ -66,6 +67,18 @@
       <artifactId>rest-assured</artifactId>
       <version>${rest-assured.version}</version>
       <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>com.github.tomakehurst</groupId>
+      <artifactId>wiremock</artifactId>
+      <version>${wiremock.version}</version>
+      <scope>test</scope>
+      <exclusions>
+        <exclusion>
+          <groupId>net.sf.jopt-simple</groupId>
+          <artifactId>jopt-simple</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
   </dependencies>
 

--- a/src/main/java/org/folio/dao/JobExecutionDao.java
+++ b/src/main/java/org/folio/dao/JobExecutionDao.java
@@ -6,6 +6,7 @@ import org.folio.rest.jaxrs.model.JobExecutionCollection;
 
 /**
  * DAO interface for the JobExecution entity
+ *
  * @see JobExecution
  */
 public interface JobExecutionDao {
@@ -19,5 +20,14 @@ public interface JobExecutionDao {
    * @return future with {@link JobExecutionCollection}
    */
   Future<JobExecutionCollection> getJobExecutions(String query, int offset, int limit);
+
+
+  /**
+   * Saves {@link JobExecution} to database
+   *
+   * @param jobExecution {@link JobExecution} to save
+   * @return future
+   */
+  Future<String> save(JobExecution jobExecution);
 
 }

--- a/src/main/java/org/folio/dao/JobExecutionDaoImpl.java
+++ b/src/main/java/org/folio/dao/JobExecutionDaoImpl.java
@@ -38,11 +38,18 @@ public class JobExecutionDaoImpl implements JobExecutionDao {
       CQLWrapper cql = getCQLWrapper(TABLE_NAME, query, limit, offset);
       pgClient.get(TABLE_NAME, JobExecution.class, fieldList, cql, true, false, future.completer());
     } catch (Exception e) {
-      LOG.error("Error while querying db", e);
+      LOG.error("Error while getting JobExecutions", e);
       future.fail(e);
     }
     return future.map(results -> new JobExecutionCollection()
       .withJobExecutions(results.getResults())
       .withTotalRecords(results.getResultInfo().getTotalRecords()));
+  }
+
+  @Override
+  public Future<String> save(JobExecution jobExecution) {
+    Future<String> future = Future.future();
+    pgClient.save(TABLE_NAME, jobExecution.getId(), jobExecution, future.completer());
+    return future;
   }
 }

--- a/src/main/java/org/folio/dao/JobExecutionDaoImpl.java
+++ b/src/main/java/org/folio/dao/JobExecutionDaoImpl.java
@@ -23,7 +23,7 @@ public class JobExecutionDaoImpl implements JobExecutionDao {
 
   private static final Logger LOG = LoggerFactory.getLogger(JobExecutionDaoImpl.class);
 
-  private static final String TABLE_NAME = "job_executions";
+  public static final String TABLE_NAME = "job_executions";
   private PostgresClient pgClient;
 
   public JobExecutionDaoImpl(Vertx vertx, String tenantId) {

--- a/src/main/java/org/folio/rest/impl/ChangeManagerImpl.java
+++ b/src/main/java/org/folio/rest/impl/ChangeManagerImpl.java
@@ -5,6 +5,8 @@ import io.vertx.core.Context;
 import io.vertx.core.Future;
 import io.vertx.core.Handler;
 import io.vertx.core.Vertx;
+import io.vertx.core.logging.Logger;
+import io.vertx.core.logging.LoggerFactory;
 import org.folio.rest.jaxrs.model.InitJobExecutionsRqDto;
 import org.folio.rest.jaxrs.resource.ChangeManager;
 import org.folio.rest.tools.utils.TenantTool;
@@ -19,6 +21,7 @@ import java.util.Map;
 public class ChangeManagerImpl implements ChangeManager {
 
   private JobExecutionService jobExecutionService;
+  private static final Logger LOGGER = LoggerFactory.getLogger(ChangeManagerImpl.class);
 
   public ChangeManagerImpl(Vertx vertx, String tenantId) {
     String calculatedTenantId = TenantTool.calculateTenantId(tenantId);
@@ -36,6 +39,7 @@ public class ChangeManagerImpl implements ChangeManager {
           .otherwise(ExceptionHelper::mapExceptionToResponse)
           .setHandler(asyncResultHandler);
       } catch (Exception e) {
+        LOGGER.error("Error during initializing JobExecution entities", e, e.getMessage());
         asyncResultHandler.handle(Future.failedFuture(e));
       }
     });

--- a/src/main/java/org/folio/services/JobExecutionService.java
+++ b/src/main/java/org/folio/services/JobExecutionService.java
@@ -1,6 +1,7 @@
 package org.folio.services;
 
 import io.vertx.core.Future;
+import org.folio.dao.JobExecutionDao;
 import org.folio.rest.jaxrs.model.InitJobExecutionsRqDto;
 import org.folio.rest.jaxrs.model.InitJobExecutionsRsDto;
 import org.folio.rest.jaxrs.model.JobExecution;
@@ -27,8 +28,12 @@ public interface JobExecutionService {
 
   /**
    * Performs creation of JobExecution and Snapshot entities
+   * Saves created JobExecution entities into storage using {@link JobExecutionDao}
+   * Performs save for created Snapshot entities.
+   * For each Snapshot posts the request to mod-source-record-manager.
    *
-   * @param dto Dto contains request params enough to create JobExecution and Snapshot entities
+   * @param dto    Dto contains request params enough to create JobExecution and Snapshot entities
+   * @param params object-wrapper with params necessary to connect to OKAPI
    * @return Future
    */
   Future<InitJobExecutionsRsDto> initializeJobExecutions(InitJobExecutionsRqDto dto, OkapiConnectionParams params);

--- a/src/main/java/org/folio/services/JobExecutionService.java
+++ b/src/main/java/org/folio/services/JobExecutionService.java
@@ -1,11 +1,15 @@
 package org.folio.services;
 
 import io.vertx.core.Future;
+import org.folio.rest.jaxrs.model.InitJobExecutionsRqDto;
+import org.folio.rest.jaxrs.model.InitJobExecutionsRsDto;
 import org.folio.rest.jaxrs.model.JobExecution;
 import org.folio.rest.jaxrs.model.JobExecutionCollectionDto;
+import org.folio.util.OkapiConnectionParams;
 
 /**
  * JobExecution Service interface, contains logic for accessing jobs.
+ *
  * @see JobExecution
  * @see org.folio.dao.JobExecutionDao
  * @see org.folio.rest.jaxrs.model.JobExecutionDto
@@ -20,5 +24,13 @@ public interface JobExecutionService {
    * @param limit  maximum number of results to return
    */
   Future<JobExecutionCollectionDto> getCollectionDtoByQuery(String query, int offset, int limit);
+
+  /**
+   * Performs creation of JobExecution and Snapshot entities
+   *
+   * @param dto Dto contains request params enough to create JobExecution and Snapshot entities
+   * @return Future
+   */
+  Future<InitJobExecutionsRsDto> initializeJobExecutions(InitJobExecutionsRqDto dto, OkapiConnectionParams params);
 
 }

--- a/src/main/java/org/folio/services/JobExecutionServiceImpl.java
+++ b/src/main/java/org/folio/services/JobExecutionServiceImpl.java
@@ -53,8 +53,9 @@ public class JobExecutionServiceImpl implements JobExecutionService {
 
   public Future<InitJobExecutionsRsDto> initializeJobExecutions(InitJobExecutionsRqDto jobExecutionsRqDto, OkapiConnectionParams params) {
     if (jobExecutionsRqDto.getFiles().isEmpty()) {
-      logger.error("Received files must not be empty");
-      return Future.failedFuture(new BadRequestException());
+      String errorMessage = "Received files must not be empty";
+      logger.error(errorMessage);
+      return Future.failedFuture(new BadRequestException(errorMessage));
     } else {
       String parentJobExecutionId = UUID.randomUUID().toString();
 
@@ -154,6 +155,7 @@ public class JobExecutionServiceImpl implements JobExecutionService {
    * For each Snapshot posts the request to mod-source-record-manager.
    *
    * @param snapshots list of Snapshot entities
+   * @param params object-wrapper with params necessary to connect to OKAPI
    * @return future
    */
   private Future saveSnapshots(List<JsonObject> snapshots, OkapiConnectionParams params) {

--- a/src/main/java/org/folio/services/JobExecutionServiceImpl.java
+++ b/src/main/java/org/folio/services/JobExecutionServiceImpl.java
@@ -61,15 +61,14 @@ public class JobExecutionServiceImpl implements JobExecutionService {
       List<JobExecution> jobExecutions = prepareJobExecutionList(parentJobExecutionId, jobExecutionsRqDto.getFiles());
       List<JsonObject> snapshots = prepareSnapshotList(jobExecutions);
 
-      Future savedJsobExecutionsFuture = saveJobExecutions(jobExecutions);
+      Future savedJsonExecutionsFuture = saveJobExecutions(jobExecutions);
       Future savedSnapshotsFuture = saveSnapshots(snapshots, params);
 
-      return CompositeFuture.all(savedJsobExecutionsFuture, savedSnapshotsFuture)
+      return CompositeFuture.all(savedJsonExecutionsFuture, savedSnapshotsFuture)
         .map(new InitJobExecutionsRsDto()
           .withParentJobExecutionId(parentJobExecutionId)
           .withJobExecutions(jobExecutions));
     }
-
   }
 
   private List<JobExecution> prepareJobExecutionList(String parentJobExecutionId, List<File> files) {
@@ -117,7 +116,7 @@ public class JobExecutionServiceImpl implements JobExecutionService {
   }
 
   private Future<List<String>> saveJobExecutions(List<JobExecution> jobExecutions) {
-    List<Future> savedJobExecutionFutures = new ArrayList<>();;
+    List<Future> savedJobExecutionFutures = new ArrayList<>();
     for (JobExecution jobExecution : jobExecutions) {
       Future<String> savedJobExecutionFuture = jobExecutionDao.save(jobExecution);
       savedJobExecutionFutures.add(savedJobExecutionFuture);

--- a/src/main/java/org/folio/services/JobExecutionServiceImpl.java
+++ b/src/main/java/org/folio/services/JobExecutionServiceImpl.java
@@ -1,21 +1,41 @@
 package org.folio.services;
 
+import io.vertx.core.CompositeFuture;
 import io.vertx.core.Future;
 import io.vertx.core.Vertx;
+import io.vertx.core.http.HttpMethod;
+import io.vertx.core.json.JsonObject;
+import io.vertx.core.logging.Logger;
+import io.vertx.core.logging.LoggerFactory;
 import org.folio.dao.JobExecutionDao;
 import org.folio.dao.JobExecutionDaoImpl;
+import org.folio.rest.jaxrs.model.File;
+import org.folio.rest.jaxrs.model.InitJobExecutionsRqDto;
+import org.folio.rest.jaxrs.model.InitJobExecutionsRsDto;
 import org.folio.rest.jaxrs.model.JobExecution;
 import org.folio.rest.jaxrs.model.JobExecutionCollectionDto;
 import org.folio.services.converters.JobExecutionToDtoConverter;
+import org.folio.util.OkapiConnectionParams;
+import org.folio.util.RestUtil;
+
+import javax.ws.rs.BadRequestException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.UUID;
+
+import static org.folio.util.RestUtil.CREATED_STATUS_CODE;
 
 /**
  * Implementation of the JobExecutionService, calls JobExecutionDao to access JobExecution metadata.
+ *
  * @see JobExecutionService
  * @see JobExecutionDao
  * @see JobExecution
  */
 public class JobExecutionServiceImpl implements JobExecutionService {
 
+  public static final String SNAPSHOT_SERVICE_URL = "/source-storage/snapshot";
+  private static final Logger logger = LoggerFactory.getLogger(JobExecutionServiceImpl.class);
   private JobExecutionDao jobExecutionDao;
   private JobExecutionToDtoConverter jobExecutionToDtoConverter;
 
@@ -31,4 +51,109 @@ public class JobExecutionServiceImpl implements JobExecutionService {
         .withTotalRecords(jobExecutionCollection.getTotalRecords()));
   }
 
+  public Future<InitJobExecutionsRsDto> initializeJobExecutions(InitJobExecutionsRqDto jobExecutionsRqDto, OkapiConnectionParams params) {
+    Future<InitJobExecutionsRsDto> future = Future.future();
+    if (jobExecutionsRqDto.getFiles().isEmpty()) {
+      logger.error("Received files must not be empty");
+      future.fail(new BadRequestException());
+    } else {
+      String parentJobExecutionId = UUID.randomUUID().toString();
+
+      List<JobExecution> jobExecutions = prepareJobExecutionList(parentJobExecutionId, jobExecutionsRqDto.getFiles());
+      List<JsonObject> snapshots = prepareSnapshotList(jobExecutions);
+
+      saveJobExecutions(jobExecutions);
+      saveSnapshots(snapshots, params);
+
+      // TODO wait for the completion of save JobExecutions and Snapshots if needed
+
+      future.complete(new InitJobExecutionsRsDto()
+        .withParentJobExecutionId(parentJobExecutionId)
+        .withJobExecutions(jobExecutions));
+    }
+    return future;
+  }
+
+  private List<JobExecution> prepareJobExecutionList(String parentJobExecutionId, List<File> files) {
+    List<JobExecution> result = new ArrayList<>();
+    if (files.size() > 1) {
+      for (File file : files) {
+        JobExecution child = new JobExecution()
+          .withId(UUID.randomUUID().toString())
+          .withParentJobId(parentJobExecutionId)
+          .withSubordinationType(JobExecution.SubordinationType.CHILD)
+          .withStatus(JobExecution.Status.NEW)
+          .withSourcePath(file.getName());
+        result.add(child);
+      }
+      JobExecution parentMultiple = new JobExecution()
+        .withId(parentJobExecutionId)
+        .withParentJobId(parentJobExecutionId)
+        .withSubordinationType(JobExecution.SubordinationType.PARENT_MULTIPLE)
+        .withStatus(JobExecution.Status.NEW);
+      result.add(parentMultiple);
+    } else {
+      File file = files.get(0);
+      JobExecution parentSingle = new JobExecution()
+        .withId(parentJobExecutionId)
+        .withParentJobId(parentJobExecutionId)
+        .withSubordinationType(JobExecution.SubordinationType.PARENT_SINGLE)
+        .withStatus(JobExecution.Status.NEW)
+        .withSourcePath(file.getName());
+      result.add(parentSingle);
+    }
+    return result;
+  }
+
+  private List<JsonObject> prepareSnapshotList(List<JobExecution> jobExecutions) {
+    List<JsonObject> jsonSnapshots = new ArrayList<>();
+    for (JobExecution jobExecution : jobExecutions) {
+      if (!JobExecution.SubordinationType.PARENT_MULTIPLE.equals(jobExecution.getSubordinationType())) {
+        JsonObject jsonSnapshot = new JsonObject();
+        jsonSnapshot.put("jobExecutionId", jobExecution.getId());
+        jsonSnapshot.put("status", JobExecution.Status.NEW.name());
+        jsonSnapshots.add(jsonSnapshot);
+      }
+    }
+    return jsonSnapshots;
+  }
+
+  private Future<List<String>> saveJobExecutions(List<JobExecution> jobExecutions) {
+    List<Future> savedJobExecutionFutures = new ArrayList<>();
+    for (JobExecution jobExecution : jobExecutions) {
+      Future<String> savedJobExecutionFuture = jobExecutionDao.save(jobExecution);
+      savedJobExecutionFutures.add(savedJobExecutionFuture);
+    }
+    return CompositeFuture.all(savedJobExecutionFutures).map(compositeFuture -> compositeFuture.result().list());
+  }
+
+  private Future saveSnapshots(List<JsonObject> snapshots, OkapiConnectionParams params) {
+    List<Future> postedSnapshotFutures = new ArrayList<>();
+    for (JsonObject snapshot : snapshots) {
+      Future<String> postedSnapshotFuture = postSnapshot(snapshot, params);
+      postedSnapshotFutures.add(postedSnapshotFuture);
+    }
+    return CompositeFuture.all(postedSnapshotFutures).map(compositeFuture -> compositeFuture.result().list());
+  }
+
+  private Future<String> postSnapshot(JsonObject snapshot, OkapiConnectionParams params) {
+    Future<String> future = Future.future();
+    RestUtil.doRequest(params, SNAPSHOT_SERVICE_URL, HttpMethod.POST, snapshot.encode())
+      .setHandler(responseResult -> {
+        try {
+          int responseCode = responseResult.result().getCode();
+          if (responseResult.failed() || responseCode != CREATED_STATUS_CODE) {
+            logger.error("Error during post for new Snapshot. Response code: " + responseCode, responseResult.cause());
+            future.fail(responseResult.cause());
+          } else {
+            String responseBody = responseResult.result().getBody();
+            future.complete(responseBody);
+          }
+        } catch (Exception e) {
+          logger.error("Error during post for new Snapshot", e, e.getMessage());
+          future.fail(e);
+        }
+      });
+    return future;
+  }
 }

--- a/src/main/java/org/folio/util/OkapiConnectionParams.java
+++ b/src/main/java/org/folio/util/OkapiConnectionParams.java
@@ -1,0 +1,65 @@
+package org.folio.util;
+
+import io.vertx.core.Vertx;
+import io.vertx.core.http.CaseInsensitiveHeaders;
+
+import java.util.Map;
+
+import static org.folio.util.RestUtil.OKAPI_TENANT_HEADER;
+import static org.folio.util.RestUtil.OKAPI_TOKEN_HEADER;
+import static org.folio.util.RestUtil.OKAPI_URL_HEADER;
+
+/**
+ * Wrapper class for Okapi connection params
+ */
+public class OkapiConnectionParams {
+
+  private static final int DEF_TIMEOUT = 2000;
+  private String okapiUrl;
+  private String tenantId;
+  private String token;
+  private Vertx vertx;
+  private Integer timeout;
+  private CaseInsensitiveHeaders headers = new CaseInsensitiveHeaders();
+
+  public OkapiConnectionParams(Map<String, String> okapiHeaders, Vertx vertx, Integer timeout) {
+    this.okapiUrl = okapiHeaders.getOrDefault(OKAPI_URL_HEADER, "localhost");
+    this.tenantId = okapiHeaders.getOrDefault(OKAPI_TENANT_HEADER, "");
+    this.token = okapiHeaders.getOrDefault(OKAPI_TOKEN_HEADER, "dummy");
+    this.vertx = vertx;
+    this.timeout = timeout != null ? timeout : DEF_TIMEOUT;
+    this.headers.addAll(okapiHeaders);
+  }
+
+  public OkapiConnectionParams(Map<String, String> okapiHeaders, Vertx vertx) {
+    this(okapiHeaders, vertx, null);
+  }
+
+  public String getOkapiUrl() {
+    return okapiUrl;
+  }
+
+  public String getTenantId() {
+    return tenantId;
+  }
+
+  public String getToken() {
+    return token;
+  }
+
+  public Vertx getVertx() {
+    return vertx;
+  }
+
+  public int getTimeout() {
+    return timeout;
+  }
+
+  public CaseInsensitiveHeaders getHeaders() {
+    return headers;
+  }
+
+  public void setHeaders(CaseInsensitiveHeaders headers) {
+    this.headers = headers;
+  }
+}

--- a/src/main/java/org/folio/util/RestUtil.java
+++ b/src/main/java/org/folio/util/RestUtil.java
@@ -1,0 +1,113 @@
+package org.folio.util;
+
+import io.vertx.core.Future;
+import io.vertx.core.http.CaseInsensitiveHeaders;
+import io.vertx.core.http.HttpClient;
+import io.vertx.core.http.HttpClientOptions;
+import io.vertx.core.http.HttpClientRequest;
+import io.vertx.core.http.HttpClientResponse;
+import io.vertx.core.http.HttpMethod;
+import io.vertx.core.json.JsonObject;
+
+import java.util.Map;
+
+/**
+ * Util class with static method for sending http request
+ */
+public class RestUtil {
+
+  public static final String OKAPI_TENANT_HEADER = "x-okapi-tenant";
+  public static final String OKAPI_TOKEN_HEADER = "x-okapi-token";
+  public static final String OKAPI_URL_HEADER = "x-okapi-url";
+  public static final int CREATED_STATUS_CODE = 201;
+
+  public static class WrappedResponse {
+    private int code;
+    private String body;
+    private JsonObject json;
+    private HttpClientResponse response;
+
+    WrappedResponse(int code, String body,
+                    HttpClientResponse response) {
+      this.code = code;
+      this.body = body;
+      this.response = response;
+      try {
+        json = new JsonObject(body);
+      } catch (Exception e) {
+        json = null;
+      }
+    }
+
+    public int getCode() {
+      return code;
+    }
+
+    public String getBody() {
+      return body;
+    }
+
+    public HttpClientResponse getResponse() {
+      return response;
+    }
+
+    public JsonObject getJson() {
+      return json;
+    }
+  }
+
+  private RestUtil() {
+  }
+
+  /**
+   * Create http request
+   *
+   * @param url     - url for http request
+   * @param method  - http method
+   * @param payload - body of request
+   * @return - async http response
+   */
+  public static Future<WrappedResponse> doRequest(OkapiConnectionParams params, String url,
+                                                  HttpMethod method, String payload) {
+    Future<WrappedResponse> future = Future.future();
+    try {
+      CaseInsensitiveHeaders headers = params.getHeaders();
+      String requestUrl = params.getOkapiUrl() + url;
+      HttpClientRequest request = getHttpClient(params).requestAbs(method, requestUrl);
+      if (headers != null) {
+        headers.add("Content-type", "application/json")
+          .add("Accept", "application/json, text/plain");
+        for (Map.Entry entry : headers.entries()) {
+          request.putHeader((String) entry.getKey(), (String) entry.getValue());
+        }
+      }
+      request.exceptionHandler(future::fail);
+      request.handler(req -> req.bodyHandler(buf -> {
+        WrappedResponse wr = new WrappedResponse(req.statusCode(), buf.toString(), req);
+        future.complete(wr);
+      }));
+      if (method == HttpMethod.PUT || method == HttpMethod.POST) {
+        request.end(payload);
+      } else {
+        request.end();
+      }
+      return future;
+    } catch (Exception e) {
+      future.fail(e);
+      return future;
+    }
+  }
+
+  /**
+   * Prepare HttpClient from OkapiConnection params
+   *
+   * @param params - Okapi connection params
+   * @return - Vertx Http Client
+   */
+  private static HttpClient getHttpClient(OkapiConnectionParams params) {
+    HttpClientOptions options = new HttpClientOptions();
+    options.setConnectTimeout(params.getTimeout());
+    options.setIdleTimeout(params.getTimeout());
+    return params.getVertx().createHttpClient(options);
+  }
+}

--- a/src/test/java/org/folio/rest/impl/changeManager/ChangeManagerAPITest.java
+++ b/src/test/java/org/folio/rest/impl/changeManager/ChangeManagerAPITest.java
@@ -1,24 +1,38 @@
 package org.folio.rest.impl.changeManager;
 
+import com.github.tomakehurst.wiremock.client.WireMock;
+import com.github.tomakehurst.wiremock.common.ConsoleNotifier;
+import com.github.tomakehurst.wiremock.core.WireMockConfiguration;
+import com.github.tomakehurst.wiremock.junit.WireMockRule;
 import io.restassured.RestAssured;
+import io.restassured.builder.RequestSpecBuilder;
+import io.restassured.http.ContentType;
 import io.restassured.response.ResponseBodyExtractionOptions;
 import io.restassured.specification.RequestSpecification;
-import io.vertx.core.http.HttpHeaders;
 import io.vertx.core.json.JsonObject;
 import io.vertx.ext.unit.TestContext;
 import io.vertx.ext.unit.junit.VertxUnitRunner;
+import org.apache.http.HttpStatus;
+import org.folio.dao.JobExecutionDaoImpl;
+import org.folio.rest.RestVerticle;
 import org.folio.rest.impl.AbstractRestTest;
 import org.folio.rest.jaxrs.model.File;
 import org.folio.rest.jaxrs.model.InitJobExecutionsRqDto;
 import org.folio.rest.jaxrs.model.JobExecution;
+import org.folio.rest.persist.Criteria.Criterion;
+import org.folio.rest.persist.PostgresClient;
+import org.folio.services.JobExecutionServiceImpl;
 import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
-import javax.ws.rs.core.MediaType;
 import java.util.List;
+import java.util.UUID;
 
-import static org.folio.rest.RestVerticle.OKAPI_HEADER_TENANT;
+import static org.folio.util.RestUtil.OKAPI_TENANT_HEADER;
+import static org.folio.util.RestUtil.OKAPI_URL_HEADER;
 
 /**
  * REST tests for ChangeManager to manager JobExecution entities initialization
@@ -27,38 +41,131 @@ import static org.folio.rest.RestVerticle.OKAPI_HEADER_TENANT;
 @RunWith(VertxUnitRunner.class)
 public class ChangeManagerAPITest extends AbstractRestTest {
 
-
   private static final String CHANGE_MANAGER_PATH = "/change-manager";
-  private static final String ACCEPT_VALUES = "application/json, text/plain";
+  private static final String POST_JOB_EXECUTIONS_PATH = CHANGE_MANAGER_PATH + "/jobExecutions";
+
+  private static RequestSpecification spec;
+  private static String postedSnapshotResponseBody = UUID.randomUUID().toString();
+
+  @Rule
+  public WireMockRule snapshotMockServer = new WireMockRule(
+    WireMockConfiguration.wireMockConfig()
+      .dynamicPort()
+      .notifier(new ConsoleNotifier(true)));
+
+  @Before
+  public void setUp(TestContext context) {
+    spec = new RequestSpecBuilder()
+      .setContentType(ContentType.JSON)
+      .addHeader(OKAPI_URL_HEADER, "http://localhost:" + snapshotMockServer.port())
+      .addHeader(OKAPI_TENANT_HEADER, TENANT_ID)
+      .addHeader(RestVerticle.OKAPI_USERID_HEADER, UUID.randomUUID().toString())
+      .addHeader("Accept", "text/plain, application/json")
+      .setBaseUri("http://localhost:" + port)
+      .build();
+
+    WireMock.stubFor(WireMock.post(JobExecutionServiceImpl.SNAPSHOT_SERVICE_URL)
+      .willReturn(WireMock.created().withBody(postedSnapshotResponseBody)));
+
+    clearTable(context);
+  }
 
   @Test
-  public void testInitJobExecutions(TestContext context) {
-    String servicePath = "/jobExecutions";
-    String testUrl = CHANGE_MANAGER_PATH + servicePath;
+  public void testInitJobExecutionsWith1File(TestContext context) {
+    // given
     InitJobExecutionsRqDto requestDto = new InitJobExecutionsRqDto();
-
     requestDto.getFiles().add(new File().withName("importBib.bib"));
-    requestDto.getFiles().add(new File().withName("importMarc.marc"));
+    int expectedJobExecutionsNumber = 1;
 
-    ResponseBodyExtractionOptions body = getDefaultGiven()
-      .port(port)
+    // when
+    ResponseBodyExtractionOptions body = RestAssured.given()
+      .spec(spec)
       .header(TENANT_HEADER)
       .body(JsonObject.mapFrom(requestDto).toString())
-      .when().post(testUrl)
-      .then().statusCode(201)
+      .when().post(POST_JOB_EXECUTIONS_PATH)
+      .then().statusCode(HttpStatus.SC_CREATED)
       .extract().body();
 
+    // then
     String actualParentJobExecutionId = body.jsonPath().getObject("parentJobExecutionId", String.class);
     List<JobExecution> actualJobExecutions = body.jsonPath().getObject("jobExecutions", List.class);
 
     Assert.assertNotNull(actualParentJobExecutionId);
-    Assert.assertEquals(requestDto.getFiles().size(), actualJobExecutions.size());
+    Assert.assertEquals(expectedJobExecutionsNumber, actualJobExecutions.size());
   }
 
-  protected RequestSpecification getDefaultGiven() {
-    return RestAssured.given()
-      .header(OKAPI_HEADER_TENANT, TENANT_ID)
-      .header(HttpHeaders.ACCEPT.toString(), ACCEPT_VALUES)
-      .header(HttpHeaders.CONTENT_TYPE.toString(), MediaType.APPLICATION_JSON);
+  @Test
+  public void testInitJobExecutionsWith2Files(TestContext context) {
+    // given
+    String servicePath = "/jobExecutions";
+    String testUrl = CHANGE_MANAGER_PATH + servicePath;
+    InitJobExecutionsRqDto requestDto = new InitJobExecutionsRqDto();
+    requestDto.getFiles().add(new File().withName("importBib.bib"));
+    requestDto.getFiles().add(new File().withName("importMarc.mrc"));
+    int expectedJobExecutionsNumber = 3;
+
+    // when
+    ResponseBodyExtractionOptions body = RestAssured.given()
+      .spec(spec)
+      .header(TENANT_HEADER)
+      .body(JsonObject.mapFrom(requestDto).toString())
+      .when().post(testUrl)
+      .then().statusCode(HttpStatus.SC_CREATED)
+      .extract().body();
+
+    // then
+    String actualParentJobExecutionId = body.jsonPath().getObject("parentJobExecutionId", String.class);
+    List<JobExecution> actualJobExecutions = body.jsonPath().getObject("jobExecutions", List.class);
+
+    Assert.assertNotNull(actualParentJobExecutionId);
+    Assert.assertEquals(expectedJobExecutionsNumber, actualJobExecutions.size());
+  }
+
+  @Test
+  public void testInitJobExecutionsWith3Files(TestContext context) {
+    // given
+    InitJobExecutionsRqDto requestDto = new InitJobExecutionsRqDto();
+    requestDto.getFiles().add(new File().withName("importBib1.bib"));
+    requestDto.getFiles().add(new File().withName("importBib2.bib"));
+    requestDto.getFiles().add(new File().withName("importMarc1.bib"));
+    int expectedJobExecutionsNumber = 4;
+
+    // when
+    ResponseBodyExtractionOptions body = RestAssured.given()
+      .spec(spec)
+      .header(TENANT_HEADER)
+      .body(JsonObject.mapFrom(requestDto).toString())
+      .when().post(POST_JOB_EXECUTIONS_PATH)
+      .then().statusCode(HttpStatus.SC_CREATED)
+      .extract().body();
+
+    // then
+    String actualParentJobExecutionId = body.jsonPath().getObject("parentJobExecutionId", String.class);
+    List<JobExecution> actualJobExecutions = body.jsonPath().getObject("jobExecutions", List.class);
+
+    Assert.assertNotNull(actualParentJobExecutionId);
+    Assert.assertEquals(expectedJobExecutionsNumber, actualJobExecutions.size());
+  }
+
+  @Test
+  public void testInitJobExecutionsWithNoFiles(TestContext context) {
+    // given
+    InitJobExecutionsRqDto requestDto = new InitJobExecutionsRqDto();
+
+    // when
+    RestAssured.given()
+      .spec(spec)
+      .header(TENANT_HEADER)
+      .body(JsonObject.mapFrom(requestDto).toString())
+      .when().post(POST_JOB_EXECUTIONS_PATH)
+      .then().statusCode(HttpStatus.SC_BAD_REQUEST);
+  }
+
+  private void clearTable(TestContext context) {
+    PostgresClient.getInstance(vertx, TENANT_ID).delete(JobExecutionDaoImpl.TABLE_NAME, new Criterion(), event -> {
+      if (event.failed()) {
+        context.fail(event.cause());
+      }
+    });
   }
 }

--- a/src/test/java/org/folio/rest/impl/changeManager/ChangeManagerAPITest.java
+++ b/src/test/java/org/folio/rest/impl/changeManager/ChangeManagerAPITest.java
@@ -98,6 +98,7 @@ public class ChangeManagerAPITest extends AbstractRestTest {
     Assert.assertEquals(expectedJobExecutionsNumber, actualJobExecutions.size());
 
     JobExecution parentSingle = actualJobExecutions.get(0);
+    Assert.assertEquals(JobExecution.SubordinationType.PARENT_SINGLE, parentSingle.getSubordinationType());
     assertParent(parentSingle);
   }
 

--- a/src/test/java/org/folio/rest/impl/changeManager/ChangeManagerAPITest.java
+++ b/src/test/java/org/folio/rest/impl/changeManager/ChangeManagerAPITest.java
@@ -49,6 +49,11 @@ public class ChangeManagerAPITest extends AbstractRestTest {
   private static RequestSpecification spec;
   private static String postedSnapshotResponseBody = UUID.randomUUID().toString();
 
+  Set<JobExecution.SubordinationType> parentTypes = EnumSet.of(
+    JobExecution.SubordinationType.PARENT_SINGLE,
+    JobExecution.SubordinationType.PARENT_MULTIPLE
+  );
+
   @Rule
   public WireMockRule snapshotMockServer = new WireMockRule(
     WireMockConfiguration.wireMockConfig()
@@ -166,10 +171,6 @@ public class ChangeManagerAPITest extends AbstractRestTest {
     Assert.assertNotNull(parent);
     Assert.assertNotNull(parent.getId());
     Assert.assertNotNull(parent.getParentJobId());
-    Set<JobExecution.SubordinationType> parentTypes = EnumSet.of(
-      JobExecution.SubordinationType.PARENT_SINGLE,
-      JobExecution.SubordinationType.PARENT_MULTIPLE
-    );
     Assert.assertTrue(parentTypes.contains(parent.getSubordinationType()));
     Assert.assertEquals(parent.getId(), parent.getParentJobId());
     Assert.assertEquals(JobExecution.Status.NEW, parent.getStatus());


### PR DESCRIPTION
- REST method receives InitJobExecutionsRqDto with files,
- Service method does parentJobExecutionId generation,
- Service method prepares a necessary amount of JobExecution entities,
- Service method prepares a necessary amount Snapshot json entities,
- Service method does save prepared JobExecution entities using DAO,
- Service method calls mod-source-record-storage to save prepared Snapshots,
- Service method completes future and returns InitJobExecutionsRsDto with parentJobExecutionId and prepared JobExecution entities,
- REST method returns response containing InitJobExecutionsRsDto