### PR TITLE
Modsourman 67 Remove JobProfile from the module 

### DIFF
--- a/mod-source-record-manager-server/src/main/java/org/folio/rest/impl/ChangeManagerImpl.java
+++ b/mod-source-record-manager-server/src/main/java/org/folio/rest/impl/ChangeManagerImpl.java
@@ -11,7 +11,7 @@ import org.folio.dataimport.util.ExceptionHelper;
 import org.folio.dataimport.util.OkapiConnectionParams;
 import org.folio.rest.jaxrs.model.InitJobExecutionsRqDto;
 import org.folio.rest.jaxrs.model.JobExecution;
-import org.folio.rest.jaxrs.model.JobProfile;
+import org.folio.rest.jaxrs.model.JobProfileInfo;
 import org.folio.rest.jaxrs.model.RawRecordsDto;
 import org.folio.rest.jaxrs.model.StatusDto;
 import org.folio.rest.jaxrs.resource.ChangeManager;
@@ -139,8 +139,7 @@ public class ChangeManagerImpl implements ChangeManager {
   }
 
   @Override
-  public void putChangeManagerJobExecutionsJobProfileById(String id, JobProfile entity, Map<String, String> okapiHeaders,
-                                                          Handler<AsyncResult<Response>> asyncResultHandler, Context vertxContext) {
+  public void putChangeManagerJobExecutionsJobProfileById(String id, JobProfileInfo entity, Map<String, String> okapiHeaders, Handler<AsyncResult<Response>> asyncResultHandler, Context vertxContext) {
     vertxContext.runOnContext(v -> {
       try {
         jobExecutionService.setJobProfileToJobExecution(id, entity, tenantId)

--- a/mod-source-record-manager-server/src/main/java/org/folio/services/ChangeEngineServiceImpl.java
+++ b/mod-source-record-manager-server/src/main/java/org/folio/services/ChangeEngineServiceImpl.java
@@ -127,7 +127,7 @@ public class ChangeEngineServiceImpl implements ChangeEngineService {
   }
 
   /**
-   * STUB implementation until job profile is't exist
+   * Get records format for parser from Job Execution
    *
    * @param jobExecution - job execution object
    * @return - Records format for jobExecution's records

--- a/mod-source-record-manager-server/src/main/java/org/folio/services/ChangeEngineServiceImpl.java
+++ b/mod-source-record-manager-server/src/main/java/org/folio/services/ChangeEngineServiceImpl.java
@@ -28,6 +28,7 @@ import javax.ws.rs.NotFoundException;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.UUID;
 import java.util.stream.Collectors;
 
 import static org.folio.rest.RestVerticle.MODULE_SPECIFIC_ARGS;
@@ -99,6 +100,7 @@ public class ChangeEngineServiceImpl implements ChangeEngineService {
       .map(rawRecord -> {
         ParsedResult parsedResult = parser.parseRecord(rawRecord);
         Record record = new Record()
+          .withMatchedId(getMatchedIdFromParsedResult(parsedResult))
           .withSnapshotId(jobExecution.getId())
           .withRawRecord(new RawRecord()
             .withContent(rawRecord));
@@ -130,8 +132,8 @@ public class ChangeEngineServiceImpl implements ChangeEngineService {
    * @param jobExecution - job execution object
    * @return - Records format for jobExecution's records
    */
-  private RecordFormat getRecordFormatByJobExecution(JobExecution jobExecution) { //NOSONAR
-    return RecordFormat.MARC;
+  private RecordFormat getRecordFormatByJobExecution(JobExecution jobExecution) {
+    return RecordFormat.getByDataType(jobExecution.getJobProfileInfo().getDataType());
   }
 
   /**
@@ -159,5 +161,10 @@ public class ChangeEngineServiceImpl implements ChangeEngineService {
       future.fail(e);
     }
     return future;
+  }
+
+  private String getMatchedIdFromParsedResult(ParsedResult parsedResult) { //NOSONAR
+    // STUB implementation
+    return UUID.randomUUID().toString();
   }
 }

--- a/mod-source-record-manager-server/src/main/java/org/folio/services/JobExecutionService.java
+++ b/mod-source-record-manager-server/src/main/java/org/folio/services/JobExecutionService.java
@@ -8,7 +8,7 @@ import org.folio.rest.jaxrs.model.InitJobExecutionsRsDto;
 import org.folio.rest.jaxrs.model.JobExecution;
 import org.folio.rest.jaxrs.model.JobExecutionCollection;
 import org.folio.rest.jaxrs.model.JobExecutionCollectionDto;
-import org.folio.rest.jaxrs.model.JobProfile;
+import org.folio.rest.jaxrs.model.JobProfileInfo;
 import org.folio.rest.jaxrs.model.LogCollectionDto;
 import org.folio.rest.jaxrs.model.StatusDto;
 
@@ -97,9 +97,9 @@ public interface JobExecutionService {
    * Sets JobProfile for JobExecution
    *
    * @param jobExecutionId JobExecution id
-   * @param jobProfile     JobProfile entity
+   * @param jobProfile     JobProfileInfo entity
    * @return future with updated JobExecution
    */
-  Future<JobExecution> setJobProfileToJobExecution(String jobExecutionId, JobProfile jobProfile, String tenantId);
+  Future<JobExecution> setJobProfileToJobExecution(String jobExecutionId, JobProfileInfo jobProfile, String tenantId);
 
 }

--- a/mod-source-record-manager-server/src/main/java/org/folio/services/JobExecutionServiceImpl.java
+++ b/mod-source-record-manager-server/src/main/java/org/folio/services/JobExecutionServiceImpl.java
@@ -15,7 +15,7 @@ import org.folio.rest.jaxrs.model.InitJobExecutionsRsDto;
 import org.folio.rest.jaxrs.model.JobExecution;
 import org.folio.rest.jaxrs.model.JobExecutionCollection;
 import org.folio.rest.jaxrs.model.JobExecutionCollectionDto;
-import org.folio.rest.jaxrs.model.JobProfile;
+import org.folio.rest.jaxrs.model.JobProfileInfo;
 import org.folio.rest.jaxrs.model.LogCollectionDto;
 import org.folio.rest.jaxrs.model.Snapshot;
 import org.folio.rest.jaxrs.model.StatusDto;
@@ -161,11 +161,11 @@ public class JobExecutionServiceImpl implements JobExecutionService {
   }
 
   @Override
-  public Future<JobExecution> setJobProfileToJobExecution(String jobExecutionId, JobProfile jobProfile, String tenantId) {
+  public Future<JobExecution> setJobProfileToJobExecution(String jobExecutionId, JobProfileInfo jobProfile, String tenantId) {
     return jobExecutionDao.updateBlocking(jobExecutionId, jobExecution -> {
       Future<JobExecution> future = Future.future();
       try {
-        jobExecution.setJobProfile(jobProfile);
+        jobExecution.setJobProfileInfo(jobProfile);
         future.complete(jobExecution);
       } catch (Exception e) {
         String errorMessage = "Error setting JobProfile to JobExecution with id " + jobExecutionId;

--- a/mod-source-record-manager-server/src/main/java/org/folio/services/converters/JobExecutionToDtoConverter.java
+++ b/mod-source-record-manager-server/src/main/java/org/folio/services/converters/JobExecutionToDtoConverter.java
@@ -39,8 +39,8 @@ public class JobExecutionToDtoConverter extends AbstractGenericConverter<JobExec
     target.setCompletedDate(source.getCompletedDate());
     target.setStatus(JobExecutionDto.Status.valueOf(source.getStatus().name()));
     target.setUiStatus(JobExecutionDto.UiStatus.valueOf((source.getUiStatus().name())));
-    if (source.getJobProfile() != null) {
-      target.setJobProfileName(source.getJobProfile().getName());
+    if (source.getJobProfileInfo() != null) {
+      target.setJobProfileName(source.getJobProfileInfo().getName());
     }
     // set progress properly
     target.setProgress(getProgress(source));

--- a/mod-source-record-manager-server/src/main/java/org/folio/services/converters/JobExecutionToLogDtoConverter.java
+++ b/mod-source-record-manager-server/src/main/java/org/folio/services/converters/JobExecutionToLogDtoConverter.java
@@ -18,7 +18,7 @@ public class JobExecutionToLogDtoConverter extends AbstractGenericConverter<JobE
     return new LogDto()
       .withJobExecutionId(source.getId())
       .withJobExecutionHrId(source.getHrId())
-      .withJobProfileName(source.getJobProfile() == null ? null : source.getJobProfile().getName())
+      .withJobProfileName(source.getJobProfileInfo() == null ? null : source.getJobProfileInfo().getName())
       .withCompletedDate(source.getCompletedDate())
       .withFileName(source.getSourcePath())
       .withRunBy(source.getRunBy())

--- a/mod-source-record-manager-server/src/main/java/org/folio/services/parsers/RecordFormat.java
+++ b/mod-source-record-manager-server/src/main/java/org/folio/services/parsers/RecordFormat.java
@@ -1,18 +1,35 @@
 package org.folio.services.parsers;
 
+import org.folio.rest.jaxrs.model.JobProfileInfo;
+
 /**
  * Source Record formats
  */
 public enum RecordFormat {
-  MARC("marc");
+  MARC("marc", JobProfileInfo.DataType.MARC);
 
   private String format;
+  private JobProfileInfo.DataType dataType;
 
-  RecordFormat(String format) {
+  RecordFormat(String format, JobProfileInfo.DataType dataType) {
+    this.dataType = dataType;
     this.format = format;
+  }
+
+  public JobProfileInfo.DataType getDataType() {
+    return dataType;
   }
 
   public String getFormat() {
     return format;
+  }
+
+  public static RecordFormat getByDataType(JobProfileInfo.DataType dataType) {
+    for (RecordFormat format : RecordFormat.values()) {
+      if (format.getDataType().equals(dataType)) {
+        return format;
+      }
+    }
+    return null;
   }
 }

--- a/mod-source-record-manager-server/src/test/java/org/folio/dao/JobExecutionDaoImplUnitTest.java
+++ b/mod-source-record-manager-server/src/test/java/org/folio/dao/JobExecutionDaoImplUnitTest.java
@@ -6,7 +6,7 @@ import io.vertx.ext.sql.UpdateResult;
 import org.folio.dao.util.PostgresClientFactory;
 import org.folio.dataimport.util.test.GenericHandlerAnswer;
 import org.folio.rest.jaxrs.model.JobExecution;
-import org.folio.rest.jaxrs.model.JobProfile;
+import org.folio.rest.jaxrs.model.JobProfileInfo;
 import org.folio.rest.persist.Criteria.Criterion;
 import org.folio.rest.persist.PostgresClient;
 import org.junit.Assert;
@@ -42,7 +42,7 @@ public class JobExecutionDaoImplUnitTest {
     .withStatus(JobExecution.Status.NEW)
     .withUiStatus(JobExecution.UiStatus.INITIALIZATION)
     .withSourcePath("importMarc.mrc")
-    .withJobProfile(new JobProfile().withId(UUID.randomUUID().toString()).withName("Marc jobs profile"))
+    .withJobProfileInfo(new JobProfileInfo().withId(UUID.randomUUID().toString()).withName("Marc jobs profile"))
     .withUserId(UUID.randomUUID().toString());
 
   @Mock
@@ -69,13 +69,13 @@ public class JobExecutionDaoImplUnitTest {
     when(updateResult.failed()).thenReturn(false);
     when(updateResult.result()).thenReturn(sqlUpdateResult);
 
-    doAnswer(new GenericHandlerAnswer<>(updateResult,4))
+    doAnswer(new GenericHandlerAnswer<>(updateResult, 4))
       .when(pgClient).update(eq(TABLE_NAME), eq(jobExecution), any(Criterion.class), eq(true), any(Handler.class));
 
     // when
     jobExecutionDao.updateJobExecution(jobExecution, TENANT_ID)
 
-    // then
+      // then
       .setHandler(ar -> {
         Assert.assertTrue(ar.succeeded());
         Assert.assertEquals(jobExecution.getId(), ar.result().getId());
@@ -86,8 +86,8 @@ public class JobExecutionDaoImplUnitTest {
         Assert.assertEquals(jobExecution.getUiStatus(), ar.result().getUiStatus());
         Assert.assertEquals(jobExecution.getSourcePath(), ar.result().getSourcePath());
         Assert.assertEquals(jobExecution.getUserId(), ar.result().getUserId());
-        Assert.assertEquals(jobExecution.getJobProfile().getId(), ar.result().getJobProfile().getId());
-        Assert.assertEquals(jobExecution.getJobProfile().getName(), ar.result().getJobProfile().getName());
+        Assert.assertEquals(jobExecution.getJobProfileInfo().getId(), ar.result().getJobProfileInfo().getId());
+        Assert.assertEquals(jobExecution.getJobProfileInfo().getName(), ar.result().getJobProfileInfo().getName());
 
         verify(pgClient).update(eq(TABLE_NAME), eq(jobExecution), any(Criterion.class), eq(true), any(Handler.class));
       });
@@ -102,11 +102,11 @@ public class JobExecutionDaoImplUnitTest {
     when(updateResult.failed()).thenReturn(false);
     when(updateResult.result()).thenReturn(sqlUpdateResult);
 
-    doAnswer(new GenericHandlerAnswer<>(updateResult,4))
+    doAnswer(new GenericHandlerAnswer<>(updateResult, 4))
       .when(pgClient).update(eq(TABLE_NAME), eq(jobExecution), any(Criterion.class), eq(true), any(Handler.class));
     // when
     jobExecutionDao.updateJobExecution(jobExecution, TENANT_ID)
-    // then
+      // then
       .setHandler(ar -> {
         Assert.assertTrue(ar.failed());
         verify(pgClient).update(eq(TABLE_NAME), eq(jobExecution), any(Criterion.class), eq(true), any(Handler.class));
@@ -119,11 +119,11 @@ public class JobExecutionDaoImplUnitTest {
     AsyncResult updateResult = mock(AsyncResult.class);
     when(updateResult.failed()).thenReturn(true);
 
-    doAnswer(new GenericHandlerAnswer<>(updateResult,4))
+    doAnswer(new GenericHandlerAnswer<>(updateResult, 4))
       .when(pgClient).update(eq(TABLE_NAME), eq(jobExecution), any(Criterion.class), eq(true), any(Handler.class));
     // when
     jobExecutionDao.updateJobExecution(jobExecution, TENANT_ID)
-    // then
+      // then
       .setHandler(ar -> {
         Assert.assertTrue(ar.failed());
         verify(pgClient).update(eq(TABLE_NAME), eq(jobExecution), any(Criterion.class), eq(true), any(Handler.class));
@@ -137,7 +137,7 @@ public class JobExecutionDaoImplUnitTest {
       .when(pgClient).update(eq(TABLE_NAME), eq(jobExecution), any(Criterion.class), eq(true), any(Handler.class));
     // when
     jobExecutionDao.updateJobExecution(jobExecution, TENANT_ID)
-    // then
+      // then
       .setHandler(ar -> {
         Assert.assertTrue(ar.failed());
         verify(pgClient).update(eq(TABLE_NAME), eq(jobExecution), any(Criterion.class), eq(true), any(Handler.class));

--- a/mod-source-record-manager-server/src/test/java/org/folio/rest/impl/changeManager/ChangeManagerAPITest.java
+++ b/mod-source-record-manager-server/src/test/java/org/folio/rest/impl/changeManager/ChangeManagerAPITest.java
@@ -16,7 +16,7 @@ import org.folio.rest.jaxrs.model.File;
 import org.folio.rest.jaxrs.model.InitJobExecutionsRqDto;
 import org.folio.rest.jaxrs.model.InitJobExecutionsRsDto;
 import org.folio.rest.jaxrs.model.JobExecution;
-import org.folio.rest.jaxrs.model.JobProfile;
+import org.folio.rest.jaxrs.model.JobProfileInfo;
 import org.folio.rest.jaxrs.model.RawRecordsDto;
 import org.folio.rest.jaxrs.model.StatusDto;
 import org.folio.services.converters.Status;
@@ -60,7 +60,7 @@ public class ChangeManagerAPITest extends AbstractRestTest {
     .withStatus(JobExecution.Status.NEW)
     .withUiStatus(JobExecution.UiStatus.INITIALIZATION)
     .withSourcePath("importMarc.mrc")
-    .withJobProfile(new JobProfile().withId(UUID.randomUUID().toString()).withName("Marc jobs profile"))
+    .withJobProfileInfo(new JobProfileInfo().withId(UUID.randomUUID().toString()).withName("Marc jobs profile"))
     .withUserId(UUID.randomUUID().toString());
 
   private RawRecordsDto rawRecordsDto = new RawRecordsDto()
@@ -180,7 +180,7 @@ public class ChangeManagerAPITest extends AbstractRestTest {
     JobExecution singleParent = createdJobExecutions.get(0);
     Assert.assertThat(singleParent.getSubordinationType(), is(JobExecution.SubordinationType.PARENT_SINGLE));
 
-    singleParent.setJobProfile(new JobProfile().withId(UUID.randomUUID().toString()).withName("Marc jobs profile"));
+    singleParent.setJobProfileInfo(new JobProfileInfo().withId(UUID.randomUUID().toString()).withName("Marc jobs profile"));
     RestAssured.given()
       .spec(spec)
       .body(JsonObject.mapFrom(singleParent).toString())
@@ -189,7 +189,7 @@ public class ChangeManagerAPITest extends AbstractRestTest {
       .then()
       .statusCode(HttpStatus.SC_OK)
       .body("id", is(singleParent.getId()))
-      .body("jobProfile.name", is(singleParent.getJobProfile().getName()));
+      .body("jobProfileInfo.name", is(singleParent.getJobProfileInfo().getName()));
   }
 
   @Test
@@ -497,7 +497,7 @@ public class ChangeManagerAPITest extends AbstractRestTest {
     JobExecution multipleParent = createdJobExecutions.stream()
       .filter(jobExec -> jobExec.getSubordinationType().equals(JobExecution.SubordinationType.PARENT_MULTIPLE)).findFirst().get();
 
-    multipleParent.setJobProfile(new JobProfile().withId(UUID.randomUUID().toString()).withName("Marc jobs profile"));
+    multipleParent.setJobProfileInfo(new JobProfileInfo().withId(UUID.randomUUID().toString()).withName("Marc jobs profile"));
     RestAssured.given()
       .spec(spec)
       .body(JsonObject.mapFrom(multipleParent).toString())
@@ -506,7 +506,7 @@ public class ChangeManagerAPITest extends AbstractRestTest {
       .then()
       .statusCode(HttpStatus.SC_OK)
       .body("id", is(multipleParent.getId()))
-      .body("jobProfile.name", is(multipleParent.getJobProfile().getName()));
+      .body("jobProfileInfo.name", is(multipleParent.getJobProfileInfo().getName()));
 
     RestAssured.given()
       .spec(spec)
@@ -514,7 +514,7 @@ public class ChangeManagerAPITest extends AbstractRestTest {
       .get(JOB_EXECUTION_PATH + multipleParent.getId())
       .then()
       .statusCode(HttpStatus.SC_OK)
-      .body("jobProfile.name", is(multipleParent.getJobProfile().getName()));
+      .body("jobProfileInfo.name", is(multipleParent.getJobProfileInfo().getName()));
   }
 
   @Test
@@ -573,8 +573,8 @@ public class ChangeManagerAPITest extends AbstractRestTest {
   }
 
   @Test
-  public void shouldReturnNotFoundOnSetJobProfile() {
-    JobProfile jobProfile = new JobProfile().withId(UUID.randomUUID().toString()).withName("marc");
+  public void shouldReturnNotFoundOnSetJobProfileInfo() {
+    JobProfileInfo jobProfile = new JobProfileInfo().withId(UUID.randomUUID().toString()).withName("marc");
     RestAssured.given()
       .spec(spec)
       .body(JsonObject.mapFrom(jobProfile).toString())
@@ -585,8 +585,8 @@ public class ChangeManagerAPITest extends AbstractRestTest {
   }
 
   @Test
-  public void shouldReturnBadRequestOnSetJobProfile() {
-    JobProfile jobProfile = new JobProfile().withName("Nonsense");
+  public void shouldReturnBadRequestOnSetJobProfileInfo() {
+    JobProfileInfo jobProfile = new JobProfileInfo().withName("Nonsense");
     RestAssured.given()
       .spec(spec)
       .body(JsonObject.mapFrom(jobProfile).toString())
@@ -597,14 +597,14 @@ public class ChangeManagerAPITest extends AbstractRestTest {
   }
 
   @Test
-  public void shouldSetJobProfileForJobExecution() {
+  public void shouldSetJobProfileInfoForJobExecution() {
     InitJobExecutionsRsDto response =
       constructAndPostInitJobExecutionRqDto(1);
     List<JobExecution> createdJobExecutions = response.getJobExecutions();
     Assert.assertThat(createdJobExecutions.size(), is(1));
     JobExecution jobExec = createdJobExecutions.get(0);
 
-    JobProfile jobProfile = new JobProfile().withId(UUID.randomUUID().toString()).withName("marc");
+    JobProfileInfo jobProfile = new JobProfileInfo().withId(UUID.randomUUID().toString()).withName("marc");
     RestAssured.given()
       .spec(spec)
       .body(JsonObject.mapFrom(jobProfile).toString())
@@ -612,8 +612,8 @@ public class ChangeManagerAPITest extends AbstractRestTest {
       .put(JOB_EXECUTION_PATH + jobExec.getId() + JOB_PROFILE_PATH)
       .then()
       .statusCode(HttpStatus.SC_OK)
-      .body("jobProfile.id", is(jobProfile.getId()))
-      .body("jobProfile.name", is(jobProfile.getName()));
+      .body("jobProfileInfo.id", is(jobProfile.getId()))
+      .body("jobProfileInfo.name", is(jobProfile.getName()));
 
     RestAssured.given()
       .spec(spec)
@@ -621,8 +621,8 @@ public class ChangeManagerAPITest extends AbstractRestTest {
       .get(JOB_EXECUTION_PATH + jobExec.getId())
       .then()
       .statusCode(HttpStatus.SC_OK)
-      .body("jobProfile.id", is(jobProfile.getId()))
-      .body("jobProfile.name", is(jobProfile.getName()));
+      .body("jobProfileInfo.id", is(jobProfile.getId()))
+      .body("jobProfileInfo.name", is(jobProfile.getName()));
   }
 
   @Test
@@ -657,6 +657,17 @@ public class ChangeManagerAPITest extends AbstractRestTest {
 
     RestAssured.given()
       .spec(spec)
+      .body(new JobProfileInfo()
+        .withName("MARC records")
+        .withId(UUID.randomUUID().toString())
+        .withDataType(JobProfileInfo.DataType.MARC))
+      .when()
+      .put(JOB_EXECUTION_PATH + jobExec.getId() + JOB_PROFILE_PATH)
+      .then()
+      .statusCode(HttpStatus.SC_OK);
+
+    RestAssured.given()
+      .spec(spec)
       .body(rawRecordsDto)
       .when()
       .post(JOB_EXECUTION_PATH + jobExec.getId() + POST_RAW_RECORDS_PATH)
@@ -679,6 +690,17 @@ public class ChangeManagerAPITest extends AbstractRestTest {
     List<JobExecution> createdJobExecutions = response.getJobExecutions();
     Assert.assertThat(createdJobExecutions.size(), is(1));
     JobExecution jobExec = createdJobExecutions.get(0);
+
+    RestAssured.given()
+      .spec(spec)
+      .body(new JobProfileInfo()
+        .withName("MARC records")
+        .withId(UUID.randomUUID().toString())
+        .withDataType(JobProfileInfo.DataType.MARC))
+      .when()
+      .put(JOB_EXECUTION_PATH + jobExec.getId() + JOB_PROFILE_PATH)
+      .then()
+      .statusCode(HttpStatus.SC_OK);
 
     RestAssured.given()
       .spec(spec)
@@ -737,7 +759,7 @@ public class ChangeManagerAPITest extends AbstractRestTest {
     JobExecution singleParent = createdJobExecutions.get(0);
     Assert.assertThat(singleParent.getSubordinationType(), is(JobExecution.SubordinationType.PARENT_SINGLE));
 
-    singleParent.setJobProfile(new JobProfile().withId(UUID.randomUUID().toString()).withName("Marc jobs profile"));
+    singleParent.setJobProfileInfo(new JobProfileInfo().withId(UUID.randomUUID().toString()).withName("Marc jobs profile"));
     RestAssured.given()
       .spec(spec)
       .body(JsonObject.mapFrom(singleParent).toString())
@@ -755,6 +777,17 @@ public class ChangeManagerAPITest extends AbstractRestTest {
     List<JobExecution> createdJobExecutions = response.getJobExecutions();
     Assert.assertThat(createdJobExecutions.size(), is(1));
     JobExecution jobExec = createdJobExecutions.get(0);
+
+    RestAssured.given()
+      .spec(spec)
+      .body(new JobProfileInfo()
+        .withName("MARC records")
+        .withId(UUID.randomUUID().toString())
+        .withDataType(JobProfileInfo.DataType.MARC))
+      .when()
+      .put(JOB_EXECUTION_PATH + jobExec.getId() + JOB_PROFILE_PATH)
+      .then()
+      .statusCode(HttpStatus.SC_OK);
 
     WireMock.stubFor(WireMock.post(RECORDS_SERVICE_URL)
       .willReturn(WireMock.serverError()));

--- a/mod-source-record-manager-server/src/test/java/org/folio/rest/impl/metadataProvider/MetadataProviderJobExecutionAPITest.java
+++ b/mod-source-record-manager-server/src/test/java/org/folio/rest/impl/metadataProvider/MetadataProviderJobExecutionAPITest.java
@@ -78,7 +78,7 @@ public class MetadataProviderJobExecutionAPITest extends AbstractRestTest {
       .filter(jobExec -> jobExec.getSubordinationType().equals(JobExecution.SubordinationType.CHILD)).collect(Collectors.toList());
     StatusDto discardedStatus = new StatusDto().withStatus(StatusDto.Status.DISCARDED);
 
-    for (int i = 0; i < children.size() - expectedNotDiscardedNumber ; i++) {
+    for (int i = 0; i < children.size() - expectedNotDiscardedNumber; i++) {
       updateJobExecutionStatus(children.get(i), discardedStatus)
         .then()
         .statusCode(HttpStatus.SC_OK);

--- a/mod-source-record-manager-server/src/test/java/org/folio/rest/impl/metadataProvider/MetadataProviderLogAPITest.java
+++ b/mod-source-record-manager-server/src/test/java/org/folio/rest/impl/metadataProvider/MetadataProviderLogAPITest.java
@@ -7,7 +7,7 @@ import io.vertx.ext.unit.junit.VertxUnitRunner;
 import org.apache.http.HttpStatus;
 import org.folio.rest.impl.AbstractRestTest;
 import org.folio.rest.jaxrs.model.JobExecution;
-import org.folio.rest.jaxrs.model.JobProfile;
+import org.folio.rest.jaxrs.model.JobProfileInfo;
 import org.folio.rest.jaxrs.model.LogCollectionDto;
 import org.folio.rest.jaxrs.model.LogDto;
 import org.junit.Assert;
@@ -37,7 +37,7 @@ public class MetadataProviderLogAPITest extends AbstractRestTest {
   private static final String GET_LOGS_PATH_LANDING_PAGE_TRUE = "/metadata-provider/logs?landingPage=true";
   private static final String PUT_JOB_EXECUTIONS_PATH = "/change-manager/jobExecutions/";
   private static final String PROFILE_NAME = "Parse Marc files profile";
-  private  static final int LANDING_PAGE_LOGS_LIMIT = 25;
+  private static final int LANDING_PAGE_LOGS_LIMIT = 25;
 
   @Test
   public void shouldReturnEmptyListOnGetIfNoLogsExist() {
@@ -101,7 +101,7 @@ public class MetadataProviderLogAPITest extends AbstractRestTest {
     JobExecution expectedCommittedChild = createdJobExecutions.get(0);
     Assert.assertEquals(PARENT_SINGLE, expectedCommittedChild.getSubordinationType());
     expectedCommittedChild.setStatus(COMMITTED);
-    expectedCommittedChild.setJobProfile(new JobProfile().withId(UUID.randomUUID().toString()).withName(PROFILE_NAME));
+    expectedCommittedChild.setJobProfileInfo(new JobProfileInfo().withId(UUID.randomUUID().toString()).withName(PROFILE_NAME));
 
     putJobExecution(expectedCommittedChild)
       .then()
@@ -129,7 +129,7 @@ public class MetadataProviderLogAPITest extends AbstractRestTest {
       .filter(jobExec -> jobExec.getSubordinationType().equals(CHILD)).findFirst().get();
 
     expectedCommittedChild.setStatus(COMMITTED);
-    expectedCommittedChild.setJobProfile(new JobProfile().withId(UUID.randomUUID().toString()).withName(PROFILE_NAME));
+    expectedCommittedChild.setJobProfileInfo(new JobProfileInfo().withId(UUID.randomUUID().toString()).withName(PROFILE_NAME));
 
     putJobExecution(expectedCommittedChild)
       .then()
@@ -160,7 +160,7 @@ public class MetadataProviderLogAPITest extends AbstractRestTest {
     for (JobExecution createdJobExecution : createdJobExecutions) {
       if (CHILD.equals(createdJobExecution.getSubordinationType())) {
         createdJobExecution.setStatus(COMMITTED);
-        createdJobExecution.setJobProfile(new JobProfile().withId(UUID.randomUUID().toString()).withName(PROFILE_NAME));
+        createdJobExecution.setJobProfileInfo(new JobProfileInfo().withId(UUID.randomUUID().toString()).withName(PROFILE_NAME));
         expectedCommittedChildren.add(createdJobExecution);
       }
     }
@@ -205,7 +205,7 @@ public class MetadataProviderLogAPITest extends AbstractRestTest {
     for (JobExecution createdJobExecution : createdJobExecutions) {
       if (CHILD.equals(createdJobExecution.getSubordinationType())) {
         createdJobExecution.setStatus(COMMITTED);
-        createdJobExecution.setJobProfile(new JobProfile().withId(UUID.randomUUID().toString()).withName(PROFILE_NAME));
+        createdJobExecution.setJobProfileInfo(new JobProfileInfo().withId(UUID.randomUUID().toString()).withName(PROFILE_NAME));
         expectedCommittedChildren.add(createdJobExecution);
       }
     }
@@ -239,7 +239,7 @@ public class MetadataProviderLogAPITest extends AbstractRestTest {
       JobExecution createdJobExecution = createdJobExecutions.get(i);
       if (CHILD.equals(createdJobExecution.getSubordinationType())) {
         createdJobExecution.setStatus(COMMITTED);
-        createdJobExecution.setJobProfile(new JobProfile().withId(UUID.randomUUID().toString()).withName(PROFILE_NAME));
+        createdJobExecution.setJobProfileInfo(new JobProfileInfo().withId(UUID.randomUUID().toString()).withName(PROFILE_NAME));
         createdJobExecution.setCompletedDate(new Date(1542714612000L + i));
         expectedCommittedChildren.add(createdJobExecution);
       }
@@ -277,7 +277,7 @@ public class MetadataProviderLogAPITest extends AbstractRestTest {
       JobExecution createdJobExecution = createdJobExecutions.get(i);
       if (CHILD.equals(createdJobExecution.getSubordinationType())) {
         createdJobExecution.setStatus(COMMITTED);
-        createdJobExecution.setJobProfile(new JobProfile().withId(UUID.randomUUID().toString()).withName(PROFILE_NAME));
+        createdJobExecution.setJobProfileInfo(new JobProfileInfo().withId(UUID.randomUUID().toString()).withName(PROFILE_NAME));
         expectedCommittedChildren.add(createdJobExecution);
       }
     }
@@ -315,7 +315,7 @@ public class MetadataProviderLogAPITest extends AbstractRestTest {
         } else {
           createdJobExecution.setStatus(ERROR);
         }
-        createdJobExecution.setJobProfile(new JobProfile().withId(UUID.randomUUID().toString()).withName(PROFILE_NAME));
+        createdJobExecution.setJobProfileInfo(new JobProfileInfo().withId(UUID.randomUUID().toString()).withName(PROFILE_NAME));
         createdJobExecution.setCompletedDate(new Date(1542714612000L + i));
         expectedLogs.add(createdJobExecution);
       }

--- a/mod-source-record-manager-server/src/test/java/org/folio/services/converters/JobExecutionToDtoConverterUnitTest.java
+++ b/mod-source-record-manager-server/src/test/java/org/folio/services/converters/JobExecutionToDtoConverterUnitTest.java
@@ -47,7 +47,7 @@ public class JobExecutionToDtoConverterUnitTest {
     Assert.assertEquals(jobExecutionDto.getCompletedDate(), jobExecutionEntity.getCompletedDate());
     Assert.assertEquals(jobExecutionDto.getStatus().name(), jobExecutionEntity.getStatus().name());
     Assert.assertEquals(jobExecutionDto.getUiStatus().name(), jobExecutionEntity.getUiStatus().name());
-    Assert.assertEquals(jobExecutionDto.getJobProfileName(), jobExecutionEntity.getJobProfile().getName());
+    Assert.assertEquals(jobExecutionDto.getJobProfileName(), jobExecutionEntity.getJobProfileInfo().getName());
     // TODO assert progress properly
   }
 

--- a/mod-source-record-manager-server/src/test/java/org/folio/services/converters/JobExecutionToLogDtoConverterUnitTest.java
+++ b/mod-source-record-manager-server/src/test/java/org/folio/services/converters/JobExecutionToLogDtoConverterUnitTest.java
@@ -34,7 +34,7 @@ public class JobExecutionToLogDtoConverterUnitTest extends JobExecutionToDtoConv
     LogDto logDto = collectionDtoList.get(0);
     Assert.assertEquals(logDto.getJobExecutionId(), jobExecutionEntity.getId());
     Assert.assertEquals(logDto.getJobExecutionHrId(), jobExecutionEntity.getHrId());
-    Assert.assertEquals(logDto.getJobProfileName(), jobExecutionEntity.getJobProfile().getName());
+    Assert.assertEquals(logDto.getJobProfileName(), jobExecutionEntity.getJobProfileInfo().getName());
     Assert.assertEquals(logDto.getRunBy().getFirstName(), jobExecutionEntity.getRunBy().getFirstName());
     Assert.assertEquals(logDto.getRunBy().getLastName(), jobExecutionEntity.getRunBy().getLastName());
     Assert.assertEquals(logDto.getFileName(), jobExecutionEntity.getSourcePath());

--- a/mod-source-record-manager-server/src/test/resources/org/folio/services/converters/jobExecutionCollectionMultipleTest.sample
+++ b/mod-source-record-manager-server/src/test/resources/org/folio/services/converters/jobExecutionCollectionMultipleTest.sample
@@ -3,9 +3,10 @@
     {
       "id": "fgbnm001-1caf-4470-9ad1-d533f6360bdd",
       "hrId": "17782",
-      "jobProfile": {
+      "jobProfileInfo": {
         "id": "as4fgbn1-1caf-4470-9ad1-d533f6360bdd",
-        "name": "Marc files profile"
+        "name": "Marc files profile",
+        "dataType": "MARC"
       },
       "parentJobId": "12gb700q-1caf-4470-9ad1-d533f6360bdd",
       "subordinationType": "CHILD",
@@ -22,9 +23,10 @@
     {
       "id": "zrrg6nm1-1caf-4470-9ad1-d533f6360bdd",
       "hrId": "24001",
-      "jobProfile": {
+      "jobProfileInfo": {
         "id": "as4fgbn1-1caf-4470-9ad1-d533f6360bdd",
-         "name": "Marc files profile"
+         "name": "Marc files profile",
+         "dataType": "MARC"
       },
       "parentJobId": "12gb700q-1caf-4470-9ad1-d533f6360bdd",
       "subordinationType": "CHILD",

--- a/mod-source-record-manager-server/src/test/resources/org/folio/services/converters/jobExecutionCollectionSingleTest.sample
+++ b/mod-source-record-manager-server/src/test/resources/org/folio/services/converters/jobExecutionCollectionSingleTest.sample
@@ -3,9 +3,10 @@
     {
       "id": "rr5bnm8q-1caf-4470-9ad1-d533f6360bdd",
       "hrId": "12200",
-      "jobProfile": {
+      "jobProfileInfo": {
         "id": "as4fgbn1-1caf-4470-9ad1-d533f6360bdd",
-       "name": "Marc files profile"
+       "name": "Marc files profile",
+       "dataType": "MARC"
       },
       "parentJobId": "12cbtg50-1caf-4470-9ad1-d533f6360bdd",
       "subordinationType": "CHILD",

--- a/ramls/change-manager.raml
+++ b/ramls/change-manager.raml
@@ -21,7 +21,7 @@ types:
   snapshot: !include raml-storage/schemas/mod-source-record-storage/snapshot.json
   record: !include raml-storage/schemas/dto/record.json
   recordCollection: !include raml-storage/schemas/dto/recordCollection.json
-  jobProfile: !include raml-storage/schemas/mod-source-record-manager/jobProfile.json
+  jobProfileInfo: !include raml-storage/schemas/common/profileInfo.json
 
 traits:
   validate: !include raml-storage/raml-util/traits/validation.raml
@@ -135,7 +135,7 @@ resourceTypes:
           description: "Set JobProfile for JobExecution"
           body:
             application/json:
-              schema: jobProfile
+              schema: jobProfileInfo
           responses:
             200:
               body:


### PR DESCRIPTION
* Add jobExecution dependency on DataType (MARC, BIBFRAME, EDIFACT, etc.)
* Implement the stub getRecordFormatByJobExecution method in ChangeEngineService based on the dataType associated with JobExecution
* Remove jobProfile schema from mod-source-record-manager schemas
* Change /change-manager/jobExecutions/id/jobProfile endpoint implementation that assigns JobProfile to JobExecution
* Update calls to the mentioned above endpoint from mod-data-import module
