### PR TITLE
MODSOURMAN-172 Added instance-format settings loading for mapping

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
-## 2019-09-09 v1.7.0-SNAPSHOT
+## 2019-09-09 v1.7.1
  * Added instance-type settings loading for mapping
+ * Added classification settings loading for mapping
+ * Added instance-format settings loading for mapping
 
 ## 2019-09-09 v1.6.0
  * Progress mechanism was updated

--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -29,6 +29,10 @@
     {
       "id": "instance-types",
       "version": "2.0"
+    },
+    {
+      "id": "instance-formats",
+      "version": "2.0"
     }
   ],
   "provides": [
@@ -94,7 +98,8 @@
             "users.collection.get",
             "inventory-storage.identifier-types.collection.get",
             "inventory-storage.classification-types.collection.get",
-            "inventory-storage.instance-types.collection.get"
+            "inventory-storage.instance-types.collection.get",
+            "inventory-storage.instance-formats.collection.get"
           ]
         },
         {

--- a/mod-source-record-manager-server/src/main/java/org/folio/services/mappers/processor/functions/NormalizationFunction.java
+++ b/mod-source-record-manager-server/src/main/java/org/folio/services/mappers/processor/functions/NormalizationFunction.java
@@ -4,6 +4,7 @@ import io.vertx.core.json.JsonObject;
 import org.apache.commons.lang.StringUtils;
 import org.folio.rest.jaxrs.model.InstanceType;
 import org.folio.rest.jaxrs.model.ClassificationType;
+import org.folio.rest.jaxrs.model.InstanceFormat;
 import org.folio.services.mappers.processor.RuleExecutionContext;
 import org.folio.services.mappers.processor.publisher.PublisherRole;
 import org.marc4j.marc.DataField;
@@ -123,6 +124,21 @@ public enum NormalizationFunction implements Function<RuleExecutionContext, Stri
       } else {
         return publisherRole.getCaption();
       }
+    }
+  },
+
+  SET_INSTANCE_FORMAT_ID() {
+    @Override
+    public String apply(RuleExecutionContext context) {
+      List<InstanceFormat> instanceFormats = context.getMappingParameters().getInstanceFormats();
+      if (instanceFormats == null) {
+        return StringUtils.EMPTY;
+      }
+      return instanceFormats.stream()
+        .filter(instanceFormat -> instanceFormat.getCode().equals(context.getSubFieldValue()))
+        .findFirst()
+        .map(InstanceFormat::getId)
+        .orElse(StringUtils.EMPTY);
     }
   },
 

--- a/mod-source-record-manager-server/src/main/java/org/folio/services/mappers/processor/parameters/MappingParameters.java
+++ b/mod-source-record-manager-server/src/main/java/org/folio/services/mappers/processor/parameters/MappingParameters.java
@@ -4,6 +4,7 @@ import org.apache.commons.collections4.list.UnmodifiableList;
 import org.folio.rest.jaxrs.model.ClassificationType;
 import org.folio.rest.jaxrs.model.IdentifierType;
 import org.folio.rest.jaxrs.model.InstanceType;
+import org.folio.rest.jaxrs.model.InstanceFormat;
 
 import java.util.List;
 
@@ -15,6 +16,7 @@ public class MappingParameters {
   private UnmodifiableList<IdentifierType> identifierTypes;
   private UnmodifiableList<ClassificationType> classificationTypes;
   private UnmodifiableList<InstanceType> instanceTypes;
+  private UnmodifiableList<InstanceFormat> instanceFormats;
 
   public List<IdentifierType> getIdentifierTypes() {
     return identifierTypes;
@@ -40,6 +42,15 @@ public class MappingParameters {
 
   public MappingParameters withInstanceTypes(List<InstanceType> instanceTypes) {
     this.instanceTypes = new UnmodifiableList<>(instanceTypes);
+    return this;
+  }
+
+  public List<InstanceFormat> getInstanceFormats() {
+    return instanceFormats;
+  }
+
+  public MappingParameters withInstanceFormats(List<InstanceFormat> instanceFormats) {
+    this.instanceFormats = new UnmodifiableList<>(instanceFormats);
     return this;
   }
 }

--- a/mod-source-record-manager-server/src/main/resources/rules.json
+++ b/mod-source-record-manager-server/src/main/resources/rules.json
@@ -1615,18 +1615,14 @@
     {
       "target": "instanceFormatIds",
       "description": "Instance Format ID",
-      "applyRulesOnConcatenatedData": true,
       "subfield": [
-        "a",
-        "b",
-        "2",
-        "3"
+        "b"
       ],
       "rules": [
         {
           "conditions": [
             {
-              "type": "trim_period"
+              "type": "set_instance_format_id"
             }
           ]
         }

--- a/mod-source-record-manager-server/src/test/java/org/folio/rest/impl/AbstractRestTest.java
+++ b/mod-source-record-manager-server/src/test/java/org/folio/rest/impl/AbstractRestTest.java
@@ -72,6 +72,7 @@ public abstract class AbstractRestTest {
   private static final String IDENTIFIER_TYPES_URL = "/identifier-types";
   private static final String INSTANCE_TYPES_URL = "/instance-types";
   private static final String CLASSIFICATION_TYPES_URL = "/classification-types";
+  private static final String INSTANE_FORMATS_URL = "/instance-formats";
   protected static final String FILES_PATH = "src/test/resources/org/folio/rest/files.sample";
   protected static final String RECORD_PATH = "src/test/resources/org/folio/rest/record.json";
   protected static final String SNAPSHOT_SERVICE_URL = "/source-storage/snapshots";
@@ -196,6 +197,8 @@ public abstract class AbstractRestTest {
     WireMock.stubFor(WireMock.get(INSTANCE_TYPES_URL)
       .willReturn(WireMock.okJson(new JsonObject().toString())));
     WireMock.stubFor(WireMock.get(CLASSIFICATION_TYPES_URL)
+      .willReturn(WireMock.okJson(new JsonObject().toString())));
+    WireMock.stubFor(WireMock.get(INSTANE_FORMATS_URL)
       .willReturn(WireMock.okJson(new JsonObject().toString())));
     WireMock.stubFor(WireMock.delete(new UrlPathPattern(new RegexPattern("/source-storage/snapshots/.{36}/records"), true))
       .willReturn(WireMock.noContent()));

--- a/mod-source-record-manager-server/src/test/java/org/folio/services/mapping/functions/NormalizationFunctionTest.java
+++ b/mod-source-record-manager-server/src/test/java/org/folio/services/mapping/functions/NormalizationFunctionTest.java
@@ -1,7 +1,9 @@
 package org.folio.services.mapping.functions;
 
 import io.vertx.core.json.JsonObject;
+import org.apache.commons.lang3.StringUtils;
 import org.folio.rest.jaxrs.model.ClassificationType;
+import org.folio.rest.jaxrs.model.InstanceFormat;
 import org.folio.rest.jaxrs.model.InstanceType;
 import org.folio.services.mappers.processor.RuleExecutionContext;
 import org.folio.services.mappers.processor.parameters.MappingParameters;
@@ -308,6 +310,37 @@ public class NormalizationFunctionTest {
     String actualTypeId = runFunction("set_instance_type_id", context);
     // then
     assertEquals(STUB_FIELD_TYPE_ID, actualTypeId);
+  }
+
+  @Test
+  public void SET_INSTANCE_FORMAT_ID_shouldReturnExpectedResult() {
+    // given
+    String expectedInstanceFormatId = UUID.randomUUID().toString();
+    InstanceFormat instanceFormat = new InstanceFormat()
+      .withId(expectedInstanceFormatId)
+      .withCode("nc");
+    RuleExecutionContext context = new RuleExecutionContext();
+    context.setSubFieldValue("nc");
+    context.setMappingParameters(new MappingParameters().withInstanceFormats(Collections.singletonList(instanceFormat)));
+    // when
+    String actualTypeId = runFunction("set_instance_format_id", context);
+    // then
+    assertEquals(expectedInstanceFormatId, actualTypeId);
+  }
+
+  @Test
+  public void SET_INSTANCE_FORMAT_ID_shouldReturnEmptyStringIfNoSettingsSpecified() {
+    // given
+    InstanceFormat instanceFormat = new InstanceFormat()
+      .withId(UUID.randomUUID().toString())
+      .withCode("fail");
+    RuleExecutionContext context = new RuleExecutionContext();
+    context.setSubFieldValue("nc");
+    context.setMappingParameters(new MappingParameters().withInstanceFormats(Collections.singletonList(instanceFormat)));
+    // when
+    String actualTypeId = runFunction("set_instance_format_id", context);
+    // then
+    assertEquals(StringUtils.EMPTY, actualTypeId);
   }
 
 }

--- a/mod-source-record-manager-server/src/test/resources/org/folio/services/mapping/instances.json
+++ b/mod-source-record-manager-server/src/test/resources/org/folio/services/mapping/instances.json
@@ -257,10 +257,7 @@
     "publicationRange": [],
     "electronicAccess": [],
     "instanceTypeId": "fe19bae4-da28-472b-be90-d442e2428ead",
-    "instanceFormatIds": [
-      "volume nc rdacarrier",
-      "microfilm reel hd rdacarrier"
-    ],
+    "instanceFormatIds": [],
     "physicalDescriptions": [
       "microfilm reels : illustrations ; 35 mm + 1 guide (8 v.)"
     ],
@@ -1930,9 +1927,7 @@
       }
     ],
     "instanceTypeId": "6312d172-f0cf-40f6-b27d-9fa8feaf332f",
-    "instanceFormatIds": [
-      "online resource rdacarrier"
-    ],
+    "instanceFormatIds": [],
     "physicalDescriptions": [
       "1 online resource."
     ],
@@ -3735,9 +3730,7 @@
     "publicationRange": [],
     "electronicAccess": [],
     "instanceTypeId": "fe19bae4-da28-472b-be90-d442e2428ead",
-    "instanceFormatIds": [
-      "audio disc sd rdacarrier"
-    ],
+    "instanceFormatIds": [],
     "physicalDescriptions": [
       "13 audio discs : digital, mono, stereo ; 4 3/4 in."
     ],
@@ -4832,9 +4825,7 @@
       }
     ],
     "instanceTypeId": "fe19bae4-da28-472b-be90-d442e2428ead",
-    "instanceFormatIds": [
-      "online resource cr rdacarrier"
-    ],
+    "instanceFormatIds": [],
     "physicalDescriptions": [
       "1 online resource."
     ],
@@ -5310,9 +5301,7 @@
     "publicationRange": [],
     "electronicAccess": [],
     "instanceTypeId": "fe19bae4-da28-472b-be90-d442e2428ead",
-    "instanceFormatIds": [
-      "volume nc rdacarrier"
-    ],
+    "instanceFormatIds": [],
     "physicalDescriptions": [
       "74 pages ; 21 cm"
     ],
@@ -5390,9 +5379,7 @@
     "publicationRange": [],
     "electronicAccess": [],
     "instanceTypeId": "fe19bae4-da28-472b-be90-d442e2428ead",
-    "instanceFormatIds": [
-      "volume nc rdacarrier"
-    ],
+    "instanceFormatIds": [],
     "physicalDescriptions": [
       "276 pages : illustrations ; 21 cm"
     ],
@@ -5550,11 +5537,7 @@
       }
     ],
     "instanceTypeId": "fe19bae4-da28-472b-be90-d442e2428ead",
-    "instanceFormatIds": [
-      "audio disc sd rdacarrier",
-      "computer chip cartridge cb rdacarrier",
-      "volume nc rdacarrier"
-    ],
+    "instanceFormatIds": [],
     "physicalDescriptions": [
       "6 audio discs : analog, mono ; 12 in + 1 USB flash drive (7.6 GB ; 6 x 5 cm) + 1 volume (255 pages ; 34 cm) + 1 volume (360 pages ; 28 cm) + 2 booklets (24 cm) + 1 unnumbered sheet (22 x 28 cm) ; in box (14 x 41 x 47 cm)"
     ],
@@ -5676,9 +5659,7 @@
     "publicationRange": [],
     "electronicAccess": [],
     "instanceTypeId": "79a09d3a-bae8-433f-af70-9db9e134c662",
-    "instanceFormatIds": [
-      "sheet rdacarrier"
-    ],
+    "instanceFormatIds": [],
     "physicalDescriptions": [
       "1 map : color, plastic-coated ; sheet 71 x 61 cm, folded to 18 x 11 cm"
     ],
@@ -5778,9 +5759,7 @@
       }
     ],
     "instanceTypeId": "fe19bae4-da28-472b-be90-d442e2428ead",
-    "instanceFormatIds": [
-      "online resource cr rdacarrier"
-    ],
+    "instanceFormatIds": [],
     "physicalDescriptions": [
       "1 online resource (174 pages)."
     ],
@@ -5868,9 +5847,7 @@
     "publicationRange": [],
     "electronicAccess": [],
     "instanceTypeId": "fe19bae4-da28-472b-be90-d442e2428ead",
-    "instanceFormatIds": [
-      "volume nc rdacarrier"
-    ],
+    "instanceFormatIds": [],
     "physicalDescriptions": [
       "2, 6, 225 pages : illustrations ; 22 cm"
     ],
@@ -6046,10 +6023,7 @@
       }
     ],
     "instanceTypeId": "fe19bae4-da28-472b-be90-d442e2428ead",
-    "instanceFormatIds": [
-      "audio disc sd rdacarrier",
-      "volume nc rdacarrier"
-    ],
+    "instanceFormatIds": [],
     "physicalDescriptions": [
       "3 audio discs ; 12 in.",
       "92 pages : color illustrations ; 32 cm"
@@ -6175,9 +6149,7 @@
     "publicationRange": [],
     "electronicAccess": [],
     "instanceTypeId": "9eeda240-e773-4643-b037-06db69553b74",
-    "instanceFormatIds": [
-      "card rdacarrier"
-    ],
+    "instanceFormatIds": [],
     "physicalDescriptions": [
       "521 flash cards ; each 8 x 13 cm, in containers 9 x 14 x 9 cm and 9 x 14 x 6 cm"
     ],
@@ -6274,9 +6246,7 @@
     "publicationRange": [],
     "electronicAccess": [],
     "instanceTypeId": "fe19bae4-da28-472b-be90-d442e2428ead",
-    "instanceFormatIds": [
-      "volume nc rdacarrier"
-    ],
+    "instanceFormatIds": [],
     "physicalDescriptions": [
       "219 pages : illustrations ; 20 cm"
     ],
@@ -6361,9 +6331,7 @@
     "publicationRange": [],
     "electronicAccess": [],
     "instanceTypeId": "fe19bae4-da28-472b-be90-d442e2428ead",
-    "instanceFormatIds": [
-      "volume nc rdacarrier"
-    ],
+    "instanceFormatIds": [],
     "physicalDescriptions": [
       "100 loose-leaf : chiefly color illustrations ; 37 cm + 1 suppl. (158 pages ; 26 cm)"
     ],
@@ -6453,9 +6421,7 @@
     "publicationRange": [],
     "electronicAccess": [],
     "instanceTypeId": "fe19bae4-da28-472b-be90-d442e2428ead",
-    "instanceFormatIds": [
-      "volume nc rdacarrier"
-    ],
+    "instanceFormatIds": [],
     "physicalDescriptions": [
       "1 score (42 pages) + 4 parts ; 28 cm"
     ],
@@ -6571,9 +6537,7 @@
     "publicationRange": [],
     "electronicAccess": [],
     "instanceTypeId": "fe19bae4-da28-472b-be90-d442e2428ead",
-    "instanceFormatIds": [
-      "volume nc rdacarrier"
-    ],
+    "instanceFormatIds": [],
     "physicalDescriptions": [
       "1 score (6 pages) ; 30 x 42 cm"
     ],
@@ -6649,9 +6613,7 @@
     "publicationRange": [],
     "electronicAccess": [],
     "instanceTypeId": "fe19bae4-da28-472b-be90-d442e2428ead",
-    "instanceFormatIds": [
-      "volume nc rdacarrier"
-    ],
+    "instanceFormatIds": [],
     "physicalDescriptions": [
       "1 score (55 pages) : illustrations ; 22 x 28 cm",
       "6 parts ; 28 cm"
@@ -6796,9 +6758,7 @@
     "publicationRange": [],
     "electronicAccess": [],
     "instanceTypeId": "fe19bae4-da28-472b-be90-d442e2428ead",
-    "instanceFormatIds": [
-      "volume nc rdacarrier"
-    ],
+    "instanceFormatIds": [],
     "physicalDescriptions": [
       "14, 539, 173 pages : portrait ; 25 cm"
     ],
@@ -6896,10 +6856,7 @@
       }
     ],
     "instanceTypeId": "fe19bae4-da28-472b-be90-d442e2428ead",
-    "instanceFormatIds": [
-      "object nr rdacarrier",
-      "other cz rdacarrier accompanying USB flash drive"
-    ],
+    "instanceFormatIds": [],
     "physicalDescriptions": [
       "1 object : plastic ; 13 x 20 x 20 cm + 1 USB flash drive."
     ],
@@ -6976,9 +6933,7 @@
     "publicationRange": [],
     "electronicAccess": [],
     "instanceTypeId": "fe19bae4-da28-472b-be90-d442e2428ead",
-    "instanceFormatIds": [
-      "volume nc rdacarrier"
-    ],
+    "instanceFormatIds": [],
     "physicalDescriptions": [
       "61 leaves : paper ; 230 x 140 (200 x 120) mm"
     ],
@@ -7103,9 +7058,7 @@
       }
     ],
     "instanceTypeId": "fe19bae4-da28-472b-be90-d442e2428ead",
-    "instanceFormatIds": [
-      "online resource cr rdacarrier"
-    ],
+    "instanceFormatIds": [],
     "physicalDescriptions": [
       "1 online resource (10 video files (4 hr., 46 min., 42 sec.)) : sound, color."
     ],
@@ -7217,9 +7170,7 @@
     "publicationRange": [],
     "electronicAccess": [],
     "instanceTypeId": "fe19bae4-da28-472b-be90-d442e2428ead",
-    "instanceFormatIds": [
-      "volume nc rdacarrier"
-    ],
+    "instanceFormatIds": [],
     "physicalDescriptions": [
       "xii, 314 pages ; 25 cm"
     ],
@@ -7322,9 +7273,7 @@
     "publicationRange": [],
     "electronicAccess": [],
     "instanceTypeId": "fe19bae4-da28-472b-be90-d442e2428ead",
-    "instanceFormatIds": [
-      "volume nc rdacarrier"
-    ],
+    "instanceFormatIds": [],
     "physicalDescriptions": [
       "ix, 306 pages ; 23 cm."
     ],

--- a/ramls/change-manager.raml
+++ b/ramls/change-manager.raml
@@ -32,6 +32,8 @@ types:
   classificationTypes: !include settings/classificationtypes.json
   instanceType: !include settings/instancetype.json
   instanceTypes: !include settings/instancetypes.json
+  instanceFormat: !include settings/instanceformat.json
+  instanceFormats: !include settings/instanceformats.json
 
 traits:
   validate: !include raml-storage/raml-util/traits/validation.raml

--- a/ramls/settings/instanceformat.json
+++ b/ramls/settings/instanceformat.json
@@ -1,0 +1,32 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "description": "The format of an Instance",
+  "type": "object",
+  "properties": {
+    "id": {
+      "type": "string"
+    },
+    "name": {
+      "description": "label for the Instance format",
+      "type": "string"
+    },
+    "code": {
+      "description": "distinct code for the Instance format",
+      "type": "string"
+    },
+    "source": {
+      "description": "origin of the Instance format record",
+      "type": "string"
+    },
+    "metadata": {
+      "type": "object",
+      "$ref": "../raml-storage/raml-util/schemas/metadata.schema",
+      "readonly": true
+    }
+  },
+  "required": [
+    "name",
+    "code",
+    "source"
+  ]
+}

--- a/ramls/settings/instanceformats.json
+++ b/ramls/settings/instanceformats.json
@@ -1,0 +1,23 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "description": "A collection of Instance format records (controlled vocabulary)",
+  "type": "object",
+  "properties": {
+    "instanceFormats": {
+      "description": "List of instance formats",
+      "id": "instanceFormat",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "$ref": "instanceformat.json"
+      }
+    },
+    "totalRecords": {
+      "type": "integer"
+    }
+  },
+  "required": [
+    "instanceFormats",
+    "totalRecords"
+  ]
+}


### PR DESCRIPTION
- In the Create/Edit screen, this is one value (Format) with 2 terms hyphenated together in the dropdown list (Category and Term)
- In the View details screen, there are 4 values: Category, Term, Code, and Source
- Valid values are listed in the tenant’s Settings/Inventory/Format
- Comes from the 337 and 338 fields of the MARC record
- Mapping: 
             337 $a: Format Category
             338 $a: Format Term
             338 $b: Format Code
             338 $2: Format Source
- Note: MARC 337/338 fields are repeatable. Instance Format is also repeatable. If multiple 3372/3382, pair the first 337$a with the first 338 $a$b$2. Pair the second 337$a with the second 338 $a$b$2. Etc. 
