### PR TITLE
MODSOURMAN-194 Added mapping for GPO and Cancelled GPO number identifier types

### DIFF
--- a/mod-source-record-manager-server/src/main/java/org/folio/services/mappers/processor/functions/NormalizationFunction.java
+++ b/mod-source-record-manager-server/src/main/java/org/folio/services/mappers/processor/functions/NormalizationFunction.java
@@ -4,6 +4,7 @@ import io.vertx.core.json.JsonObject;
 import org.apache.commons.lang.StringUtils;
 import org.folio.rest.jaxrs.model.ContributorNameType;
 import org.folio.rest.jaxrs.model.ContributorType;
+import org.folio.rest.jaxrs.model.IdentifierType;
 import org.folio.rest.jaxrs.model.InstanceType;
 import org.folio.rest.jaxrs.model.ClassificationType;
 import org.folio.rest.jaxrs.model.InstanceFormat;
@@ -226,6 +227,7 @@ public enum NormalizationFunction implements Function<RuleExecutionContext, Stri
         .orElse(STUB_FIELD_TYPE_ID);
     }
   },
+
   SET_ELECTRONIC_ACCESS_RELATIONS_ID() {
     @Override
     public String apply(RuleExecutionContext context) {
@@ -237,10 +239,27 @@ public enum NormalizationFunction implements Function<RuleExecutionContext, Stri
       String name = ElectronicAccessRelationshipEnum.getNameByIndicator(ind2);
       return electronicAccessRelationships
         .stream()
-        .filter(electronicAccessRelationship -> electronicAccessRelationship
-          .getName().toLowerCase().equals(name)
-        ).findFirst()
+        .filter(electronicAccessRelationship -> electronicAccessRelationship.getName().equalsIgnoreCase(name))
+        .findFirst()
         .map(ElectronicAccessRelationship::getId)
+        .orElse(STUB_FIELD_TYPE_ID);
+    }
+  },
+
+  SET_IDENTIFIER_TYPE_ID_BY_NAME() {
+    private static final String NAME_PARAMETER = "name";
+
+    @Override
+    public String apply(RuleExecutionContext context) {
+      String typeName = context.getRuleParameter().getString(NAME_PARAMETER);
+      List<IdentifierType> identifierTypes = context.getMappingParameters().getIdentifierTypes();
+      if (identifierTypes == null || typeName == null) {
+        return STUB_FIELD_TYPE_ID;
+      }
+      return identifierTypes.stream()
+        .filter(identifierType -> identifierType.getName().equals(typeName))
+        .findFirst()
+        .map(IdentifierType::getId)
         .orElse(STUB_FIELD_TYPE_ID);
     }
   };

--- a/mod-source-record-manager-server/src/main/resources/rules.json
+++ b/mod-source-record-manager-server/src/main/resources/rules.json
@@ -753,8 +753,14 @@
           ],
           "rules": [
             {
-              "conditions": [],
-              "value": "351ebc1c-3aae-4825-8765-c6d50dbf011f"
+              "conditions": [
+                {
+                  "type": "set_identifier_type_id_by_name",
+                  "parameter": {
+                    "name": "GPO item number"
+                  }
+                }
+              ]
             }
           ]
         },
@@ -787,8 +793,14 @@
           ],
           "rules": [
             {
-              "conditions": [],
-              "value": "351ebc1c-3aae-4825-8765-c6d50dbf011f"
+              "conditions": [
+                {
+                  "type": "set_identifier_type_id_by_name",
+                  "parameter": {
+                    "name": "Cancelled GPO item number"
+                  }
+                }
+              ]
             }
           ]
         },

--- a/mod-source-record-manager-server/src/test/java/org/folio/services/mapping/functions/NormalizationFunctionTest.java
+++ b/mod-source-record-manager-server/src/test/java/org/folio/services/mapping/functions/NormalizationFunctionTest.java
@@ -6,6 +6,7 @@ import org.folio.rest.jaxrs.model.ClassificationType;
 import org.folio.rest.jaxrs.model.ContributorNameType;
 import org.folio.rest.jaxrs.model.ElectronicAccessRelationship;
 import org.folio.rest.jaxrs.model.ContributorType;
+import org.folio.rest.jaxrs.model.IdentifierType;
 import org.folio.rest.jaxrs.model.InstanceFormat;
 import org.folio.rest.jaxrs.model.InstanceType;
 import org.folio.services.mappers.processor.RuleExecutionContext;
@@ -497,6 +498,34 @@ public class NormalizationFunctionTest {
     String actualContributorNameTypeId = runFunction("set_contributor_name_type_id", context);
     // then
     assertEquals(STUB_FIELD_TYPE_ID, actualContributorNameTypeId);
+  }
+
+  @Test
+  public void SET_IDENTIFIER_TYPE_ID_BY_NAME_shouldReturnExpectedResult() {
+    // given
+    String expectedIdentifierTypeId = UUID.randomUUID().toString();
+    IdentifierType identifierType = new IdentifierType()
+      .withId(expectedIdentifierTypeId)
+      .withName("GPO item number");
+    RuleExecutionContext context = new RuleExecutionContext();
+    context.setMappingParameters(new MappingParameters().withIdentifierTypes(Collections.singletonList(identifierType)));
+    context.setRuleParameter(new JsonObject().put("name", "GPO item number"));
+    // when
+    String actualIdentifierTypeId = runFunction("set_identifier_type_id_by_name", context);
+    // then
+    assertEquals(expectedIdentifierTypeId, actualIdentifierTypeId);
+  }
+
+  @Test
+  public void SET_IDENTIFIER_TYPE_ID_BY_NAME_shouldReturnStubIdIfNoSettingsSpecified() {
+    // given
+    RuleExecutionContext context = new RuleExecutionContext();
+    context.setMappingParameters(new MappingParameters());
+    context.setRuleParameter(new JsonObject().put("name", "GPO item number"));
+    // when
+    String actualIdentifierTypeId = runFunction("set_identifier_type_id_by_name", context);
+    // then
+    assertEquals(STUB_FIELD_TYPE_ID, actualIdentifierTypeId);
   }
 
 }


### PR DESCRIPTION
Identifier: GPO and Cancelled GPO number (rows 14, 15)
Review the subfields carefully to determine GPO Identifier Type
074 $a = [Valid] GPO item number
074 $z = Cancelled GPO item number
Each of the above subfields should be in a separate Instance GPO number field, even if they are in the same MARC 074 field

Examples
074 \\$a1002-A
074 \\$a1002-B (MF)
Become
GPO item number 1002-A
GPO item number 1002-B (MF)

074 \\$a1022-A$z1012-A
Become
GPO item number 1022-A
Cancelled GPO item number 1012-A
