### PR TITLE
MODSOURMAN-193 Added mapping for System control number vs. OCLC number

### DIFF
--- a/mod-source-record-manager-server/src/main/resources/rules.json
+++ b/mod-source-record-manager-server/src/main/resources/rules.json
@@ -333,8 +333,14 @@
           ],
           "rules": [
             {
-              "conditions": [],
-              "value": "7e591197-f335-4afb-bc6d-a6d76ca3bace"
+              "conditions": [
+                {
+                  "type": "set_identifier_type_id_by_name",
+                  "parameter": {
+                    "name": "Cancelled system control number"
+                  }
+                }
+              ]
             }
           ]
         },
@@ -642,13 +648,19 @@
           "target": "identifiers.identifierTypeId",
           "description": "Type for System Control Number",
           "subfield": [
-            "a",
-            "z"
+            "a"
           ],
           "rules": [
             {
-              "conditions": [],
-              "value": "7e591197-f335-4afb-bc6d-a6d76ca3bace"
+              "conditions": [
+                {
+                  "type": "set_identifier_type_id_by_value",
+                  "parameter": {
+                    "names": ["System control number", "OCLC"],
+                    "oclc_regex": "(\\(OCoLC\\)|ocm|ocn|on).*"
+                  }
+                }
+              ]
             }
           ]
         },
@@ -656,7 +668,37 @@
           "target": "identifiers.value",
           "description": "System Control Number",
           "subfield": [
-            "a",
+            "a"
+          ]
+        }
+      ]
+    },
+    {
+      "entityPerRepeatedSubfield": true,
+      "entity": [
+        {
+          "target": "identifiers.identifierTypeId",
+          "description": "Type for System Control Number",
+          "subfield": [
+            "z"
+          ],
+          "rules": [
+            {
+              "conditions": [
+                {
+                  "type": "set_identifier_type_id_by_name",
+                  "parameter": {
+                    "name": "Cancelled system control number"
+                  }
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "target": "identifiers.value",
+          "description": "System Control Number",
+          "subfield": [
             "z"
           ]
         }

--- a/mod-source-record-manager-server/src/test/resources/org/folio/services/mapping/instances.json
+++ b/mod-source-record-manager-server/src/test/resources/org/folio/services/mapping/instances.json
@@ -21,19 +21,19 @@
       },
       {
         "value": "(CStRLIN)NYCX1604275S",
-        "identifierTypeId": "7e591197-f335-4afb-bc6d-a6d76ca3bace"
+        "identifierTypeId": "fe19bae4-da28-472b-be90-d442e2428ead"
       },
       {
         "value": "(NIC)notisABP6388",
-        "identifierTypeId": "7e591197-f335-4afb-bc6d-a6d76ca3bace"
+        "identifierTypeId": "fe19bae4-da28-472b-be90-d442e2428ead"
       },
       {
         "value": "366832",
-        "identifierTypeId": "7e591197-f335-4afb-bc6d-a6d76ca3bace"
+        "identifierTypeId": "fe19bae4-da28-472b-be90-d442e2428ead"
       },
       {
         "value": "(OCoLC)1604275",
-        "identifierTypeId": "7e591197-f335-4afb-bc6d-a6d76ca3bace"
+        "identifierTypeId": "fe19bae4-da28-472b-be90-d442e2428ead"
       }
     ],
     "contributors": [
@@ -101,11 +101,11 @@
       },
       {
         "value": "(OCoLC)63611770",
-        "identifierTypeId": "7e591197-f335-4afb-bc6d-a6d76ca3bace"
+        "identifierTypeId": "fe19bae4-da28-472b-be90-d442e2428ead"
       },
       {
         "value": "393893",
-        "identifierTypeId": "7e591197-f335-4afb-bc6d-a6d76ca3bace"
+        "identifierTypeId": "fe19bae4-da28-472b-be90-d442e2428ead"
       }
     ],
     "contributors": [
@@ -172,51 +172,51 @@
       },
       {
         "value": "(OCoLC)9198532",
-        "identifierTypeId": "7e591197-f335-4afb-bc6d-a6d76ca3bace"
+        "identifierTypeId": "fe19bae4-da28-472b-be90-d442e2428ead"
       },
       {
         "value": "(OCoLC)10110074",
-        "identifierTypeId": "7e591197-f335-4afb-bc6d-a6d76ca3bace"
+        "identifierTypeId": "fe19bae4-da28-472b-be90-d442e2428ead"
       },
       {
         "value": "(OCoLC)10244202",
-        "identifierTypeId": "7e591197-f335-4afb-bc6d-a6d76ca3bace"
+        "identifierTypeId": "fe19bae4-da28-472b-be90-d442e2428ead"
       },
       {
         "value": "(OCoLC)10783351",
-        "identifierTypeId": "7e591197-f335-4afb-bc6d-a6d76ca3bace"
+        "identifierTypeId": "fe19bae4-da28-472b-be90-d442e2428ead"
       },
       {
         "value": "(OCoLC)13815315",
-        "identifierTypeId": "7e591197-f335-4afb-bc6d-a6d76ca3bace"
+        "identifierTypeId": "fe19bae4-da28-472b-be90-d442e2428ead"
       },
       {
         "value": "(OCoLC)15380354",
-        "identifierTypeId": "7e591197-f335-4afb-bc6d-a6d76ca3bace"
+        "identifierTypeId": "fe19bae4-da28-472b-be90-d442e2428ead"
       },
       {
         "value": "(OCoLC)19554478",
-        "identifierTypeId": "7e591197-f335-4afb-bc6d-a6d76ca3bace"
+        "identifierTypeId": "fe19bae4-da28-472b-be90-d442e2428ead"
       },
       {
         "value": "(OCoLC)22099324",
-        "identifierTypeId": "7e591197-f335-4afb-bc6d-a6d76ca3bace"
+        "identifierTypeId": "fe19bae4-da28-472b-be90-d442e2428ead"
       },
       {
         "value": "(OCoLC)22675561",
-        "identifierTypeId": "7e591197-f335-4afb-bc6d-a6d76ca3bace"
+        "identifierTypeId": "fe19bae4-da28-472b-be90-d442e2428ead"
       },
       {
         "value": "(CStRLIN)NYCX83B57",
-        "identifierTypeId": "7e591197-f335-4afb-bc6d-a6d76ca3bace"
+        "identifierTypeId": "fe19bae4-da28-472b-be90-d442e2428ead"
       },
       {
         "value": "(NIC)notisADJ8405",
-        "identifierTypeId": "7e591197-f335-4afb-bc6d-a6d76ca3bace"
+        "identifierTypeId": "fe19bae4-da28-472b-be90-d442e2428ead"
       },
       {
         "value": "788038",
-        "identifierTypeId": "7e591197-f335-4afb-bc6d-a6d76ca3bace"
+        "identifierTypeId": "fe19bae4-da28-472b-be90-d442e2428ead"
       }
     ],
     "contributors": [
@@ -299,15 +299,15 @@
     "identifiers": [
       {
         "value": "(OCoLC)10724092",
-        "identifierTypeId": "7e591197-f335-4afb-bc6d-a6d76ca3bace"
+        "identifierTypeId": "fe19bae4-da28-472b-be90-d442e2428ead"
       },
       {
         "value": "(NIC)notisAHJ5096",
-        "identifierTypeId": "7e591197-f335-4afb-bc6d-a6d76ca3bace"
+        "identifierTypeId": "fe19bae4-da28-472b-be90-d442e2428ead"
       },
       {
         "value": "1567726",
-        "identifierTypeId": "7e591197-f335-4afb-bc6d-a6d76ca3bace"
+        "identifierTypeId": "fe19bae4-da28-472b-be90-d442e2428ead"
       }
     ],
     "contributors": [
@@ -423,15 +423,15 @@
       },
       {
         "value": "(NIC)notisAHK7689",
-        "identifierTypeId": "7e591197-f335-4afb-bc6d-a6d76ca3bace"
+        "identifierTypeId": "fe19bae4-da28-472b-be90-d442e2428ead"
       },
       {
         "value": "(OCoLC)3289989",
-        "identifierTypeId": "7e591197-f335-4afb-bc6d-a6d76ca3bace"
+        "identifierTypeId": "fe19bae4-da28-472b-be90-d442e2428ead"
       },
       {
         "value": "1579067",
-        "identifierTypeId": "7e591197-f335-4afb-bc6d-a6d76ca3bace"
+        "identifierTypeId": "fe19bae4-da28-472b-be90-d442e2428ead"
       }
     ],
     "contributors": [
@@ -515,19 +515,19 @@
     "identifiers": [
       {
         "value": "(CStRLIN)NYCX89B13682",
-        "identifierTypeId": "7e591197-f335-4afb-bc6d-a6d76ca3bace"
+        "identifierTypeId": "fe19bae4-da28-472b-be90-d442e2428ead"
       },
       {
         "value": "(NIC)notisAJC6081",
-        "identifierTypeId": "7e591197-f335-4afb-bc6d-a6d76ca3bace"
+        "identifierTypeId": "fe19bae4-da28-472b-be90-d442e2428ead"
       },
       {
         "value": "(OCoLC)20036158",
-        "identifierTypeId": "7e591197-f335-4afb-bc6d-a6d76ca3bace"
+        "identifierTypeId": "fe19bae4-da28-472b-be90-d442e2428ead"
       },
       {
         "value": "1735560",
-        "identifierTypeId": "7e591197-f335-4afb-bc6d-a6d76ca3bace"
+        "identifierTypeId": "fe19bae4-da28-472b-be90-d442e2428ead"
       }
     ],
     "contributors": [
@@ -599,19 +599,19 @@
       },
       {
         "value": "(CStRLIN)NYCX91C2172",
-        "identifierTypeId": "7e591197-f335-4afb-bc6d-a6d76ca3bace"
+        "identifierTypeId": "fe19bae4-da28-472b-be90-d442e2428ead"
       },
       {
         "value": "(NIC)notisAJX6816",
-        "identifierTypeId": "7e591197-f335-4afb-bc6d-a6d76ca3bace"
+        "identifierTypeId": "fe19bae4-da28-472b-be90-d442e2428ead"
       },
       {
         "value": "(OCoLC)526872",
-        "identifierTypeId": "7e591197-f335-4afb-bc6d-a6d76ca3bace"
+        "identifierTypeId": "fe19bae4-da28-472b-be90-d442e2428ead"
       },
       {
         "value": "1913668",
-        "identifierTypeId": "7e591197-f335-4afb-bc6d-a6d76ca3bace"
+        "identifierTypeId": "fe19bae4-da28-472b-be90-d442e2428ead"
       }
     ],
     "contributors": [
@@ -689,19 +689,19 @@
     "identifiers": [
       {
         "value": "(CStRLIN)NYCV84A1595",
-        "identifierTypeId": "7e591197-f335-4afb-bc6d-a6d76ca3bace"
+        "identifierTypeId": "fe19bae4-da28-472b-be90-d442e2428ead"
       },
       {
         "value": "(CStRLIN)NYCV84-A1595",
-        "identifierTypeId": "7e591197-f335-4afb-bc6d-a6d76ca3bace"
+        "identifierTypeId": "fe19bae4-da28-472b-be90-d442e2428ead"
       },
       {
         "value": "(OCoLC)64073323",
-        "identifierTypeId": "7e591197-f335-4afb-bc6d-a6d76ca3bace"
+        "identifierTypeId": "fe19bae4-da28-472b-be90-d442e2428ead"
       },
       {
         "value": "2074805",
-        "identifierTypeId": "7e591197-f335-4afb-bc6d-a6d76ca3bace"
+        "identifierTypeId": "fe19bae4-da28-472b-be90-d442e2428ead"
       }
     ],
     "contributors": [
@@ -765,23 +765,23 @@
     "identifiers": [
       {
         "value": "(CStRLIN)NYCV88A235",
-        "identifierTypeId": "7e591197-f335-4afb-bc6d-a6d76ca3bace"
+        "identifierTypeId": "fe19bae4-da28-472b-be90-d442e2428ead"
       },
       {
         "value": "(CStRLIN)NYCV88-A235",
-        "identifierTypeId": "7e591197-f335-4afb-bc6d-a6d76ca3bace"
+        "identifierTypeId": "fe19bae4-da28-472b-be90-d442e2428ead"
       },
       {
         "value": "(NIC)notisAKS5183",
-        "identifierTypeId": "7e591197-f335-4afb-bc6d-a6d76ca3bace"
+        "identifierTypeId": "fe19bae4-da28-472b-be90-d442e2428ead"
       },
       {
         "value": "(OCoLC)63934641",
-        "identifierTypeId": "7e591197-f335-4afb-bc6d-a6d76ca3bace"
+        "identifierTypeId": "fe19bae4-da28-472b-be90-d442e2428ead"
       },
       {
         "value": "2087008",
-        "identifierTypeId": "7e591197-f335-4afb-bc6d-a6d76ca3bace"
+        "identifierTypeId": "fe19bae4-da28-472b-be90-d442e2428ead"
       }
     ],
     "contributors": [
@@ -894,23 +894,23 @@
     "identifiers": [
       {
         "value": "(CStRLIN)NYCV85A227",
-        "identifierTypeId": "7e591197-f335-4afb-bc6d-a6d76ca3bace"
+        "identifierTypeId": "fe19bae4-da28-472b-be90-d442e2428ead"
       },
       {
         "value": "(CStRLIN)NYCV85-A227",
-        "identifierTypeId": "7e591197-f335-4afb-bc6d-a6d76ca3bace"
+        "identifierTypeId": "fe19bae4-da28-472b-be90-d442e2428ead"
       },
       {
         "value": "(NIC)notisAKY0509",
-        "identifierTypeId": "7e591197-f335-4afb-bc6d-a6d76ca3bace"
+        "identifierTypeId": "fe19bae4-da28-472b-be90-d442e2428ead"
       },
       {
         "value": "(OCoLC)63945058",
-        "identifierTypeId": "7e591197-f335-4afb-bc6d-a6d76ca3bace"
+        "identifierTypeId": "fe19bae4-da28-472b-be90-d442e2428ead"
       },
       {
         "value": "2139224",
-        "identifierTypeId": "7e591197-f335-4afb-bc6d-a6d76ca3bace"
+        "identifierTypeId": "fe19bae4-da28-472b-be90-d442e2428ead"
       }
     ],
     "contributors": [
@@ -1164,19 +1164,19 @@
       },
       {
         "value": "(CStRLIN)NYCX92R2055",
-        "identifierTypeId": "7e591197-f335-4afb-bc6d-a6d76ca3bace"
+        "identifierTypeId": "fe19bae4-da28-472b-be90-d442e2428ead"
       },
       {
         "value": "(NIC)notisAMA8780",
-        "identifierTypeId": "7e591197-f335-4afb-bc6d-a6d76ca3bace"
+        "identifierTypeId": "fe19bae4-da28-472b-be90-d442e2428ead"
       },
       {
         "value": "(OCoLC)27328814",
-        "identifierTypeId": "7e591197-f335-4afb-bc6d-a6d76ca3bace"
+        "identifierTypeId": "fe19bae4-da28-472b-be90-d442e2428ead"
       },
       {
         "value": "2395240",
-        "identifierTypeId": "7e591197-f335-4afb-bc6d-a6d76ca3bace"
+        "identifierTypeId": "fe19bae4-da28-472b-be90-d442e2428ead"
       }
     ],
     "contributors": [
@@ -1231,19 +1231,19 @@
       },
       {
         "value": "(CStRLIN)NYCX93B21842",
-        "identifierTypeId": "7e591197-f335-4afb-bc6d-a6d76ca3bace"
+        "identifierTypeId": "fe19bae4-da28-472b-be90-d442e2428ead"
       },
       {
         "value": "(NIC)notisAMR4493",
-        "identifierTypeId": "7e591197-f335-4afb-bc6d-a6d76ca3bace"
+        "identifierTypeId": "fe19bae4-da28-472b-be90-d442e2428ead"
       },
       {
         "value": "(OCoLC)10462561",
-        "identifierTypeId": "7e591197-f335-4afb-bc6d-a6d76ca3bace"
+        "identifierTypeId": "fe19bae4-da28-472b-be90-d442e2428ead"
       },
       {
         "value": "2536831",
-        "identifierTypeId": "7e591197-f335-4afb-bc6d-a6d76ca3bace"
+        "identifierTypeId": "fe19bae4-da28-472b-be90-d442e2428ead"
       }
     ],
     "contributors": [
@@ -1298,15 +1298,15 @@
       },
       {
         "value": "(NIC)notisANX3362",
-        "identifierTypeId": "7e591197-f335-4afb-bc6d-a6d76ca3bace"
+        "identifierTypeId": "fe19bae4-da28-472b-be90-d442e2428ead"
       },
       {
         "value": "(OCoLC)29565042",
-        "identifierTypeId": "7e591197-f335-4afb-bc6d-a6d76ca3bace"
+        "identifierTypeId": "fe19bae4-da28-472b-be90-d442e2428ead"
       },
       {
         "value": "2824702",
-        "identifierTypeId": "7e591197-f335-4afb-bc6d-a6d76ca3bace"
+        "identifierTypeId": "fe19bae4-da28-472b-be90-d442e2428ead"
       }
     ],
     "contributors": [
@@ -1407,15 +1407,15 @@
     "identifiers": [
       {
         "value": "(NIC)notisAQT5075",
-        "identifierTypeId": "7e591197-f335-4afb-bc6d-a6d76ca3bace"
+        "identifierTypeId": "fe19bae4-da28-472b-be90-d442e2428ead"
       },
       {
         "value": "3247314",
-        "identifierTypeId": "7e591197-f335-4afb-bc6d-a6d76ca3bace"
+        "identifierTypeId": "fe19bae4-da28-472b-be90-d442e2428ead"
       },
       {
         "value": "(OCoLC)13959794",
-        "identifierTypeId": "7e591197-f335-4afb-bc6d-a6d76ca3bace"
+        "identifierTypeId": "fe19bae4-da28-472b-be90-d442e2428ead"
       }
     ],
     "contributors": [
@@ -1498,15 +1498,15 @@
       },
       {
         "value": "(NIC)notisAQY8394",
-        "identifierTypeId": "7e591197-f335-4afb-bc6d-a6d76ca3bace"
+        "identifierTypeId": "fe19bae4-da28-472b-be90-d442e2428ead"
       },
       {
         "value": "(OCoLC)38553572",
-        "identifierTypeId": "7e591197-f335-4afb-bc6d-a6d76ca3bace"
+        "identifierTypeId": "fe19bae4-da28-472b-be90-d442e2428ead"
       },
       {
         "value": "3298956",
-        "identifierTypeId": "7e591197-f335-4afb-bc6d-a6d76ca3bace"
+        "identifierTypeId": "fe19bae4-da28-472b-be90-d442e2428ead"
       }
     ],
     "contributors": [
@@ -1597,11 +1597,11 @@
     "identifiers": [
       {
         "value": "4215849",
-        "identifierTypeId": "7e591197-f335-4afb-bc6d-a6d76ca3bace"
+        "identifierTypeId": "fe19bae4-da28-472b-be90-d442e2428ead"
       },
       {
         "value": "(OCoLC)166375848",
-        "identifierTypeId": "7e591197-f335-4afb-bc6d-a6d76ca3bace"
+        "identifierTypeId": "fe19bae4-da28-472b-be90-d442e2428ead"
       }
     ],
     "contributors": [
@@ -1683,11 +1683,11 @@
       },
       {
         "value": "4442869",
-        "identifierTypeId": "7e591197-f335-4afb-bc6d-a6d76ca3bace"
+        "identifierTypeId": "fe19bae4-da28-472b-be90-d442e2428ead"
       },
       {
         "value": "(OCoLC)34818133",
-        "identifierTypeId": "7e591197-f335-4afb-bc6d-a6d76ca3bace"
+        "identifierTypeId": "fe19bae4-da28-472b-be90-d442e2428ead"
       }
     ],
     "contributors": [
@@ -1756,11 +1756,11 @@
       },
       {
         "value": "4986243",
-        "identifierTypeId": "7e591197-f335-4afb-bc6d-a6d76ca3bace"
+        "identifierTypeId": "fe19bae4-da28-472b-be90-d442e2428ead"
       },
       {
         "value": "(OCoLC)42856539",
-        "identifierTypeId": "7e591197-f335-4afb-bc6d-a6d76ca3bace"
+        "identifierTypeId": "fe19bae4-da28-472b-be90-d442e2428ead"
       }
     ],
     "contributors": [
@@ -1860,15 +1860,15 @@
       },
       {
         "value": "(WaSeSS)OCM1ssj0000060",
-        "identifierTypeId": "7e591197-f335-4afb-bc6d-a6d76ca3bace"
+        "identifierTypeId": "fe19bae4-da28-472b-be90-d442e2428ead"
       },
       {
         "value": "(OCoLC)61523343",
-        "identifierTypeId": "7e591197-f335-4afb-bc6d-a6d76ca3bace"
+        "identifierTypeId": "fe19bae4-da28-472b-be90-d442e2428ead"
       },
       {
         "value": "5383976",
-        "identifierTypeId": "7e591197-f335-4afb-bc6d-a6d76ca3bace"
+        "identifierTypeId": "fe19bae4-da28-472b-be90-d442e2428ead"
       }
     ],
     "contributors": [
@@ -2004,11 +2004,11 @@
       },
       {
         "value": "(OCoLC)34116891",
-        "identifierTypeId": "7e591197-f335-4afb-bc6d-a6d76ca3bace"
+        "identifierTypeId": "fe19bae4-da28-472b-be90-d442e2428ead"
       },
       {
         "value": "5442502",
-        "identifierTypeId": "7e591197-f335-4afb-bc6d-a6d76ca3bace"
+        "identifierTypeId": "fe19bae4-da28-472b-be90-d442e2428ead"
       }
     ],
     "contributors": [
@@ -2069,11 +2069,11 @@
     "identifiers": [
       {
         "value": "6086303",
-        "identifierTypeId": "7e591197-f335-4afb-bc6d-a6d76ca3bace"
+        "identifierTypeId": "fe19bae4-da28-472b-be90-d442e2428ead"
       },
       {
         "value": "(OCoLC)56430919",
-        "identifierTypeId": "7e591197-f335-4afb-bc6d-a6d76ca3bace"
+        "identifierTypeId": "fe19bae4-da28-472b-be90-d442e2428ead"
       }
     ],
     "contributors": [
@@ -2145,11 +2145,11 @@
     "identifiers": [
       {
         "value": "(OCoLC)166334683",
-        "identifierTypeId": "7e591197-f335-4afb-bc6d-a6d76ca3bace"
+        "identifierTypeId": "fe19bae4-da28-472b-be90-d442e2428ead"
       },
       {
         "value": "6093806",
-        "identifierTypeId": "7e591197-f335-4afb-bc6d-a6d76ca3bace"
+        "identifierTypeId": "fe19bae4-da28-472b-be90-d442e2428ead"
       }
     ],
     "contributors": [
@@ -2243,11 +2243,11 @@
     "identifiers": [
       {
         "value": "6190220",
-        "identifierTypeId": "7e591197-f335-4afb-bc6d-a6d76ca3bace"
+        "identifierTypeId": "fe19bae4-da28-472b-be90-d442e2428ead"
       },
       {
         "value": "(OCoLC)11883822",
-        "identifierTypeId": "7e591197-f335-4afb-bc6d-a6d76ca3bace"
+        "identifierTypeId": "fe19bae4-da28-472b-be90-d442e2428ead"
       }
     ],
     "contributors": [
@@ -2306,15 +2306,15 @@
     "identifiers": [
       {
         "value": "(OCoLC)ocm62784216",
-        "identifierTypeId": "7e591197-f335-4afb-bc6d-a6d76ca3bace"
+        "identifierTypeId": "fe19bae4-da28-472b-be90-d442e2428ead"
       },
       {
         "value": "6216570",
-        "identifierTypeId": "7e591197-f335-4afb-bc6d-a6d76ca3bace"
+        "identifierTypeId": "fe19bae4-da28-472b-be90-d442e2428ead"
       },
       {
         "value": "(OCoLC)62784216",
-        "identifierTypeId": "7e591197-f335-4afb-bc6d-a6d76ca3bace"
+        "identifierTypeId": "fe19bae4-da28-472b-be90-d442e2428ead"
       }
     ],
     "contributors": [
@@ -2390,11 +2390,11 @@
       },
       {
         "value": "6268723",
-        "identifierTypeId": "7e591197-f335-4afb-bc6d-a6d76ca3bace"
+        "identifierTypeId": "fe19bae4-da28-472b-be90-d442e2428ead"
       },
       {
         "value": "(OCoLC)226859466",
-        "identifierTypeId": "7e591197-f335-4afb-bc6d-a6d76ca3bace"
+        "identifierTypeId": "fe19bae4-da28-472b-be90-d442e2428ead"
       }
     ],
     "contributors": [
@@ -2472,15 +2472,15 @@
     "identifiers": [
       {
         "value": "(LSDIArch)2796995",
-        "identifierTypeId": "7e591197-f335-4afb-bc6d-a6d76ca3bace"
+        "identifierTypeId": "fe19bae4-da28-472b-be90-d442e2428ead"
       },
       {
         "value": "(OCoLC)468797681",
-        "identifierTypeId": "7e591197-f335-4afb-bc6d-a6d76ca3bace"
+        "identifierTypeId": "fe19bae4-da28-472b-be90-d442e2428ead"
       },
       {
         "value": "6769537",
-        "identifierTypeId": "7e591197-f335-4afb-bc6d-a6d76ca3bace"
+        "identifierTypeId": "fe19bae4-da28-472b-be90-d442e2428ead"
       }
     ],
     "contributors": [
@@ -3566,11 +3566,11 @@
       },
       {
         "value": "(OCoLC)436228315",
-        "identifierTypeId": "7e591197-f335-4afb-bc6d-a6d76ca3bace"
+        "identifierTypeId": "fe19bae4-da28-472b-be90-d442e2428ead"
       },
       {
         "value": "6881317",
-        "identifierTypeId": "7e591197-f335-4afb-bc6d-a6d76ca3bace"
+        "identifierTypeId": "fe19bae4-da28-472b-be90-d442e2428ead"
       }
     ],
     "contributors": [
@@ -3982,11 +3982,11 @@
     "identifiers": [
       {
         "value": "(OCoLC)659310846",
-        "identifierTypeId": "7e591197-f335-4afb-bc6d-a6d76ca3bace"
+        "identifierTypeId": "fe19bae4-da28-472b-be90-d442e2428ead"
       },
       {
         "value": "6942105",
-        "identifierTypeId": "7e591197-f335-4afb-bc6d-a6d76ca3bace"
+        "identifierTypeId": "fe19bae4-da28-472b-be90-d442e2428ead"
       }
     ],
     "contributors": [],
@@ -4068,11 +4068,11 @@
       },
       {
         "value": "6970336",
-        "identifierTypeId": "7e591197-f335-4afb-bc6d-a6d76ca3bace"
+        "identifierTypeId": "fe19bae4-da28-472b-be90-d442e2428ead"
       },
       {
         "value": "(OCoLC)653119755",
-        "identifierTypeId": "7e591197-f335-4afb-bc6d-a6d76ca3bace"
+        "identifierTypeId": "fe19bae4-da28-472b-be90-d442e2428ead"
       }
     ],
     "contributors": [
@@ -4196,11 +4196,11 @@
       },
       {
         "value": "7025902",
-        "identifierTypeId": "7e591197-f335-4afb-bc6d-a6d76ca3bace"
+        "identifierTypeId": "fe19bae4-da28-472b-be90-d442e2428ead"
       },
       {
         "value": "(OCoLC)656507721",
-        "identifierTypeId": "7e591197-f335-4afb-bc6d-a6d76ca3bace"
+        "identifierTypeId": "fe19bae4-da28-472b-be90-d442e2428ead"
       }
     ],
     "contributors": [
@@ -4320,11 +4320,11 @@
       },
       {
         "value": "7063543",
-        "identifierTypeId": "7e591197-f335-4afb-bc6d-a6d76ca3bace"
+        "identifierTypeId": "fe19bae4-da28-472b-be90-d442e2428ead"
       },
       {
         "value": "(OCoLC)669625356",
-        "identifierTypeId": "7e591197-f335-4afb-bc6d-a6d76ca3bace"
+        "identifierTypeId": "fe19bae4-da28-472b-be90-d442e2428ead"
       }
     ],
     "contributors": [
@@ -4399,11 +4399,11 @@
       },
       {
         "value": "(OCoLC)698070011",
-        "identifierTypeId": "7e591197-f335-4afb-bc6d-a6d76ca3bace"
+        "identifierTypeId": "fe19bae4-da28-472b-be90-d442e2428ead"
       },
       {
         "value": "7196443",
-        "identifierTypeId": "7e591197-f335-4afb-bc6d-a6d76ca3bace"
+        "identifierTypeId": "fe19bae4-da28-472b-be90-d442e2428ead"
       }
     ],
     "contributors": [
@@ -4467,15 +4467,15 @@
     "identifiers": [
       {
         "value": "(VaAlASP)ASP71782/glmu",
-        "identifierTypeId": "7e591197-f335-4afb-bc6d-a6d76ca3bace"
+        "identifierTypeId": "fe19bae4-da28-472b-be90-d442e2428ead"
       },
       {
         "value": "7280974",
-        "identifierTypeId": "7e591197-f335-4afb-bc6d-a6d76ca3bace"
+        "identifierTypeId": "fe19bae4-da28-472b-be90-d442e2428ead"
       },
       {
         "value": "(OCoLC)689536878",
-        "identifierTypeId": "7e591197-f335-4afb-bc6d-a6d76ca3bace"
+        "identifierTypeId": "fe19bae4-da28-472b-be90-d442e2428ead"
       }
     ],
     "contributors": [
@@ -4573,11 +4573,11 @@
       },
       {
         "value": "(OCoLC)743321427",
-        "identifierTypeId": "7e591197-f335-4afb-bc6d-a6d76ca3bace"
+        "identifierTypeId": "fe19bae4-da28-472b-be90-d442e2428ead"
       },
       {
         "value": "7311468",
-        "identifierTypeId": "7e591197-f335-4afb-bc6d-a6d76ca3bace"
+        "identifierTypeId": "fe19bae4-da28-472b-be90-d442e2428ead"
       }
     ],
     "contributors": [
@@ -4665,11 +4665,11 @@
       },
       {
         "value": "(OCoLC)648766901",
-        "identifierTypeId": "7e591197-f335-4afb-bc6d-a6d76ca3bace"
+        "identifierTypeId": "fe19bae4-da28-472b-be90-d442e2428ead"
       },
       {
         "value": "7720373",
-        "identifierTypeId": "7e591197-f335-4afb-bc6d-a6d76ca3bace"
+        "identifierTypeId": "fe19bae4-da28-472b-be90-d442e2428ead"
       }
     ],
     "contributors": [
@@ -4750,11 +4750,11 @@
       },
       {
         "value": "(OCoLC)855219292",
-        "identifierTypeId": "7e591197-f335-4afb-bc6d-a6d76ca3bace"
+        "identifierTypeId": "fe19bae4-da28-472b-be90-d442e2428ead"
       },
       {
         "value": "8246009",
-        "identifierTypeId": "7e591197-f335-4afb-bc6d-a6d76ca3bace"
+        "identifierTypeId": "fe19bae4-da28-472b-be90-d442e2428ead"
       }
     ],
     "contributors": [
@@ -4876,11 +4876,11 @@
       },
       {
         "value": "(OCoLC)870426828",
-        "identifierTypeId": "7e591197-f335-4afb-bc6d-a6d76ca3bace"
+        "identifierTypeId": "fe19bae4-da28-472b-be90-d442e2428ead"
       },
       {
         "value": "8256521",
-        "identifierTypeId": "7e591197-f335-4afb-bc6d-a6d76ca3bace"
+        "identifierTypeId": "fe19bae4-da28-472b-be90-d442e2428ead"
       }
     ],
     "contributors": [],
@@ -4925,11 +4925,11 @@
     "identifiers": [
       {
         "value": "(OCoLC)690107024",
-        "identifierTypeId": "7e591197-f335-4afb-bc6d-a6d76ca3bace"
+        "identifierTypeId": "fe19bae4-da28-472b-be90-d442e2428ead"
       },
       {
         "value": "8306272",
-        "identifierTypeId": "7e591197-f335-4afb-bc6d-a6d76ca3bace"
+        "identifierTypeId": "fe19bae4-da28-472b-be90-d442e2428ead"
       }
     ],
     "contributors": [
@@ -5016,15 +5016,15 @@
       },
       {
         "value": "(Naxos)8.557330",
-        "identifierTypeId": "7e591197-f335-4afb-bc6d-a6d76ca3bace"
+        "identifierTypeId": "fe19bae4-da28-472b-be90-d442e2428ead"
       },
       {
         "value": "8536818",
-        "identifierTypeId": "7e591197-f335-4afb-bc6d-a6d76ca3bace"
+        "identifierTypeId": "fe19bae4-da28-472b-be90-d442e2428ead"
       },
       {
         "value": "(OCoLC)884180198",
-        "identifierTypeId": "7e591197-f335-4afb-bc6d-a6d76ca3bace"
+        "identifierTypeId": "fe19bae4-da28-472b-be90-d442e2428ead"
       }
     ],
     "contributors": [
@@ -5233,15 +5233,15 @@
       },
       {
         "value": "(Naxos)5099920882457",
-        "identifierTypeId": "7e591197-f335-4afb-bc6d-a6d76ca3bace"
+        "identifierTypeId": "fe19bae4-da28-472b-be90-d442e2428ead"
       },
       {
         "value": "(OCoLC)885043143",
-        "identifierTypeId": "7e591197-f335-4afb-bc6d-a6d76ca3bace"
+        "identifierTypeId": "fe19bae4-da28-472b-be90-d442e2428ead"
       },
       {
         "value": "8579052",
-        "identifierTypeId": "7e591197-f335-4afb-bc6d-a6d76ca3bace"
+        "identifierTypeId": "fe19bae4-da28-472b-be90-d442e2428ead"
       }
     ],
     "contributors": [
@@ -5438,11 +5438,11 @@
       },
       {
         "value": "(OCoLC)913573026",
-        "identifierTypeId": "7e591197-f335-4afb-bc6d-a6d76ca3bace"
+        "identifierTypeId": "fe19bae4-da28-472b-be90-d442e2428ead"
       },
       {
         "value": "9134222",
-        "identifierTypeId": "7e591197-f335-4afb-bc6d-a6d76ca3bace"
+        "identifierTypeId": "fe19bae4-da28-472b-be90-d442e2428ead"
       }
     ],
     "contributors": [
@@ -5518,11 +5518,11 @@
     "identifiers": [
       {
         "value": "9220704",
-        "identifierTypeId": "7e591197-f335-4afb-bc6d-a6d76ca3bace"
+        "identifierTypeId": "fe19bae4-da28-472b-be90-d442e2428ead"
       },
       {
         "value": "(OCoLC)965475081",
-        "identifierTypeId": "7e591197-f335-4afb-bc6d-a6d76ca3bace"
+        "identifierTypeId": "fe19bae4-da28-472b-be90-d442e2428ead"
       }
     ],
     "contributors": [
@@ -5630,11 +5630,11 @@
       },
       {
         "value": "(OCoLC)863715403",
-        "identifierTypeId": "7e591197-f335-4afb-bc6d-a6d76ca3bace"
+        "identifierTypeId": "fe19bae4-da28-472b-be90-d442e2428ead"
       },
       {
         "value": "9520682",
-        "identifierTypeId": "7e591197-f335-4afb-bc6d-a6d76ca3bace"
+        "identifierTypeId": "fe19bae4-da28-472b-be90-d442e2428ead"
       }
     ],
     "contributors": [
@@ -5806,11 +5806,11 @@
     "identifiers": [
       {
         "value": "(OCoLC)959661050",
-        "identifierTypeId": "7e591197-f335-4afb-bc6d-a6d76ca3bace"
+        "identifierTypeId": "fe19bae4-da28-472b-be90-d442e2428ead"
       },
       {
         "value": "9629391",
-        "identifierTypeId": "7e591197-f335-4afb-bc6d-a6d76ca3bace"
+        "identifierTypeId": "fe19bae4-da28-472b-be90-d442e2428ead"
       }
     ],
     "contributors": [
@@ -5899,15 +5899,15 @@
     "identifiers": [
       {
         "value": "(OCoLC)905337733",
-        "identifierTypeId": "7e591197-f335-4afb-bc6d-a6d76ca3bace"
+        "identifierTypeId": "fe19bae4-da28-472b-be90-d442e2428ead"
       },
       {
         "value": "(MiFhGG)NCCO3020461",
-        "identifierTypeId": "7e591197-f335-4afb-bc6d-a6d76ca3bace"
+        "identifierTypeId": "fe19bae4-da28-472b-be90-d442e2428ead"
       },
       {
         "value": "9630194",
-        "identifierTypeId": "7e591197-f335-4afb-bc6d-a6d76ca3bace"
+        "identifierTypeId": "fe19bae4-da28-472b-be90-d442e2428ead"
       }
     ],
     "contributors": [
@@ -5997,11 +5997,11 @@
       },
       {
         "value": "(OCoLC)958840466",
-        "identifierTypeId": "7e591197-f335-4afb-bc6d-a6d76ca3bace"
+        "identifierTypeId": "fe19bae4-da28-472b-be90-d442e2428ead"
       },
       {
         "value": "9668145",
-        "identifierTypeId": "7e591197-f335-4afb-bc6d-a6d76ca3bace"
+        "identifierTypeId": "fe19bae4-da28-472b-be90-d442e2428ead"
       }
     ],
     "contributors": [
@@ -6103,11 +6103,11 @@
     "identifiers": [
       {
         "value": "(OCoLC)1004424910",
-        "identifierTypeId": "7e591197-f335-4afb-bc6d-a6d76ca3bace"
+        "identifierTypeId": "fe19bae4-da28-472b-be90-d442e2428ead"
       },
       {
         "value": "9691888",
-        "identifierTypeId": "7e591197-f335-4afb-bc6d-a6d76ca3bace"
+        "identifierTypeId": "fe19bae4-da28-472b-be90-d442e2428ead"
       }
     ],
     "contributors": [
@@ -6295,15 +6295,15 @@
       },
       {
         "value": "(OCoLC)966701167",
-        "identifierTypeId": "7e591197-f335-4afb-bc6d-a6d76ca3bace"
+        "identifierTypeId": "fe19bae4-da28-472b-be90-d442e2428ead"
       },
       {
         "value": "(POOF)1790",
-        "identifierTypeId": "7e591197-f335-4afb-bc6d-a6d76ca3bace"
+        "identifierTypeId": "fe19bae4-da28-472b-be90-d442e2428ead"
       },
       {
         "value": "9729229",
-        "identifierTypeId": "7e591197-f335-4afb-bc6d-a6d76ca3bace"
+        "identifierTypeId": "fe19bae4-da28-472b-be90-d442e2428ead"
       }
     ],
     "contributors": [
@@ -6386,15 +6386,15 @@
       },
       {
         "value": "(OCoLC)987797440",
-        "identifierTypeId": "7e591197-f335-4afb-bc6d-a6d76ca3bace"
+        "identifierTypeId": "fe19bae4-da28-472b-be90-d442e2428ead"
       },
       {
         "value": "(RuMoEVIS)5135521B",
-        "identifierTypeId": "7e591197-f335-4afb-bc6d-a6d76ca3bace"
+        "identifierTypeId": "fe19bae4-da28-472b-be90-d442e2428ead"
       },
       {
         "value": "9766936",
-        "identifierTypeId": "7e591197-f335-4afb-bc6d-a6d76ca3bace"
+        "identifierTypeId": "fe19bae4-da28-472b-be90-d442e2428ead"
       }
     ],
     "contributors": [
@@ -6496,15 +6496,15 @@
       },
       {
         "value": "(OCoLC)26218343",
-        "identifierTypeId": "7e591197-f335-4afb-bc6d-a6d76ca3bace"
+        "identifierTypeId": "fe19bae4-da28-472b-be90-d442e2428ead"
       },
       {
         "value": "(POOF2)4476",
-        "identifierTypeId": "7e591197-f335-4afb-bc6d-a6d76ca3bace"
+        "identifierTypeId": "fe19bae4-da28-472b-be90-d442e2428ead"
       },
       {
         "value": "9860927",
-        "identifierTypeId": "7e591197-f335-4afb-bc6d-a6d76ca3bace"
+        "identifierTypeId": "fe19bae4-da28-472b-be90-d442e2428ead"
       }
     ],
     "contributors": [
@@ -6582,11 +6582,11 @@
       },
       {
         "value": "(OCoLC)974393208",
-        "identifierTypeId": "7e591197-f335-4afb-bc6d-a6d76ca3bace"
+        "identifierTypeId": "fe19bae4-da28-472b-be90-d442e2428ead"
       },
       {
         "value": "9900811",
-        "identifierTypeId": "7e591197-f335-4afb-bc6d-a6d76ca3bace"
+        "identifierTypeId": "fe19bae4-da28-472b-be90-d442e2428ead"
       }
     ],
     "contributors": [
@@ -6696,11 +6696,11 @@
       },
       {
         "value": "(OCoLC)999728261",
-        "identifierTypeId": "7e591197-f335-4afb-bc6d-a6d76ca3bace"
+        "identifierTypeId": "fe19bae4-da28-472b-be90-d442e2428ead"
       },
       {
         "value": "9904545",
-        "identifierTypeId": "7e591197-f335-4afb-bc6d-a6d76ca3bace"
+        "identifierTypeId": "fe19bae4-da28-472b-be90-d442e2428ead"
       }
     ],
     "contributors": [
@@ -6781,11 +6781,11 @@
     "identifiers": [
       {
         "value": "(OCoLC)981898654",
-        "identifierTypeId": "7e591197-f335-4afb-bc6d-a6d76ca3bace"
+        "identifierTypeId": "fe19bae4-da28-472b-be90-d442e2428ead"
       },
       {
         "value": "9905184",
-        "identifierTypeId": "7e591197-f335-4afb-bc6d-a6d76ca3bace"
+        "identifierTypeId": "fe19bae4-da28-472b-be90-d442e2428ead"
       }
     ],
     "contributors": [
@@ -6903,11 +6903,11 @@
       },
       {
         "value": "(OCoLC)962186145",
-        "identifierTypeId": "7e591197-f335-4afb-bc6d-a6d76ca3bace"
+        "identifierTypeId": "fe19bae4-da28-472b-be90-d442e2428ead"
       },
       {
         "value": "9916898",
-        "identifierTypeId": "7e591197-f335-4afb-bc6d-a6d76ca3bace"
+        "identifierTypeId": "fe19bae4-da28-472b-be90-d442e2428ead"
       }
     ],
     "contributors": [
@@ -7006,7 +7006,7 @@
     "identifiers": [
       {
         "value": "(OCoLC)874849566",
-        "identifierTypeId": "7e591197-f335-4afb-bc6d-a6d76ca3bace"
+        "identifierTypeId": "fe19bae4-da28-472b-be90-d442e2428ead"
       }
     ],
     "contributors": [
@@ -7115,11 +7115,11 @@
     "identifiers": [
       {
         "value": "(OCoLC)168535137",
-        "identifierTypeId": "7e591197-f335-4afb-bc6d-a6d76ca3bace"
+        "identifierTypeId": "fe19bae4-da28-472b-be90-d442e2428ead"
       },
       {
         "value": "9952035",
-        "identifierTypeId": "7e591197-f335-4afb-bc6d-a6d76ca3bace"
+        "identifierTypeId": "fe19bae4-da28-472b-be90-d442e2428ead"
       }
     ],
     "contributors": [
@@ -7216,11 +7216,11 @@
     "identifiers": [
       {
         "value": "(OCoLC)1000519306",
-        "identifierTypeId": "7e591197-f335-4afb-bc6d-a6d76ca3bace"
+        "identifierTypeId": "fe19bae4-da28-472b-be90-d442e2428ead"
       },
       {
         "value": "10002020",
-        "identifierTypeId": "7e591197-f335-4afb-bc6d-a6d76ca3bace"
+        "identifierTypeId": "fe19bae4-da28-472b-be90-d442e2428ead"
       }
     ],
     "contributors": [
@@ -7338,11 +7338,11 @@
       },
       {
         "value": "(OCoLC)979534062",
-        "identifierTypeId": "7e591197-f335-4afb-bc6d-a6d76ca3bace"
+        "identifierTypeId": "fe19bae4-da28-472b-be90-d442e2428ead"
       },
       {
         "value": "10004464",
-        "identifierTypeId": "7e591197-f335-4afb-bc6d-a6d76ca3bace"
+        "identifierTypeId": "fe19bae4-da28-472b-be90-d442e2428ead"
       }
     ],
     "contributors": [
@@ -7445,7 +7445,7 @@
       },
       {
         "value": "(OCoLC)951929685",
-        "identifierTypeId": "7e591197-f335-4afb-bc6d-a6d76ca3bace"
+        "identifierTypeId": "fe19bae4-da28-472b-be90-d442e2428ead"
       }
     ],
     "contributors": [
@@ -7551,11 +7551,11 @@
       },
       {
         "value": "(OCoLC)1002130878",
-        "identifierTypeId": "7e591197-f335-4afb-bc6d-a6d76ca3bace"
+        "identifierTypeId": "fe19bae4-da28-472b-be90-d442e2428ead"
       },
       {
         "value": "10062588",
-        "identifierTypeId": "7e591197-f335-4afb-bc6d-a6d76ca3bace"
+        "identifierTypeId": "fe19bae4-da28-472b-be90-d442e2428ead"
       }
     ],
     "contributors": [


### PR DESCRIPTION
For most 035 $a, identifier type should be System control number
BUT: if the 035 $a begins with
(OCoLC)
ocm
ocn
on
Then assign Identifier type OCLC instead
019 $a and 035 $z should always be assigned identifier type Cancelled system control number
Each number (subfield a or z) always goes in a separate identifier field in the Instance, even if they are in the same MARC 035 field
