### PR TITLE
Moddicore 43: Fix formatting of 035 field constructed from incoming 001

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,6 @@
 ## 2020-04-10 v2.2.0-SNAPSHOT
 * [MODSOURMAN-303](https://issues.folio.org/browse/MODSOURMAN-303) Add actual state on creating record.
-
+* [MODDICORE-43](https://issues.folio.org/browse/MODDICORE-43) SRS MARC Bib: Fix formatting of 035 field constructed from incoming 001
 ## 2020-04-10 v2.1.3-SNAPSHOT
 * [MODSOURMAN-298](https://issues.folio.org/browse/MODSOURMAN-298) Added migration script to support RMB version update 
 

--- a/mod-source-record-manager-server/src/main/java/org/folio/services/afterprocessing/HrIdFieldServiceImpl.java
+++ b/mod-source-record-manager-server/src/main/java/org/folio/services/afterprocessing/HrIdFieldServiceImpl.java
@@ -10,6 +10,8 @@ import java.util.List;
 import java.util.Map;
 
 import static org.folio.services.afterprocessing.AdditionalFieldsUtil.addControlledFieldToMarcRecord;
+import static org.folio.services.afterprocessing.AdditionalFieldsUtil.addDataFieldToMarcRecord;
+import static org.folio.services.afterprocessing.AdditionalFieldsUtil.isFieldExist;
 import static org.folio.services.afterprocessing.AdditionalFieldsUtil.removeField;
 
 @Service
@@ -17,6 +19,8 @@ public class HrIdFieldServiceImpl implements HrIdFieldService {
 
   private static final String HR_ID_FROM_FIELD = "001";
   private static final String HR_ID_TO_FIELD = "035";
+  private static final char HR_ID_FIELD_SUB = 'a';
+  private static final char HR_ID_FIELD_IND = ' ';
 
   public void moveHrIdFieldsAfterMapping(Map<Instance, Record> map) {
     map.entrySet().stream().parallel().forEach(entry -> {
@@ -36,8 +40,8 @@ public class HrIdFieldServiceImpl implements HrIdFieldService {
   public void fillHrIdFieldInMarcRecord(List<Pair<Record, Instance>> list) {
     list.stream().parallel().forEach(recordInstancePair -> {
       String hrId = recordInstancePair.getValue().getHrid();
-      if (StringUtils.isNotEmpty(hrId)) {
-        addControlledFieldToMarcRecord(recordInstancePair.getKey(), HR_ID_FROM_FIELD, hrId);
+      if (StringUtils.isNotEmpty(hrId) && !isFieldExist(recordInstancePair.getKey(), HR_ID_FROM_FIELD, HR_ID_FIELD_SUB, hrId)) {
+        addDataFieldToMarcRecord(recordInstancePair.getKey(), HR_ID_FROM_FIELD, HR_ID_FIELD_IND, HR_ID_FIELD_IND, HR_ID_FIELD_SUB, hrId);
       }
     });
   }


### PR DESCRIPTION
1. The 035 field should indicators 1 and 2 of [blank] (currently no JSON for indicators in the screenshot where 035 looks like a fixed field)
2. The contents of the former 001 field should be in subfield a of the 035 field (currently no subfield)
3. If there are existing 035 fields, the newly-created 035 should be a completely new 035 (since 035 is a repeatable field)
4. If the newly-created 035 matches an existing 035 exactly, then do not add that new 035 field.
5. If possible, put the newly-created 035 fields in numeric order within the 0XX fields (but DO NOT resequence the entire MARC record into numeric order)
6. Fix stub data and recalculate leader