### PR TITLE
MODSOURMAN-321 Return 202 when request for update of parsed record is received

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -9,6 +9,7 @@
 * [MODSOURMAN-275](https://issues.folio.org/browse/MODSOURMAN-275) Remove preview area's sample data
 * [MODSOURMAN-318](https://issues.folio.org/browse/MODSOURMAN-318) Remove hardcoded diku tenant in db schema.json
 * Updated reference to raml-storage
+* [MODSOURMAN-321](https://issues.folio.org/browse/MODSOURMAN-321) Change response status to 202 on parsed record update
 
 ## 2020-04-23 v2.1.3
 * [MODSOURMAN-303](https://issues.folio.org/browse/MODSOURMAN-303) Add actual state on creating record

--- a/mod-source-record-manager-server/src/main/java/org/folio/rest/impl/ChangeManagerImpl.java
+++ b/mod-source-record-manager-server/src/main/java/org/folio/rest/impl/ChangeManagerImpl.java
@@ -228,7 +228,7 @@ public class ChangeManagerImpl implements ChangeManager {
     vertxContext.runOnContext(v -> {
       try {
         parsedRecordService.updateRecord(entity, new OkapiConnectionParams(okapiHeaders, vertxContext.owner()))
-          .map(updated -> PutChangeManagerParsedRecordsByIdResponse.respond204())
+          .map(sentEventForProcessing -> PutChangeManagerParsedRecordsByIdResponse.respond202())
           .map(Response.class::cast)
           .otherwise(ExceptionHelper::mapExceptionToResponse)
           .setHandler(asyncResultHandler);

--- a/mod-source-record-manager-server/src/test/java/org/folio/rest/impl/changeManager/ChangeManagerParsedRecordsAPITest.java
+++ b/mod-source-record-manager-server/src/test/java/org/folio/rest/impl/changeManager/ChangeManagerParsedRecordsAPITest.java
@@ -135,7 +135,7 @@ public class ChangeManagerParsedRecordsAPITest extends AbstractRestTest {
       .when()
       .put(PARSED_RECORDS_URL + "/" + parsedRecordDto.getId())
       .then()
-      .statusCode(HttpStatus.SC_NO_CONTENT);
+      .statusCode(HttpStatus.SC_ACCEPTED);
     async.complete();
   }
 

--- a/ramls/change-manager.raml
+++ b/ramls/change-manager.raml
@@ -243,7 +243,7 @@ resourceTypes:
           application/json:
             schema: parsedRecordDto
         responses:
-          204:
+          202:
           400:
             description: "Bad request"
             body:


### PR DESCRIPTION
The update of the SRS MARC Record and the corresponding inventory Instance happens using pub-sub approach. Change Manager publishes an event upon receiving the request, and all the processing of MARC and Instance happens in other modules. Hence, 202 http response status (ACCEPTED) is more appropriate than 204.