### PR TITLE
MODSOURMAN-339: Disable CQL2PgJSON & CQLWrapper extra logging in mod-source-record-manager.

### DIFF
--- a/.rancher-pipeline.yml
+++ b/.rancher-pipeline.yml
@@ -3,7 +3,7 @@ stages:
   steps:
   - runScriptConfig:
       image: maven:3-adoptopenjdk-11
-      shellScript: mvn package -DskipTests
+      shellScript: mvn package -DskipTests -Djava.util.logging.config.file=vertx-default-jul-logging.properties
 - name: Build Docker with DIND
   steps:
   - publishImageConfig:

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,4 +1,5 @@
 ## 2020-08-17 v2.5.0-SNAPSHOT
+* [MODSOURMAN-339](https://issues.folio.org/browse/MODSOURMAN-339) Disable CQL2PgJSON & CQLWrapper extra logging in mod-source-record-manager
 
 ## 2020-08-17 v2.4.1-SNAPSHOT
 * [MODSOURMAN-363](https://issues.folio.org/browse/MODSOURMAN-363) New user with all permissions gets errors when importing with magic button

--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -439,7 +439,7 @@
     },
     "env": [
       { "name": "JAVA_OPTIONS",
-        "value": "-XX:MaxRAMPercentage=66.0"
+        "value": "-XX:MaxRAMPercentage=66.0  -Djava.util.logging.config.file=vertx-default-jul-logging.properties"
       },
       { "name": "DB_HOST", "value": "postgres" },
       { "name": "DB_PORT", "value": "5432" },

--- a/mod-source-record-manager-server/src/main/resources/log4j2.properties
+++ b/mod-source-record-manager-server/src/main/resources/log4j2.properties
@@ -13,3 +13,6 @@ appender.console.layout.pattern = %d{HH:mm:ss.SSS} [%t] %-5p %-20.20C{1} [%reqId
 
 rootLogger.level = info
 rootLogger.appenderRef.stdout.ref = STDOUT
+
+logger.cql2pgjson.name = org.folio.rest.persist.cql
+logger.cql2pgjson.level = OFF

--- a/mod-source-record-manager-server/src/main/resources/vertx-default-jul-logging.properties
+++ b/mod-source-record-manager-server/src/main/resources/vertx-default-jul-logging.properties
@@ -1,0 +1,5 @@
+handlers = java.util.logging.ConsoleHandler
+.level = ALL
+
+logger.cql2pgjson.level = ERROR
+logger.cql2pgjson.name = org.folio.cql2pgjson.CQL2PgJSON


### PR DESCRIPTION
1. New config file "vertx-default-jul-logging" for overriding vertx-jul added with disabling(except ERROR log-level) CQL2PgJSON.
2. Disabling CQLWrapper to log4j2.properties added.
3. "-Djava.util.logging.config.file=vertx-default-jul-logging.properties" added for ModuleDescriptor.
4. "-Djava.util.logging.config.file=vertx-default-jul-logging.properties" to the .rancher-config-file.
5. NEWS updated.