### PR TITLE
MOODDICORE-114: Add MARC-Instance default mappings for 880 fields .

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -2,6 +2,7 @@
 * [MODSOURMAN-380](https://issues.folio.org/browse/MODSOURMAN-380) Expand journalRecord entity with "title" property.
 * [MODSOURMAN-385](https://issues.folio.org/browse/MODSOURMAN-385) Enable OCLC update processing.
 * [MODSOURMAN-381](https://issues.folio.org/browse/MODSOURMAN-381) Add endpoint to retrieve a list of jobLogEntryDto.
+* [MODDICORE-114](https://issues.folio.org/browse/MODDICORE-114) Add MARC-Instance default mappings for 880 fields .
 
 
 ## 2020-11-20 v2.4.3

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,4 +1,5 @@
-## xxxx-xx-xx v2.5.0-SNAPSHOT
+## 2020-11-29 v2.5.0-SNAPSHOT
+* [MODSOURMAN-380](https://issues.folio.org/browse/MODSOURMAN-380) Expand journalRecord entity with "title" property.
 
 ## 2020-11-20 v2.4.3
 * [MODSOURCE-213](https://issues.folio.org/browse/MODSOURCE-213) MARC updates for selected fields is not working

--- a/RuleProcessorApi.md
+++ b/RuleProcessorApi.md
@@ -420,6 +420,47 @@ Rule:
 
 - If there is no "z" in record sub-fields then target field does not appear at all.
 - If there is "z" among record sub-fields then target field gets filled by all the `["z","q","c"].`
+
+
+#### Field replacement rules
+There are "fieldReplacement" properties. They need for changing field number for specific fields, based on field replacement rules.
+For example, if 880 field need to be changed on 711 based on some condition, "fieldReplacement" properties can help with it.
+Example:
+```json
+Rule:
+"880": [
+{
+"target": "",
+"description": "Field for target post-processing based on first 3 digits in subfield 6",
+"subfield": [
+"6"
+],
+"fieldReplacementBy3Digits" : true,
+"fieldReplacementRule" : [
+{
+"sourceDigits": "100",
+"targetField": "700"
+},
+{
+"sourceDigits": "110",
+"targetField": "710"
+},
+{
+"sourceDigits": "111",
+"targetField": "711"
+},
+{
+"sourceDigits": "245",
+"targetField": "246"
+}
+]
+}
+]
+```
+`fieldReplacementBy3Digits` property indicates that "fieldReplacement"-logic should be applied here. (There can be added and implemented other properties, not only `...3Digits`)
+`fieldReplacementRule` property contains some additional data for "fieldReplacement"-logic.
+
+This mechanism executes in Processor, in data-import-processing-core, while parsing these rules.
 #
 ### REST API
 When the source-record-manager starts up, it performs initialization for default mapping rules for given tenant.

--- a/mod-source-record-manager-server/src/main/resources/rules/rules.json
+++ b/mod-source-record-manager-server/src/main/resources/rules/rules.json
@@ -6576,6 +6576,25 @@
       "description": "Field for target post-processing based on first 3 digits in subfield 6",
       "subfield": [
         "6"
+      ],
+      "fieldReplacementBy3Digits" : true,
+      "fieldReplacementRule" : [
+        {
+          "sourceDigits": "100",
+          "targetField": "700"
+        },
+        {
+          "sourceDigits": "110",
+          "targetField": "710"
+        },
+        {
+          "sourceDigits": "111",
+          "targetField": "711"
+        },
+        {
+          "sourceDigits": "245",
+          "targetField": "246"
+        }
       ]
     }
   ]

--- a/mod-source-record-manager-server/src/main/resources/rules/rules.json
+++ b/mod-source-record-manager-server/src/main/resources/rules/rules.json
@@ -6569,5 +6569,14 @@
         }
       ]
     }
+  ],
+  "880": [
+    {
+      "target": "",
+      "description": "Field for target post-processing based on first 3 digits in subfield 6",
+      "subfield": [
+        "6"
+      ]
+    }
   ]
 }

--- a/mod-source-record-manager-server/src/main/resources/templates/db_scripts/schema.json
+++ b/mod-source-record-manager-server/src/main/resources/templates/db_scripts/schema.json
@@ -107,6 +107,11 @@
       "run": "after",
       "snippetPath": "remove_deprecated_data.sql",
       "fromModuleVersion": "mod-source-record-manager-2.3.1"
+    },
+    {
+      "run": "after",
+      "snippet": "ALTER TABLE journal_records ADD COLUMN IF NOT EXISTS title text NULL;",
+      "fromModuleVersion": "mod-source-record-manager-2.5.0-SNAPSHOT"
     }
   ]
 }


### PR DESCRIPTION
## Purpose
Add MARC-Instance default mappings for 880 fields.
It based on the rules below:
   * Finds 880 field from the record. If exists, then retrieve first 3 digits from subfield '6'.
   * If there is value from this list: 100, 110, 111, 245 - then field-value '880' will be changed on 700,710,711,246 respectively.
   * Otherwise, '880' will be changed on the first 3-digits value.

## Approach
1. rules.json updated with 880 field.
2. NEWS updated.

## Learning
Other PR for this functionality: https://github.com/folio-org/data-import-processing-core/pull/114
More info: https://issues.folio.org/browse/MODDICORE-114
