### PR TITLE
MODSOURMAN-377: Update 5xx Notes mappings to indicate staff only for some notes. 

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -5,6 +5,7 @@
 * [MODSOURMAN-382](https://issues.folio.org/browse/MODSOURMAN-382) Fill title from marc record into journalRecord entity
 * [MODSOURMAN-383](https://issues.folio.org/browse/MODSOURMAN-383) Implement endpoint to retrieve a recordProcessingLogDto.
 * [MODDICORE-114](https://issues.folio.org/browse/MODDICORE-114) Add MARC-Instance default mappings for 880 fields .
+* [MODDSOURMAN-377](https://issues.folio.org/browse/MODSOURMAN-377) Update 5xx Notes mappings to indicate staff only for some notes.
 
 ## 2020-11-20 v2.4.3
 * [MODSOURCE-213](https://issues.folio.org/browse/MODSOURCE-213) MARC updates for selected fields is not working

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,4 +1,5 @@
-## xxxx-xx-xx v2.5.0-SNAPSHOT
+## 2020-11-29 v2.5.0-SNAPSHOT
+* [MODSOURMAN-380](https://issues.folio.org/browse/MODSOURMAN-380) Expand journalRecord entity with "title" property.
 
 ## 2020-11-20 v2.4.3
 * [MODSOURCE-213](https://issues.folio.org/browse/MODSOURCE-213) MARC updates for selected fields is not working

--- a/mod-source-record-manager-server/src/main/resources/rules/rules.json
+++ b/mod-source-record-manager-server/src/main/resources/rules/rules.json
@@ -3796,8 +3796,11 @@
           ],
           "rules": [
             {
-              "conditions": [],
-              "value": "false"
+              "conditions": [
+                {
+                  "type": "set_note_staff_only_via_indicator"
+                }
+              ]
             }
           ]
         }
@@ -3912,8 +3915,11 @@
           ],
           "rules": [
             {
-              "conditions": [],
-              "value": "false"
+              "conditions": [
+                {
+                  "type": "set_note_staff_only_via_indicator"
+                }
+              ]
             }
           ]
         }
@@ -4524,8 +4530,11 @@
           ],
           "rules": [
             {
-              "conditions": [],
-              "value": "false"
+              "conditions": [
+                {
+                  "type": "set_note_staff_only_via_indicator"
+                }
+              ]
             }
           ]
         }
@@ -5024,8 +5033,11 @@
           ],
           "rules": [
             {
-              "conditions": [],
-              "value": "false"
+              "conditions": [
+                {
+                  "type": "set_note_staff_only_via_indicator"
+                }
+              ]
             }
           ]
         }

--- a/mod-source-record-manager-server/src/main/resources/templates/db_scripts/schema.json
+++ b/mod-source-record-manager-server/src/main/resources/templates/db_scripts/schema.json
@@ -107,6 +107,11 @@
       "run": "after",
       "snippetPath": "remove_deprecated_data.sql",
       "fromModuleVersion": "mod-source-record-manager-2.3.1"
+    },
+    {
+      "run": "after",
+      "snippet": "ALTER TABLE journal_records ADD COLUMN IF NOT EXISTS title text NULL;",
+      "fromModuleVersion": "mod-source-record-manager-2.5.0-SNAPSHOT"
     }
   ]
 }


### PR DESCRIPTION
## Purpose
Update 5xx Notes mappings to indicate staff only for some notes.
Some 5xx note fields have indicators that correspond to staff only. Right now the default MARC-Instance mapping is only mapping based on the 5xx field value, not indicator values. The default rules need to be adjusted to take into account the Staff only checkbox as indicated below.

For the following notes fields:
* 541 Immediate source of acquisition note
* 542 Information related to copyright status note
* 561 Ownership and custodial history note
* 583 Action note
If the first indicator = 0, then mark the "Staff only" checkbox
If the first indicator = anything else, then DO NOT mark the "Staff only" checkbox

## Approach
1. Rules for 541, 542, 561, 583 staffOnly added. "set_note_staff_only_via_indicator" function added. 
2. NEWS updated.

## Learning
Additional PR: https://github.com/folio-org/data-import-processing-core/pull/115 
 * More info: https://issues.folio.org/browse/MODSOURMAN-377

