### PR TITLE
Require pubsub.events.post

### DIFF
--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -315,14 +315,14 @@
           "methods": ["POST"],
           "pathPattern": "/change-manager/handlers/created-inventory-instance",
           "permissionsRequired": [
-            "source-records-manager.events.post"
+            "pubsub.events.post"
           ]
         },
         {
           "methods": ["POST"],
           "pathPattern": "/change-manager/handlers/processing-result",
           "permissionsRequired": [
-            "source-records-manager.events.post"
+            "pubsub.events.post"
           ],
           "modulePermissions": [
             "source-storage.snapshots.put"
@@ -332,14 +332,14 @@
           "methods": ["POST"],
           "pathPattern": "/change-manager/handlers/qm-completed",
           "permissionsRequired": [
-            "source-records-manager.events.post"
+            "pubsub.events.post"
           ]
         },
         {
           "methods": ["POST"],
           "pathPattern": "/change-manager/handlers/qm-error",
           "permissionsRequired": [
-            "source-records-manager.events.post"
+            "pubsub.events.post"
           ]
         }
       ]


### PR DESCRIPTION
Permission is renamed from source-records-manager.events.post to pubsub.events.post in mod-pubsub . See https://issues.folio.org/browse/MODPUBSUB-145