### PR TITLE
Update interface versions

### DIFF
--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -15,14 +15,6 @@
       "version": "2.0"
     },
     {
-      "id": "source-storage-batch",
-      "version": "0.1"
-    },
-    {
-      "id": "inventory-batch",
-      "version": "0.3"
-    },
-    {
       "id": "users",
       "version": "15.0"
     },
@@ -378,7 +370,7 @@
     },
     {
       "id": "source-manager-event-handlers",
-      "version": "0.1",
+      "version": "1.0",
       "handlers": [
         {
           "methods": [

--- a/ramls/change-manager-handlers.raml
+++ b/ramls/change-manager-handlers.raml
@@ -1,7 +1,7 @@
 #%RAML 1.0
 
 title: Source Record Storage event handlers API
-version: v0.1
+version: v1.0
 protocols: [ HTTP, HTTPS ]
 baseUri: http://localhost
 

--- a/ramls/change-manager.raml
+++ b/ramls/change-manager.raml
@@ -1,7 +1,7 @@
 #%RAML 1.0
 
 title: Change Manager
-version: v2.0
+version: v1.0
 protocols: [ HTTP, HTTPS ]
 baseUri: http://localhost
 

--- a/ramls/mapping-rules-provider.raml
+++ b/ramls/mapping-rules-provider.raml
@@ -1,7 +1,7 @@
 #%RAML 1.0
 
 title: Mapping rules Provider
-version: v2.0
+version: v1.0
 protocols: [ HTTP, HTTPS ]
 baseUri: http://localhost
 

--- a/ramls/metadata-provider.raml
+++ b/ramls/metadata-provider.raml
@@ -1,7 +1,7 @@
 #%RAML 1.0
 
 title: Metadata Provider
-version: v2.0
+version: v1.0
 protocols: [ HTTP, HTTPS ]
 baseUri: http://localhost
 


### PR DESCRIPTION
## Purpose
* source-manager-event-handlers API version needs to be bumped after /change-manager/handlers/processing-result and /change-manager/handlers/created-inventory-instance endpoints were removed
* remove unnecessary interface dependencies on batch save APIs
* versions declared in the ModuleDescriptor should match versions in raml
