### PR TITLE
MODSOURMAN-408: Publish event about EDIFACT record creation

### DIFF
--- a/mod-source-record-manager-server/src/main/java/org/folio/rest/impl/InitAPIImpl.java
+++ b/mod-source-record-manager-server/src/main/java/org/folio/rest/impl/InitAPIImpl.java
@@ -20,7 +20,7 @@ import org.folio.spring.SpringContextUtil;
 import org.folio.verticle.DataImportConsumersVerticle;
 import org.folio.verticle.DataImportJournalConsumersVerticle;
 import org.folio.verticle.RawMarcChunkConsumersVerticle;
-import org.folio.verticle.StoredMarcChunkConsumersVerticle;
+import org.folio.verticle.StoredRecordChunkConsumersVerticle;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.beans.factory.annotation.Value;
@@ -32,6 +32,7 @@ public class InitAPIImpl implements InitAPI {
   @Value("${srm.kafka.RawMarcChunkConsumer.instancesNumber:5}")
   private int rawMarcChunkConsumerInstancesNumber;
 
+  // TODO: srm.kafka.StoredMarcChunkConsumer should be refactored
   @Value("${srm.kafka.StoredMarcChunkConsumer.instancesNumber:5}")
   private int storedMarcChunkConsumerInstancesNumber;
 
@@ -75,7 +76,7 @@ public class InitAPIImpl implements InitAPI {
   private Future<?> deployConsumersVerticles(Vertx vertx) {
     //TODO: get rid of this workaround with global spring context
     RawMarcChunkConsumersVerticle.setSpringGlobalContext(vertx.getOrCreateContext().get("springContext"));
-    StoredMarcChunkConsumersVerticle.setSpringGlobalContext(vertx.getOrCreateContext().get("springContext"));
+    StoredRecordChunkConsumersVerticle.setSpringGlobalContext(vertx.getOrCreateContext().get("springContext"));
     DataImportConsumersVerticle.setSpringGlobalContext(vertx.getOrCreateContext().get("springContext"));
     DataImportJournalConsumersVerticle.setSpringGlobalContext(vertx.getOrCreateContext().get("springContext"));
 

--- a/mod-source-record-manager-server/src/main/java/org/folio/services/ChangeEngineServiceImpl.java
+++ b/mod-source-record-manager-server/src/main/java/org/folio/services/ChangeEngineServiceImpl.java
@@ -1,16 +1,22 @@
 package org.folio.services;
 
-import io.vertx.core.Future;
-import io.vertx.core.Promise;
-import io.vertx.core.json.Json;
-import io.vertx.core.json.JsonArray;
-import io.vertx.core.json.JsonObject;
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
-import io.vertx.kafka.client.producer.KafkaHeader;
-import io.vertx.kafka.client.producer.impl.KafkaHeaderImpl;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Date;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import java.util.UUID;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.stream.Collectors;
+
+import javax.ws.rs.NotFoundException;
+
 import org.apache.commons.collections4.CollectionUtils;
 import org.apache.commons.lang3.mutable.MutableInt;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.folio.dao.JobExecutionSourceChunkDao;
 import org.folio.dataimport.util.OkapiConnectionParams;
 import org.folio.kafka.KafkaConfig;
@@ -43,27 +49,23 @@ import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 
-import javax.ws.rs.NotFoundException;
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.Date;
-import java.util.List;
-import java.util.Map;
-import java.util.Optional;
-import java.util.Set;
-import java.util.UUID;
-import java.util.concurrent.atomic.AtomicInteger;
-import java.util.stream.Collectors;
+import io.vertx.core.Future;
+import io.vertx.core.Promise;
+import io.vertx.core.json.Json;
+import io.vertx.core.json.JsonArray;
+import io.vertx.core.json.JsonObject;
+import io.vertx.kafka.client.producer.KafkaHeader;
+import io.vertx.kafka.client.producer.impl.KafkaHeaderImpl;
 
 import static java.lang.String.format;
 import static org.apache.commons.lang3.ObjectUtils.allNotNull;
 import static org.folio.rest.RestVerticle.MODULE_SPECIFIC_ARGS;
 import static org.folio.rest.jaxrs.model.DataImportEventTypes.DI_MARC_BIB_FOR_UPDATE_RECEIVED;
+import static org.folio.rest.jaxrs.model.DataImportEventTypes.DI_RAW_RECORDS_CHUNK_PARSED;
 import static org.folio.rest.jaxrs.model.JournalRecord.ActionType.CREATE;
 import static org.folio.services.afterprocessing.AdditionalFieldsUtil.TAG_999;
 import static org.folio.services.afterprocessing.AdditionalFieldsUtil.addFieldToMarcRecord;
 import static org.folio.services.afterprocessing.AdditionalFieldsUtil.getValue;
-import static org.folio.rest.jaxrs.model.DataImportEventTypes.DI_RAW_MARC_BIB_RECORDS_CHUNK_PARSED;
 import static org.folio.services.util.EventHandlingUtil.sendEventToKafka;
 
 @Service
@@ -256,7 +258,7 @@ public class ChangeEngineServiceImpl implements ChangeEngineService {
 
     String key = String.valueOf(indexer.incrementAndGet() % maxDistributionNum);
 
-    return sendEventToKafka(params.getTenantId(), Json.encode(recordCollection), DI_RAW_MARC_BIB_RECORDS_CHUNK_PARSED.value(),
+    return sendEventToKafka(params.getTenantId(), Json.encode(recordCollection), DI_RAW_RECORDS_CHUNK_PARSED.value(),
       kafkaHeaders, kafkaConfig, key)
       .compose(ar -> buildJournalRecordsForProcessedRecords(parsedRecords, parsedRecords, CREATE, params.getTenantId())
         .compose(journalRecords -> {

--- a/mod-source-record-manager-server/src/main/java/org/folio/verticle/StoredRecordChunkConsumersVerticle.java
+++ b/mod-source-record-manager-server/src/main/java/org/folio/verticle/StoredRecordChunkConsumersVerticle.java
@@ -17,9 +17,9 @@ public class StoredRecordChunkConsumersVerticle extends AbstractConsumersVerticl
 
   @Override
   public List<String> getEvents() {
-    return Arrays.asList(new String[] {
+    return Arrays.asList(
       DI_PARSED_MARC_BIB_RECORDS_CHUNK_SAVED.value()
-    });
+    );
   }
 
   @Override

--- a/mod-source-record-manager-server/src/main/java/org/folio/verticle/StoredRecordChunkConsumersVerticle.java
+++ b/mod-source-record-manager-server/src/main/java/org/folio/verticle/StoredRecordChunkConsumersVerticle.java
@@ -4,25 +4,27 @@ import org.folio.kafka.AsyncRecordHandler;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
 
-import java.util.Collections;
+import java.util.Arrays;
 import java.util.List;
 
 import static org.folio.rest.jaxrs.model.DataImportEventTypes.DI_PARSED_MARC_BIB_RECORDS_CHUNK_SAVED;
 
-public class StoredMarcChunkConsumersVerticle extends AbstractConsumersVerticle {
+public class StoredRecordChunkConsumersVerticle extends AbstractConsumersVerticle {
 
   @Autowired
-  @Qualifier("StoredMarcChunksKafkaHandler")
-  private AsyncRecordHandler<String, String> storedMarcChunksKafkaHandler;
+  @Qualifier("StoredRecordChunksKafkaHandler")
+  private AsyncRecordHandler<String, String> storedRecordChunksKafkaHandler;
 
   @Override
   public List<String> getEvents() {
-    return Collections.singletonList(DI_PARSED_MARC_BIB_RECORDS_CHUNK_SAVED.value());
+    return Arrays.asList(new String[] {
+      DI_PARSED_MARC_BIB_RECORDS_CHUNK_SAVED.value()
+    });
   }
 
   @Override
   public AsyncRecordHandler<String, String> getHandler() {
-    return this.storedMarcChunksKafkaHandler;
+    return this.storedRecordChunksKafkaHandler;
   }
 
 }

--- a/mod-source-record-manager-server/src/main/java/org/folio/verticle/StoredRecordChunkConsumersVerticle.java
+++ b/mod-source-record-manager-server/src/main/java/org/folio/verticle/StoredRecordChunkConsumersVerticle.java
@@ -4,10 +4,10 @@ import org.folio.kafka.AsyncRecordHandler;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
 
-import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 
-import static org.folio.rest.jaxrs.model.DataImportEventTypes.DI_PARSED_MARC_BIB_RECORDS_CHUNK_SAVED;
+import static org.folio.rest.jaxrs.model.DataImportEventTypes.DI_PARSED_RECORDS_CHUNK_SAVED;
 
 public class StoredRecordChunkConsumersVerticle extends AbstractConsumersVerticle {
 
@@ -17,9 +17,7 @@ public class StoredRecordChunkConsumersVerticle extends AbstractConsumersVerticl
 
   @Override
   public List<String> getEvents() {
-    return Arrays.asList(
-      DI_PARSED_MARC_BIB_RECORDS_CHUNK_SAVED.value()
-    );
+    return Collections.singletonList(DI_PARSED_RECORDS_CHUNK_SAVED.value());
   }
 
   @Override

--- a/mod-source-record-manager-server/src/main/java/org/folio/verticle/consumers/StoredMarcChunksKafkaHandler.java
+++ b/mod-source-record-manager-server/src/main/java/org/folio/verticle/consumers/StoredMarcChunksKafkaHandler.java
@@ -1,27 +1,31 @@
 package org.folio.verticle.consumers;
 
-import io.vertx.core.Future;
-import io.vertx.core.Vertx;
-import io.vertx.core.json.JsonObject;
+import java.io.IOException;
+import java.util.List;
+
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
-import io.vertx.kafka.client.consumer.KafkaConsumerRecord;
-import io.vertx.kafka.client.producer.KafkaHeader;
 import org.folio.dataimport.util.OkapiConnectionParams;
 import org.folio.kafka.AsyncRecordHandler;
 import org.folio.kafka.KafkaHeaderUtils;
 import org.folio.processing.events.utils.ZIPArchiver;
+import org.folio.rest.jaxrs.model.DataImportEventTypes;
 import org.folio.rest.jaxrs.model.Event;
 import org.folio.rest.jaxrs.model.Record;
+import org.folio.rest.jaxrs.model.Record.RecordType;
 import org.folio.rest.jaxrs.model.RecordsBatchResponse;
 import org.folio.services.RecordsPublishingService;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.stereotype.Component;
 
-import java.io.IOException;
-import java.util.List;
+import io.vertx.core.Future;
+import io.vertx.core.Vertx;
+import io.vertx.core.json.JsonObject;
+import io.vertx.kafka.client.consumer.KafkaConsumerRecord;
+import io.vertx.kafka.client.producer.KafkaHeader;
 
+import static org.folio.rest.jaxrs.model.DataImportEventTypes.DI_EDIFACT_RECORD_CREATED;
 import static org.folio.rest.jaxrs.model.DataImportEventTypes.DI_SRS_MARC_BIB_RECORD_CREATED;
 
 @Component
@@ -51,10 +55,17 @@ public class StoredMarcChunksKafkaHandler implements AsyncRecordHandler<String, 
       String unzipped = ZIPArchiver.unzip(event.getEventPayload());
       RecordsBatchResponse recordsBatchResponse = new JsonObject(unzipped).mapTo(RecordsBatchResponse.class);
       List<Record> storedRecords = recordsBatchResponse.getRecords();
+      // default to previous static value
+      String eventType = DI_SRS_MARC_BIB_RECORD_CREATED.value();
+      // we only know record type by inspecting the records, assuming records are homogeneous type
+      if (!storedRecords.isEmpty()) {
+        RecordType recordType = storedRecords.get(0).getRecordType();
+        eventType = RecordTypeToCreatedEventType.valueOf(recordType.value()).getCreatedEventType();
+      }
 
       LOGGER.debug("RecordsBatchResponse has been received, starting processing correlationId: {} chunkNumber: {}", correlationId, chunkNumber);
       return recordsPublishingService.sendEventsWithRecords(storedRecords, okapiConnectionParams.getHeaders().get("jobExecutionId"),
-        okapiConnectionParams, DI_SRS_MARC_BIB_RECORD_CREATED.value())
+        okapiConnectionParams, eventType)
         .compose(b -> {
           LOGGER.debug("RecordsBatchResponse processing has been completed correlationId: {} chunkNumber: {}",correlationId, chunkNumber);
           return Future.succeededFuture(correlationId);
@@ -66,6 +77,25 @@ public class StoredMarcChunksKafkaHandler implements AsyncRecordHandler<String, 
       LOGGER.error("Can't process kafka record: ", e);
       return Future.failedFuture(e);
     }
+  }
+
+  /**
+   * Enum mapping from {@link RecordType} to {@link DataImportEventTypes} for created events.
+   */
+  private enum RecordTypeToCreatedEventType {
+    MARC(DI_SRS_MARC_BIB_RECORD_CREATED),
+    EDIFACT(DI_EDIFACT_RECORD_CREATED);
+
+    private String createdEventType;
+
+    private RecordTypeToCreatedEventType(DataImportEventTypes createdEventType) {
+      this.createdEventType = createdEventType.value();
+    }
+
+    public String getCreatedEventType() {
+      return this.createdEventType;
+    }
+
   }
 
 }

--- a/mod-source-record-manager-server/src/main/java/org/folio/verticle/consumers/StoredMarcChunksKafkaHandler.java
+++ b/mod-source-record-manager-server/src/main/java/org/folio/verticle/consumers/StoredMarcChunksKafkaHandler.java
@@ -2,6 +2,7 @@ package org.folio.verticle.consumers;
 
 import java.io.IOException;
 import java.util.List;
+import java.util.Map;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -27,11 +28,18 @@ import io.vertx.kafka.client.producer.KafkaHeader;
 
 import static org.folio.rest.jaxrs.model.DataImportEventTypes.DI_EDIFACT_RECORD_CREATED;
 import static org.folio.rest.jaxrs.model.DataImportEventTypes.DI_SRS_MARC_BIB_RECORD_CREATED;
+import static org.folio.rest.jaxrs.model.Record.RecordType.EDIFACT;
+import static org.folio.rest.jaxrs.model.Record.RecordType.MARC;
 
 @Component
 @Qualifier("StoredMarcChunksKafkaHandler")
 public class StoredMarcChunksKafkaHandler implements AsyncRecordHandler<String, String> {
   private static final Logger LOGGER = LogManager.getLogger();
+
+  private static final Map<RecordType, DataImportEventTypes> RECORD_TYPE_TO_EVENT_TYPE = Map.of(
+    MARC, DI_SRS_MARC_BIB_RECORD_CREATED,
+    EDIFACT, DI_EDIFACT_RECORD_CREATED
+  );
 
   private RecordsPublishingService recordsPublishingService;
   private Vertx vertx;
@@ -55,17 +63,15 @@ public class StoredMarcChunksKafkaHandler implements AsyncRecordHandler<String, 
       String unzipped = ZIPArchiver.unzip(event.getEventPayload());
       RecordsBatchResponse recordsBatchResponse = new JsonObject(unzipped).mapTo(RecordsBatchResponse.class);
       List<Record> storedRecords = recordsBatchResponse.getRecords();
-      // default to previous static value
-      String eventType = DI_SRS_MARC_BIB_RECORD_CREATED.value();
-      // we only know record type by inspecting the records, assuming records are homogeneous type
-      if (!storedRecords.isEmpty()) {
-        RecordType recordType = storedRecords.get(0).getRecordType();
-        eventType = RecordTypeToCreatedEventType.valueOf(recordType.value()).getCreatedEventType();
-      }
+
+      // we only know record type by inspecting the records, assuming records are homogeneous type and defaulting to previous static value
+      DataImportEventTypes eventType = !storedRecords.isEmpty() && RECORD_TYPE_TO_EVENT_TYPE.containsKey(storedRecords.get(0).getRecordType())
+        ? RECORD_TYPE_TO_EVENT_TYPE.get(storedRecords.get(0).getRecordType())
+        : DI_SRS_MARC_BIB_RECORD_CREATED;
 
       LOGGER.debug("RecordsBatchResponse has been received, starting processing correlationId: {} chunkNumber: {}", correlationId, chunkNumber);
       return recordsPublishingService.sendEventsWithRecords(storedRecords, okapiConnectionParams.getHeaders().get("jobExecutionId"),
-        okapiConnectionParams, eventType)
+        okapiConnectionParams, eventType.value())
         .compose(b -> {
           LOGGER.debug("RecordsBatchResponse processing has been completed correlationId: {} chunkNumber: {}",correlationId, chunkNumber);
           return Future.succeededFuture(correlationId);
@@ -77,25 +83,6 @@ public class StoredMarcChunksKafkaHandler implements AsyncRecordHandler<String, 
       LOGGER.error("Can't process kafka record: ", e);
       return Future.failedFuture(e);
     }
-  }
-
-  /**
-   * Enum mapping from {@link RecordType} to {@link DataImportEventTypes} for created events.
-   */
-  private enum RecordTypeToCreatedEventType {
-    MARC(DI_SRS_MARC_BIB_RECORD_CREATED),
-    EDIFACT(DI_EDIFACT_RECORD_CREATED);
-
-    private String createdEventType;
-
-    private RecordTypeToCreatedEventType(DataImportEventTypes createdEventType) {
-      this.createdEventType = createdEventType.value();
-    }
-
-    public String getCreatedEventType() {
-      return this.createdEventType;
-    }
-
   }
 
 }

--- a/mod-source-record-manager-server/src/main/java/org/folio/verticle/consumers/StoredRecordChunksKafkaHandler.java
+++ b/mod-source-record-manager-server/src/main/java/org/folio/verticle/consumers/StoredRecordChunksKafkaHandler.java
@@ -32,8 +32,8 @@ import static org.folio.rest.jaxrs.model.Record.RecordType.EDIFACT;
 import static org.folio.rest.jaxrs.model.Record.RecordType.MARC;
 
 @Component
-@Qualifier("StoredMarcChunksKafkaHandler")
-public class StoredMarcChunksKafkaHandler implements AsyncRecordHandler<String, String> {
+@Qualifier("StoredRecordChunksKafkaHandler")
+public class StoredRecordChunksKafkaHandler implements AsyncRecordHandler<String, String> {
   private static final Logger LOGGER = LogManager.getLogger();
 
   private static final Map<RecordType, DataImportEventTypes> RECORD_TYPE_TO_EVENT_TYPE = Map.of(
@@ -44,7 +44,7 @@ public class StoredMarcChunksKafkaHandler implements AsyncRecordHandler<String, 
   private RecordsPublishingService recordsPublishingService;
   private Vertx vertx;
 
-  public StoredMarcChunksKafkaHandler(@Autowired @Qualifier("recordsPublishingService") RecordsPublishingService recordsPublishingService,
+  public StoredRecordChunksKafkaHandler(@Autowired @Qualifier("recordsPublishingService") RecordsPublishingService recordsPublishingService,
                                       @Autowired Vertx vertx) {
     this.recordsPublishingService = recordsPublishingService;
     this.vertx = vertx;


### PR DESCRIPTION
Resolves [MODSOURMAN-408](https://issues.folio.org/browse/MODSOURMAN-408)

Requires https://github.com/folio-org/data-import-raml-storage/pull/207

- [x] rename DI_RAW_MARC_BIB_RECORDS_CHUNK_PARSED event type to DI_RAW_RECORDS_CHUNK_PARSED
- [x] update ChangeEngineServiceImpl service and publish DI_RAW_RECORDS_CHUNK_PARSED event with records chunk to save records of any type in the mod-source-record-storage
- [x] expand dataImportEventTypes schema with event DI_EDIFACT_RECORD_CREATED
- [x] update StoredMarcChunksKafkaHandler to send corresponding event (DI_SRS_MARC_BIB_RECORD_CREATED/DI_EDIFACT_RECORD_CREATED) with record based on record type (MARC/EDIFACT)
- [ ] add tests

