### PR TITLE
Improving module name for receiving one type of event by different consumers.

### DIFF
--- a/mod-source-record-manager-server/src/main/java/org/folio/verticle/AbstractConsumersVerticle.java
+++ b/mod-source-record-manager-server/src/main/java/org/folio/verticle/AbstractConsumersVerticle.java
@@ -58,7 +58,8 @@ public abstract class AbstractConsumersVerticle extends AbstractVerticle {
     });
     List<Future<Void>> futures = new ArrayList<>();
     consumerWrappersList.forEach(consumerWrapper ->
-      futures.add(consumerWrapper.start(getHandler(), PubSubClientUtils.constructModuleName())));
+      futures.add(consumerWrapper.start(getHandler(),
+        PubSubClientUtils.constructModuleName() + "_" + getClass().getSimpleName())));
 
     GenericCompositeFuture.all(futures).onComplete(ar -> startPromise.complete());
   }


### PR DESCRIPTION
## Purpose
Different consumers from the same group can't get the same type of event from kafka.

## Approach
Improving module name for groupId.

## Learning
[MODSOURMAN-384](https://issues.folio.org/browse/MODSOURMAN-384)