### PR TITLE
MODDATAIMP-370

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -13,6 +13,8 @@
 * [MODDSOURMAN-395](https://issues.folio.org/browse/MODSOURMAN-395) Add personal data disclosure form.
 * [MODSOURMAN-384](https://issues.folio.org/browse/MODSOURMAN-384) Implement writing entities processing information to the log
 * [MODSOURCE-248](https://issues.folio.org/browse/MODSOURCE-248) Incoming MARC Bib with 003, but no 001 should not create an 035[BUGFIX]
+* [MODSOURMAN-414](https://issues.folio.org/browse/MODSOURMAN-414) Add record sequence number to the summary log screen for OCLC single record imports
+* [MODDATAIMP-370](https://issues.folio.org/browse/MODDATAIMP-370) OCLC single record import: Updates don't work, and the Create action uses the wrong job profile
 
 ## 2020-11-20 v2.4.3
 * [MODSOURCE-213](https://issues.folio.org/browse/MODSOURCE-213) MARC updates for selected fields is not working

--- a/README.md
+++ b/README.md
@@ -250,6 +250,7 @@ curl -w '\n' -X POST -D -   \
 
 ```
 {
+  "id": "22fafcc3-f582-493d-88b0-3c538480cd83" // for each chunk we need to have and unique uuid
   "recordsMetadata": {
     "last": false,
     "counter": 3,
@@ -274,6 +275,7 @@ curl -w '\n' -X POST -D -   \
 
 ```
 {
+ "id": "22fafcc3-f582-493d-88b0-3c538480cd83" // for each chunk we need to have and unique uuid
   "recordsMetadata": {
     "last": false,
     "counter": 1,
@@ -292,6 +294,7 @@ curl -w '\n' -X POST -D -   \
 
 ```
 {
+ "id": "22fafcc3-f582-493d-88b0-3c538480cd83" // for each chunk we need to have and unique uuid
   "recordsMetadata": {
     "last": false,
     "counter": 2,
@@ -360,6 +363,7 @@ curl -w '\n' -X POST -D -   \
 
 ```
 {
+ "id": "22fafcc3-f582-493d-88b0-3c538480cd83" // for each chunk we need to have and unique uuid
   "recordsMetadata": {
     "last": true,
     "counter": 3,

--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -82,7 +82,7 @@
   "provides": [
     {
       "id": "source-manager-job-executions",
-      "version": "1.0",
+      "version": "1.1",
       "handlers": [
         {
           "methods": [
@@ -179,7 +179,7 @@
     },
     {
       "id": "source-manager-records",
-      "version": "1.0",
+      "version": "1.1",
       "handlers": [
         {
           "methods": [

--- a/mod-source-record-manager-server/src/main/java/org/folio/services/AbstractChunkProcessingService.java
+++ b/mod-source-record-manager-server/src/main/java/org/folio/services/AbstractChunkProcessingService.java
@@ -51,7 +51,7 @@ public abstract class AbstractChunkProcessingService implements ChunkProcessingS
     if (rawRecordsDto.getInitialRecords() != null
       && rawRecordsDto.getInitialRecords().size() == 1
       && rawRecordsDto.getRecordsMetadata() != null
-      && rawRecordsDto.getRecordsMetadata().getTotal() == 1) {
+      && (rawRecordsDto.getRecordsMetadata().getTotal() == null || rawRecordsDto.getRecordsMetadata().getTotal() == 1)) {
       rawRecordsDto.getInitialRecords().get(0).setOrder(0);
     }
   }

--- a/mod-source-record-manager-server/src/main/java/org/folio/services/AbstractChunkProcessingService.java
+++ b/mod-source-record-manager-server/src/main/java/org/folio/services/AbstractChunkProcessingService.java
@@ -29,6 +29,7 @@ public abstract class AbstractChunkProcessingService implements ChunkProcessingS
 
   @Override
   public Future<Boolean> processChunk(RawRecordsDto incomingChunk, String jobExecutionId, OkapiConnectionParams params) {
+    prepareChunk(incomingChunk);
     return jobExecutionService.getJobExecutionById(jobExecutionId, params.getTenantId())
       .compose(optionalJobExecution -> optionalJobExecution
         .map(jobExecution -> {
@@ -44,6 +45,15 @@ public abstract class AbstractChunkProcessingService implements ChunkProcessingS
             .onSuccess(ar -> processRawRecordsChunk(incomingChunk, sourceChunk, jobExecution.getId(), params)).map(true)
             .onFailure(th -> Future.succeededFuture(false));
         }).orElse(Future.failedFuture(new NotFoundException(String.format("Couldn't find JobExecution with id %s", jobExecutionId)))));
+  }
+
+  private void prepareChunk(RawRecordsDto rawRecordsDto) {
+    if (rawRecordsDto.getInitialRecords() != null
+      && rawRecordsDto.getInitialRecords().size() == 1
+      && rawRecordsDto.getRecordsMetadata() != null
+      && rawRecordsDto.getRecordsMetadata().getTotal() == 1) {
+      rawRecordsDto.getInitialRecords().get(0).setOrder(0);
+    }
   }
 
   /**

--- a/mod-source-record-manager-server/src/main/java/org/folio/services/ChangeEngineServiceImpl.java
+++ b/mod-source-record-manager-server/src/main/java/org/folio/services/ChangeEngineServiceImpl.java
@@ -113,8 +113,13 @@ public class ChangeEngineServiceImpl implements ChangeEngineService {
 
     if (updateMarcActionExists) {
       LOGGER.info("Records have not been saved in record-storage, because jobProfileSnapshotWrapper contains action for Marc-Bibliographic update");
-      recordsPublishingService.sendEventsWithRecords(parsedRecords, jobExecution.getId(), params, DI_MARC_BIB_FOR_UPDATE_RECEIVED.value());
-      promise.complete(parsedRecords);
+      recordsPublishingService.sendEventsWithRecords(parsedRecords, jobExecution.getId(), params, DI_MARC_BIB_FOR_UPDATE_RECEIVED.value())
+        .compose(ar -> buildJournalRecordsForProcessedRecords(parsedRecords, parsedRecords, CREATE, params.getTenantId())
+          .compose(journalRecords -> {
+            journalService.saveBatch(new JsonArray(journalRecords), params.getTenantId());
+            promise.complete(parsedRecords);
+            return Future.succeededFuture();
+          }));
     } else {
       saveRecords(params, jobExecution, parsedRecords)
         .onComplete(postAr -> {

--- a/mod-source-record-manager-server/src/main/java/org/folio/verticle/DataImportJournalConsumersVerticle.java
+++ b/mod-source-record-manager-server/src/main/java/org/folio/verticle/DataImportJournalConsumersVerticle.java
@@ -18,6 +18,7 @@ import static org.folio.rest.jaxrs.model.DataImportEventTypes.DI_INVENTORY_ITEM_
 import static org.folio.rest.jaxrs.model.DataImportEventTypes.DI_INVENTORY_ITEM_NOT_MATCHED;
 import static org.folio.rest.jaxrs.model.DataImportEventTypes.DI_INVENTORY_ITEM_UPDATED;
 import static org.folio.rest.jaxrs.model.DataImportEventTypes.DI_SRS_MARC_BIB_RECORD_MODIFIED;
+import static org.folio.rest.jaxrs.model.DataImportEventTypes.DI_SRS_MARC_BIB_RECORD_MODIFIED_READY_FOR_POST_PROCESSING;
 import static org.folio.rest.jaxrs.model.DataImportEventTypes.DI_SRS_MARC_BIB_RECORD_NOT_MATCHED;
 import static org.folio.rest.jaxrs.model.DataImportEventTypes.DI_SRS_MARC_BIB_RECORD_UPDATED;
 
@@ -35,6 +36,7 @@ public class DataImportJournalConsumersVerticle extends AbstractConsumersVerticl
       DI_SRS_MARC_BIB_RECORD_NOT_MATCHED.value(),
       DI_INVENTORY_INSTANCE_CREATED.value(),
       DI_INVENTORY_INSTANCE_UPDATED.value(),
+      DI_SRS_MARC_BIB_RECORD_MODIFIED_READY_FOR_POST_PROCESSING.value(),
       DI_INVENTORY_INSTANCE_NOT_MATCHED.value(),
       DI_INVENTORY_HOLDING_CREATED.value(),
       DI_INVENTORY_HOLDING_UPDATED.value(),

--- a/mod-source-record-manager-server/src/main/java/org/folio/verticle/consumers/util/JournalParams.java
+++ b/mod-source-record-manager-server/src/main/java/org/folio/verticle/consumers/util/JournalParams.java
@@ -61,6 +61,14 @@ public class JournalParams {
           JournalRecord.ActionStatus.COMPLETED);
       }
     },
+    DI_SRS_MARC_BIB_RECORD_MODIFIED_READY_FOR_POST_PROCESSING {
+      @Override
+      public JournalParams getJournalParams(DataImportEventPayload eventPayload) {
+        return new JournalParams(JournalRecord.ActionType.UPDATE,
+          JournalRecord.EntityType.INSTANCE,
+          JournalRecord.ActionStatus.COMPLETED);
+      }
+    },
     DI_INVENTORY_INSTANCE_UPDATED {
       @Override
       public JournalParams getJournalParams(DataImportEventPayload eventPayload) {

--- a/mod-source-record-manager-server/src/test/java/org/folio/rest/impl/changeManager/ChangeManagerAPITest.java
+++ b/mod-source-record-manager-server/src/test/java/org/folio/rest/impl/changeManager/ChangeManagerAPITest.java
@@ -25,6 +25,7 @@ import org.folio.rest.jaxrs.model.InitJobExecutionsRqDto;
 import org.folio.rest.jaxrs.model.InitJobExecutionsRsDto;
 import org.folio.rest.jaxrs.model.InitialRecord;
 import org.folio.rest.jaxrs.model.JobExecution;
+import org.folio.rest.jaxrs.model.JobProfile;
 import org.folio.rest.jaxrs.model.JobProfileInfo;
 import org.folio.rest.jaxrs.model.ProfileSnapshotWrapper;
 import org.folio.rest.jaxrs.model.Progress;
@@ -97,6 +98,7 @@ public class ChangeManagerAPITest extends AbstractRestTest {
   private static final String RAW_RECORD_RESULTING_IN_PARSING_ERROR = "01247nam  2200313zu 450000100110000000300080001100500170001905\u001F222\u001E1 \u001FaAriáes, Philippe.\u001E10\u001FaWestern attitudes toward death\u001Fh[electronic resource] :\u001Fbfrom the Middle Ages to the present /\u001Fcby Philippe Ariáes ; translated by Patricia M. Ranum.\u001E  \u001FaJohn Hopkins Paperbacks ed.\u001E  \u001FaBaltimore :\u001FbJohns Hopkins University Press,\u001Fc1975.\u001E  \u001Fa1 online resource.\u001E1 \u001FaThe Johns Hopkins symposia in comparative history ;\u001Fv4th\u001E  \u001FaDescription based on online resource; title from digital title page (viewed on Mar. 7, 2013).\u001E 0\u001FaDeath.\u001E2 \u001FaEbrary.\u001E 0\u001FaJohns Hopkins symposia in comparative history ;\u001Fv4th.\u001E40\u001FzConnect to e-book on Ebrary\u001Fuhttp://gateway.library.qut.edu.au/login?url=http://site.ebrary.com/lib/qut/docDetail.action?docID=10635130\u001E  \u001Fa.o1346565x\u001E  \u001Fa130307\u001Fb2095\u001Fe2095\u001Ff243966\u001Fg1\u001E  \u001FbOM\u001Fcnlnet\u001E\u001D\n";
   private static final String RAW_RECORD_WITH_999_ff_s_SUBFIELD = "00948nam a2200241 a 4500001000800000003000400008005001700012008004100029035002100070035002000091040002300111041001300134100002300147245007900170260005800249300002400307440007100331650003600402650005500438650006900493655006500562999007900627\u001E1007048\u001EICU\u001E19950912000000.0\u001E891218s1983    wyu      d    00010 eng d\u001E  \u001Fa(ICU)BID12424550\u001E  \u001Fa(OCoLC)16105467\u001E  \u001FaPAU\u001FcPAU\u001Fdm/c\u001FdICU\u001E0 \u001Faeng\u001Faarp\u001E1 \u001FaSalzmann, Zdeněk\u001E10\u001FaDictionary of contemporary Arapaho usage /\u001Fccompiled by Zdeněk Salzmann.\u001E0 \u001FaWind River, Wyoming :\u001FbWind River Reservation,\u001Fc1983.\u001E  \u001Fav, 231 p. ;\u001Fc28 cm.\u001E 0\u001FaArapaho language and culture instructional materials series\u001Fvno. 4\u001E 0\u001FaArapaho language\u001FxDictionaries.\u001E 0\u001FaIndians of North America\u001FxLanguages\u001FxDictionaries.\u001E 7\u001FaArapaho language.\u001F2fast\u001F0http://id.worldcat.org/fast/fst00812722\u001E 7\u001FaDictionaries.\u001F2fast\u001F0http://id.worldcat.org/fast/fst01423826\u001Eff\u001Fie27a5374-0857-462e-ac84-fb4795229c7a\u001Fse27a5374-0857-462e-ac84-fb4795229c7a\u001E\u001D";
   private static final String DEFAULT_JOB_PROFILE_ID = "22fafcc3-f582-493d-88b0-3c538480cd83";
+  private static final String JOB_PROFILE_ID = UUID.randomUUID().toString();
 
   private Set<JobExecution.SubordinationType> parentTypes = EnumSet.of(
     JobExecution.SubordinationType.PARENT_SINGLE,
@@ -111,10 +113,11 @@ public class ChangeManagerAPITest extends AbstractRestTest {
     .withStatus(JobExecution.Status.NEW)
     .withUiStatus(JobExecution.UiStatus.INITIALIZATION)
     .withSourcePath("importMarc.mrc")
-    .withJobProfileInfo(new JobProfileInfo().withId(UUID.randomUUID().toString()).withName("Marc jobs profile"))
+    .withJobProfileInfo(new JobProfileInfo().withId(DEFAULT_JOB_PROFILE_ID).withName("Marc jobs profile"))
     .withUserId(UUID.randomUUID().toString());
 
   private RawRecordsDto rawRecordsDto = new RawRecordsDto()
+    .withId(UUID.randomUUID().toString())
     .withRecordsMetadata(new RecordsMetadata()
       .withLast(false)
       .withCounter(15)
@@ -148,6 +151,10 @@ public class ChangeManagerAPITest extends AbstractRestTest {
   @Before
   public void setUp() {
     MockitoAnnotations.initMocks(this);
+    WireMock.stubFor(WireMock.get("/data-import-profiles/jobProfiles/"+DEFAULT_JOB_PROFILE_ID+"?withRelations=false&")
+      .willReturn(WireMock.ok().withBody(Json.encode(new JobProfile().withId(DEFAULT_JOB_PROFILE_ID).withName("Default job profile")))));
+    WireMock.stubFor(WireMock.get("/data-import-profiles/jobProfiles/"+JOB_PROFILE_ID+"?withRelations=false&")
+      .willReturn(WireMock.ok().withBody(Json.encode(new JobProfile().withId(JOB_PROFILE_ID).withName("not default job profile")))));
   }
 
   @Test
@@ -181,7 +188,7 @@ public class ChangeManagerAPITest extends AbstractRestTest {
     requestDto.setUserId(okapiUserIdHeader);
     requestDto.setSourceType(InitJobExecutionsRqDto.SourceType.ONLINE);
     requestDto.setJobProfileInfo(new JobProfileInfo()
-      .withId(UUID.randomUUID().toString())
+      .withId(DEFAULT_JOB_PROFILE_ID)
       .withDataType(JobProfileInfo.DataType.MARC)
       .withName("Test Profile"));
 
@@ -307,7 +314,7 @@ public class ChangeManagerAPITest extends AbstractRestTest {
     JobExecution singleParent = createdJobExecutions.get(0);
     assertThat(singleParent.getSubordinationType(), is(JobExecution.SubordinationType.PARENT_SINGLE));
 
-    singleParent.setJobProfileInfo(new JobProfileInfo().withId(UUID.randomUUID().toString()).withName("Marc jobs profile"));
+    singleParent.setJobProfileInfo(new JobProfileInfo().withId(DEFAULT_JOB_PROFILE_ID).withName("Marc jobs profile"));
     RestAssured.given()
       .spec(spec)
       .body(JsonObject.mapFrom(singleParent).toString())
@@ -700,7 +707,7 @@ public class ChangeManagerAPITest extends AbstractRestTest {
     JobExecution multipleParent = createdJobExecutions.stream()
       .filter(jobExec -> jobExec.getSubordinationType().equals(JobExecution.SubordinationType.PARENT_MULTIPLE)).findFirst().get();
 
-    multipleParent.setJobProfileInfo(new JobProfileInfo().withId(UUID.randomUUID().toString()).withName("Marc jobs profile"));
+    multipleParent.setJobProfileInfo(new JobProfileInfo().withId(DEFAULT_JOB_PROFILE_ID).withName("Marc jobs profile"));
     RestAssured.given()
       .spec(spec)
       .body(JsonObject.mapFrom(multipleParent).toString())
@@ -777,7 +784,7 @@ public class ChangeManagerAPITest extends AbstractRestTest {
 
   @Test
   public void shouldReturnNotFoundOnSetJobProfileInfo() {
-    JobProfileInfo jobProfile = new JobProfileInfo().withId(UUID.randomUUID().toString()).withName("marc");
+    JobProfileInfo jobProfile = new JobProfileInfo().withId(DEFAULT_JOB_PROFILE_ID).withName("marc");
     RestAssured.given()
       .spec(spec)
       .body(JsonObject.mapFrom(jobProfile).toString())
@@ -807,7 +814,7 @@ public class ChangeManagerAPITest extends AbstractRestTest {
     assertThat(createdJobExecutions.size(), is(1));
     JobExecution jobExec = createdJobExecutions.get(0);
 
-    JobProfileInfo jobProfile = new JobProfileInfo().withId(UUID.randomUUID().toString()).withName("marc");
+    JobProfileInfo jobProfile = new JobProfileInfo().withId(DEFAULT_JOB_PROFILE_ID).withName("marc");
     RestAssured.given()
       .spec(spec)
       .body(JsonObject.mapFrom(jobProfile).toString())
@@ -836,7 +843,7 @@ public class ChangeManagerAPITest extends AbstractRestTest {
     WireMock.stubFor(post(new UrlPathPattern(new RegexPattern(PROFILE_SNAPSHOT_URL + "/.*"), true))
       .willReturn(serverError()));
 
-    JobProfileInfo jobProfile = new JobProfileInfo().withId(UUID.randomUUID().toString()).withName("marc");
+    JobProfileInfo jobProfile = new JobProfileInfo().withId(DEFAULT_JOB_PROFILE_ID).withName("marc");
     RestAssured.given()
       .spec(spec)
       .body(JsonObject.mapFrom(jobProfile).toString())
@@ -863,7 +870,7 @@ public class ChangeManagerAPITest extends AbstractRestTest {
     assertThat(createdJobExecutions.size(), is(1));
     JobExecution jobExec = createdJobExecutions.get(0);
 
-    JobProfileInfo jobProfile = new JobProfileInfo().withId(UUID.randomUUID().toString()).withName("marc");
+    JobProfileInfo jobProfile = new JobProfileInfo().withId(DEFAULT_JOB_PROFILE_ID).withName("Default job profile");
     RestAssured.given()
       .spec(spec)
       .body(JsonObject.mapFrom(jobProfile).toString())
@@ -925,7 +932,7 @@ public class ChangeManagerAPITest extends AbstractRestTest {
       .spec(spec)
       .body(new JobProfileInfo()
         .withName("MARC records")
-        .withId(UUID.randomUUID().toString())
+        .withId(DEFAULT_JOB_PROFILE_ID)
         .withDataType(JobProfileInfo.DataType.MARC))
       .when()
       .put(JOB_EXECUTION_PATH + jobExec.getId() + JOB_PROFILE_PATH)
@@ -984,7 +991,7 @@ public class ChangeManagerAPITest extends AbstractRestTest {
       .spec(spec)
       .body(new JobProfileInfo()
         .withName("MARC records")
-        .withId(UUID.randomUUID().toString())
+        .withId(DEFAULT_JOB_PROFILE_ID)
         .withDataType(JobProfileInfo.DataType.MARC))
       .when()
       .put(JOB_EXECUTION_PATH + jobExec.getId() + JOB_PROFILE_PATH)
@@ -1043,7 +1050,7 @@ public class ChangeManagerAPITest extends AbstractRestTest {
       .spec(spec)
       .body(new JobProfileInfo()
         .withName("MARC records")
-        .withId(UUID.randomUUID().toString())
+        .withId(DEFAULT_JOB_PROFILE_ID)
         .withDataType(JobProfileInfo.DataType.MARC))
       .when()
       .put(JOB_EXECUTION_PATH + jobExec.getId() + JOB_PROFILE_PATH)
@@ -1147,7 +1154,7 @@ public class ChangeManagerAPITest extends AbstractRestTest {
       .spec(spec)
       .body(new JobProfileInfo()
         .withName("MARC records")
-        .withId(UUID.randomUUID().toString())
+        .withId(DEFAULT_JOB_PROFILE_ID)
         .withDataType(JobProfileInfo.DataType.MARC))
       .when()
       .put(JOB_EXECUTION_PATH + jobExec.getId() + JOB_PROFILE_PATH)
@@ -1202,7 +1209,7 @@ public class ChangeManagerAPITest extends AbstractRestTest {
       .spec(spec)
       .body(new JobProfileInfo()
         .withName("MARC records")
-        .withId(UUID.randomUUID().toString())
+        .withId(DEFAULT_JOB_PROFILE_ID)
         .withDataType(JobProfileInfo.DataType.MARC))
       .when()
       .put(JOB_EXECUTION_PATH + jobExec.getId() + JOB_PROFILE_PATH)
@@ -1250,7 +1257,7 @@ public class ChangeManagerAPITest extends AbstractRestTest {
       .spec(spec)
       .body(new JobProfileInfo()
         .withName("MARC records")
-        .withId(UUID.randomUUID().toString())
+        .withId(DEFAULT_JOB_PROFILE_ID)
         .withDataType(JobProfileInfo.DataType.MARC))
       .when()
       .put(JOB_EXECUTION_PATH + jobExec.getId() + JOB_PROFILE_PATH)
@@ -1300,7 +1307,7 @@ public class ChangeManagerAPITest extends AbstractRestTest {
       .spec(spec)
       .body(new JobProfileInfo()
         .withName("MARC records")
-        .withId(UUID.randomUUID().toString())
+        .withId(DEFAULT_JOB_PROFILE_ID)
         .withDataType(JobProfileInfo.DataType.MARC))
       .when()
       .put(JOB_EXECUTION_PATH + jobExec.getId() + JOB_PROFILE_PATH)
@@ -1373,7 +1380,7 @@ public class ChangeManagerAPITest extends AbstractRestTest {
     JobExecution singleParent = createdJobExecutions.get(0);
     assertThat(singleParent.getSubordinationType(), is(JobExecution.SubordinationType.PARENT_SINGLE));
 
-    singleParent.setJobProfileInfo(new JobProfileInfo().withId(UUID.randomUUID().toString()).withName("Marc jobs profile"));
+    singleParent.setJobProfileInfo(new JobProfileInfo().withId(DEFAULT_JOB_PROFILE_ID).withName("Marc jobs profile"));
     RestAssured.given()
       .spec(spec)
       .body(JsonObject.mapFrom(singleParent).toString())
@@ -1444,7 +1451,7 @@ public class ChangeManagerAPITest extends AbstractRestTest {
       .spec(spec)
       .body(new JobProfileInfo()
         .withName("MARC records")
-        .withId(UUID.randomUUID().toString())
+        .withId(DEFAULT_JOB_PROFILE_ID)
         .withDataType(JobProfileInfo.DataType.MARC))
       .when()
       .put(JOB_EXECUTION_PATH + jobExec.getId() + JOB_PROFILE_PATH)
@@ -1516,7 +1523,7 @@ public class ChangeManagerAPITest extends AbstractRestTest {
       .spec(spec)
       .body(new JobProfileInfo()
         .withName("MARC records")
-        .withId(UUID.randomUUID().toString())
+        .withId(DEFAULT_JOB_PROFILE_ID)
         .withDataType(JobProfileInfo.DataType.MARC))
       .when()
       .put(JOB_EXECUTION_PATH + jobExec.getId() + JOB_PROFILE_PATH)
@@ -1736,7 +1743,7 @@ public class ChangeManagerAPITest extends AbstractRestTest {
       .spec(spec)
       .body(new JobProfileInfo()
         .withName("MARC records")
-        .withId(UUID.randomUUID().toString())
+        .withId(JOB_PROFILE_ID)
         .withDataType(JobProfileInfo.DataType.MARC))
       .when()
       .put(JOB_EXECUTION_PATH + jobExec.getId() + JOB_PROFILE_PATH)
@@ -1783,7 +1790,7 @@ public class ChangeManagerAPITest extends AbstractRestTest {
       .spec(spec)
       .body(new JobProfileInfo()
         .withName("MARC records")
-        .withId(UUID.randomUUID().toString())
+        .withId(DEFAULT_JOB_PROFILE_ID)
         .withDataType(JobProfileInfo.DataType.MARC))
       .when()
       .put(JOB_EXECUTION_PATH + jobExec.getId() + JOB_PROFILE_PATH)
@@ -1833,7 +1840,7 @@ public class ChangeManagerAPITest extends AbstractRestTest {
       .spec(spec)
       .body(new JobProfileInfo()
         .withName("MARC records")
-        .withId(UUID.randomUUID().toString())
+        .withId(DEFAULT_JOB_PROFILE_ID)
         .withDataType(JobProfileInfo.DataType.MARC))
       .when()
       .put(JOB_EXECUTION_PATH + jobExec.getId() + JOB_PROFILE_PATH)


### PR DESCRIPTION
*Overview:* 2 bugs: 1) Regardless of whether a new instance is being created or an existing instance is being updated, the data import profile used by Inventory Single Record Import is the "update" profile. 2) The update job gets stuck in Running and never finishes

Expected Results: 

First import: should create a new instance and new SRS MARC, using the Default create instance job profile
Second import: should update the existing instance and create a new SRS MARC, using the Default update instance job profile