### PR TITLE
MODSOURMAN-411 Dynamicaly define the payload of Data Import events depending on MARC Record type (Bib, Authority, Holding)

### DIFF
--- a/mod-source-record-manager-server/src/main/java/org/folio/config/ApplicationConfig.java
+++ b/mod-source-record-manager-server/src/main/java/org/folio/config/ApplicationConfig.java
@@ -3,6 +3,7 @@ package org.folio.config;
 import io.vertx.core.Vertx;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import org.folio.dataimport.util.marc.MarcRecordAnalyzer;
 import org.folio.kafka.KafkaConfig;
 import org.folio.services.journal.JournalService;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -52,5 +53,10 @@ public class ApplicationConfig {
   @Bean(value = "journalServiceProxy")
   public JournalService journalServiceProxy() {
     return JournalService.createProxy(vertx);
+  }
+
+  @Bean
+  public MarcRecordAnalyzer marcRecordAnalyzer() {
+    return new MarcRecordAnalyzer();
   }
 }

--- a/mod-source-record-manager-server/src/main/java/org/folio/services/DataImportPayloadContextBuilder.java
+++ b/mod-source-record-manager-server/src/main/java/org/folio/services/DataImportPayloadContextBuilder.java
@@ -1,0 +1,13 @@
+package org.folio.services;
+
+import io.vertx.core.json.JsonObject;
+import org.folio.processing.mapping.defaultmapper.processor.parameters.MappingParameters;
+import org.folio.rest.jaxrs.model.Record;
+
+import java.util.HashMap;
+
+interface DataImportPayloadContextBuilder {
+
+  HashMap<String, String> buildFrom(Record record, JsonObject mappingRules, MappingParameters mappingParameters);
+
+}

--- a/mod-source-record-manager-server/src/main/java/org/folio/services/DataImportPayloadContextBuilderImpl.java
+++ b/mod-source-record-manager-server/src/main/java/org/folio/services/DataImportPayloadContextBuilderImpl.java
@@ -1,0 +1,78 @@
+package org.folio.services;
+
+import io.vertx.core.json.Json;
+import io.vertx.core.json.JsonObject;
+import org.folio.dataimport.util.marc.MarcRecordAnalyzer;
+import org.folio.dataimport.util.marc.MarcRecordType;
+import org.folio.processing.mapping.defaultmapper.processor.parameters.MappingParameters;
+import org.folio.rest.jaxrs.model.EntityType;
+import org.folio.rest.jaxrs.model.Record;
+import org.springframework.stereotype.Component;
+
+import java.util.EnumMap;
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.folio.dataimport.util.marc.MarcRecordType.AUTHORITY;
+import static org.folio.dataimport.util.marc.MarcRecordType.BIB;
+import static org.folio.dataimport.util.marc.MarcRecordType.HOLDING;
+import static org.folio.rest.jaxrs.model.EntityType.EDIFACT_INVOICE;
+import static org.folio.rest.jaxrs.model.EntityType.MARC_AUTHORITY;
+import static org.folio.rest.jaxrs.model.EntityType.MARC_BIBLIOGRAPHIC;
+import static org.folio.rest.jaxrs.model.EntityType.MARC_HOLDINGS;
+
+@Component
+class DataImportPayloadContextBuilderImpl implements DataImportPayloadContextBuilder {
+
+  private static final Map<MarcRecordType, EntityType> MARC_TO_ENTITY_TYPE;
+
+  private final MarcRecordAnalyzer analyzer;
+
+  static {
+    MARC_TO_ENTITY_TYPE = new EnumMap<>(MarcRecordType.class);
+
+    MARC_TO_ENTITY_TYPE.put(BIB, MARC_BIBLIOGRAPHIC);
+    MARC_TO_ENTITY_TYPE.put(HOLDING, MARC_HOLDINGS);
+    MARC_TO_ENTITY_TYPE.put(AUTHORITY, MARC_AUTHORITY);
+  }
+
+  public DataImportPayloadContextBuilderImpl(MarcRecordAnalyzer analyzer) {
+    this.analyzer = analyzer;
+  }
+
+  @Override
+  public HashMap<String, String> buildFrom(Record record, JsonObject mappingRules,
+      MappingParameters mappingParameters) {
+    EntityType entityType = detectEntityType(record);
+
+    return createAndPopulateContext(entityType, record, mappingRules, mappingParameters);
+  }
+
+  private HashMap<String, String> createAndPopulateContext(EntityType entityType, Record record,
+      JsonObject mappingRules, MappingParameters mappingParameters) {
+    HashMap<String, String> context = new HashMap<>();
+
+    if (entityType == MARC_AUTHORITY) {
+      context.put(entityType.value(), Json.encode(record));
+    } else {
+      context.put(entityType.value(), Json.encode(record));
+      context.put("MAPPING_RULES", mappingRules.encode());
+      context.put("MAPPING_PARAMS", Json.encode(mappingParameters));
+    }
+
+    return context;
+  }
+
+  private EntityType detectEntityType(Record record) {
+    switch (record.getRecordType()) {
+      case EDIFACT:
+        return EDIFACT_INVOICE;
+      case MARC:
+        MarcRecordType type = analyzer.process(new JsonObject(record.getParsedRecord().getContent().toString()));
+
+        return MARC_TO_ENTITY_TYPE.getOrDefault(type, MARC_BIBLIOGRAPHIC);
+      default:
+        throw new IllegalStateException("Unexpected record type: " + record.getRecordType());
+    }
+  }
+}

--- a/mod-source-record-manager-server/src/test/java/org/folio/services/DataImportPayloadContextBuilderImplTest.java
+++ b/mod-source-record-manager-server/src/test/java/org/folio/services/DataImportPayloadContextBuilderImplTest.java
@@ -1,0 +1,145 @@
+package org.folio.services;
+
+import io.vertx.core.json.Json;
+import io.vertx.core.json.JsonObject;
+import org.folio.dataimport.util.marc.MarcRecordAnalyzer;
+import org.folio.dataimport.util.marc.MarcRecordType;
+import org.folio.processing.mapping.defaultmapper.processor.parameters.MappingParameters;
+import org.folio.rest.jaxrs.model.ParsedRecord;
+import org.folio.rest.jaxrs.model.Record;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.folio.rest.jaxrs.model.EntityType.EDIFACT_INVOICE;
+import static org.folio.rest.jaxrs.model.EntityType.MARC_AUTHORITY;
+import static org.folio.rest.jaxrs.model.EntityType.MARC_BIBLIOGRAPHIC;
+import static org.folio.rest.jaxrs.model.EntityType.MARC_HOLDINGS;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThrows;
+import static org.mockito.Mockito.when;
+
+@RunWith(MockitoJUnitRunner.class)
+public class DataImportPayloadContextBuilderImplTest {
+
+  @Mock
+  private MarcRecordAnalyzer marcRecordAnalyzer;
+  @InjectMocks
+  private DataImportPayloadContextBuilderImpl builder;
+
+  private Record record;
+  private JsonObject rules;
+  private MappingParameters params;
+
+
+  @Before
+  public void setUp() throws Exception {
+    record = new Record();
+    rules = new JsonObject();
+    params = new MappingParameters();
+  }
+
+  @Test
+  public void shouldBuildContextForMarcAuthorityRecord() {
+    ParsedRecord parsedRecord = parsedRecord("{\"leader\":\"authority\"}");
+    record.setRecordType(Record.RecordType.MARC);
+    record.setParsedRecord(parsedRecord);
+
+    when(marcRecordAnalyzer.process(toJson(parsedRecord))).thenReturn(MarcRecordType.AUTHORITY);
+
+    HashMap<String, String> context = builder.buildFrom(record, rules, params);
+
+    assertEquals(Map.of(MARC_AUTHORITY.value(), Json.encode(record)), context);
+  }
+
+  @Test
+  public void shouldBuildContextForMarcBibRecord() {
+    ParsedRecord parsedRecord = parsedRecord("{\"leader\":\"bibliographic\"}");
+    record.setRecordType(Record.RecordType.MARC);
+    record.setParsedRecord(parsedRecord);
+
+    when(marcRecordAnalyzer.process(toJson(parsedRecord))).thenReturn(MarcRecordType.BIB);
+
+    HashMap<String, String> context = builder.buildFrom(record, rules, params);
+
+    assertEquals(Map.of(
+        MARC_BIBLIOGRAPHIC.value(), Json.encode(record),
+        "MAPPING_RULES", rules.encode(),
+        "MAPPING_PARAMS", Json.encode(params)),
+        context);
+  }
+
+  @Test
+  public void shouldBuildContextForMarcHoldingRecord() {
+    ParsedRecord parsedRecord = parsedRecord("{\"leader\":\"holding\"}");
+    record.setRecordType(Record.RecordType.MARC);
+    record.setParsedRecord(parsedRecord);
+
+    when(marcRecordAnalyzer.process(toJson(parsedRecord))).thenReturn(MarcRecordType.HOLDING);
+
+    HashMap<String, String> context = builder.buildFrom(record, rules, params);
+
+    assertEquals(Map.of(
+        MARC_HOLDINGS.value(), Json.encode(record),
+        "MAPPING_RULES", rules.encode(),
+        "MAPPING_PARAMS", Json.encode(params)),
+        context);
+  }
+
+  @Test
+  public void shouldBuildContextForEdifactInvoice() {
+    record.setRecordType(Record.RecordType.EDIFACT);
+
+    HashMap<String, String> context = builder.buildFrom(record, rules, params);
+
+    assertEquals(Map.of(
+        EDIFACT_INVOICE.value(), Json.encode(record),
+        "MAPPING_RULES", rules.encode(),
+        "MAPPING_PARAMS", Json.encode(params)),
+        context);
+  }
+
+  @Test
+  public void shouldThrowNPEIfParsedRecordIsNullAndRecordIsMarc() {
+    record.setRecordType(Record.RecordType.MARC);
+
+    assertThrows("Parsed record is null", NullPointerException.class,
+        () -> builder.buildFrom(record, rules, params));
+  }
+
+  @Test
+  public void shouldThrowNPEIfParsedRecordContentIsNullAndRecordIsMarc() {
+    record.setRecordType(Record.RecordType.MARC);
+    record.setParsedRecord(new ParsedRecord());
+
+    assertThrows("Parsed record content is null", NullPointerException.class,
+        () -> builder.buildFrom(record, rules, params));
+  }
+
+  @Test
+  public void shouldThrowExceptionIfMarcTypeUnsupported() {
+    ParsedRecord parsedRecord = parsedRecord("{\"leader\":\"NA\"}");
+    record.setRecordType(Record.RecordType.MARC);
+    record.setParsedRecord(parsedRecord);
+
+    when(marcRecordAnalyzer.process(toJson(parsedRecord))).thenReturn(MarcRecordType.NA);
+
+    assertThrows("Unsupported Marc record type", IllegalStateException.class,
+        () -> builder.buildFrom(record, rules, params));
+  }
+
+  private static ParsedRecord parsedRecord(String content) {
+    return new ParsedRecord().withContent(content);
+  }
+  
+  private static JsonObject toJson(ParsedRecord parsedRecord) {
+    return new JsonObject(parsedRecord.getContent().toString());
+  }
+
+}


### PR DESCRIPTION
## Purpose
To support importing Marc Authority records, change the way how Data Import event payload is populated. Create a payload context depending on the type of Marc record. For Authority records the payload has to contain only the record mapped to "MARC_AUTHORITY" key. See [MODSOURMAN-411](https://issues.folio.org/browse/MODSOURMAN-411)

## Approach
* introduce `DataImportPayloadContextBuilder `interface to encapsulate the logic of populating data import context.
* implement context population inside `DataImportPayloadContextBuilderImpl`. For authority records add the record into the context; for other type of records, including EDIFACT invoice and Marc Bib, add the record, mapping rules, mapping parameters, as it was before the change
* inside `DataImportPayloadContextBuilderImpl` use `MarcRecordAnalyzer` to detect the type of Marc from

#### TODOS and Open Questions
- [ ] Strangely Sonar shows 0 coverage although the new class is covered by test
