### PR TITLE
MODSOURMAN-420 - Expand endpoint for retrieving recordProcessingLogDto to support Invoice JSON screen

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,7 +1,10 @@
-## 2021-03-18 v3.0.1-SNAPSHOT
+## 2021-03-18 v3.0.2-SNAPSHOT
+* [MODSOURMAN-420](https://issues.folio.org/browse/MODSOURMAN-420) Expand endpoint for retrieving recordProcessingLogDto to provide data for Invoice JSON screen
+
+## 2021-03-28 v3.0.1
 * [MODSOURMAN-421](https://issues.folio.org/browse/MODSOURMAN-421) Syntax problem for 561 field in default mapping rules
 * [MODSOURMAN-422](https://issues.folio.org/browse/MODSOURMAN-422) Add record sequence number for records posted direct via API if it is not set
-* [MODDATAIMP-388](https://issues.folio.org/browse/MODDATAIMP-388) Import job is not completed on file parsing error[BUGFIX]
+* [MODDATAIMP-388](https://issues.folio.org/browse/MODDATAIMP-388) Import job is not completed on file parsing error
 
 ## 2021-03-18 v3.0.0
 * [MODSOURMAN-338](https://issues.folio.org/browse/MODSOURMAN-338) Change chunk processing to use kafka

--- a/mod-source-record-manager-server/src/main/java/org/folio/dao/JournalRecordDaoImpl.java
+++ b/mod-source-record-manager-server/src/main/java/org/folio/dao/JournalRecordDaoImpl.java
@@ -34,7 +34,6 @@ import java.util.Date;
 import java.util.List;
 import java.util.Set;
 import java.util.UUID;
-import java.util.stream.Collectors;
 
 import static java.lang.String.format;
 import static org.apache.commons.lang3.StringUtils.EMPTY;
@@ -58,9 +57,11 @@ import static org.folio.dao.util.JournalRecordsColumns.INVOICE_ACTION_STATUS;
 import static org.folio.dao.util.JournalRecordsColumns.INVOICE_ENTITY_ERROR;
 import static org.folio.dao.util.JournalRecordsColumns.INVOICE_ENTITY_HRID;
 import static org.folio.dao.util.JournalRecordsColumns.INVOICE_ENTITY_ID;
+import static org.folio.dao.util.JournalRecordsColumns.INVOICE_LINE_ACTION_STATUS;
 import static org.folio.dao.util.JournalRecordsColumns.INVOICE_LINE_ENTITY_ERROR;
 import static org.folio.dao.util.JournalRecordsColumns.INVOICE_LINE_ENTITY_HRID;
 import static org.folio.dao.util.JournalRecordsColumns.INVOICE_LINE_ENTITY_ID;
+import static org.folio.dao.util.JournalRecordsColumns.INVOICE_LINE_JOURNAL_RECORD_ID;
 import static org.folio.dao.util.JournalRecordsColumns.ITEM_ACTION_STATUS;
 import static org.folio.dao.util.JournalRecordsColumns.ITEM_ENTITY_ERROR;
 import static org.folio.dao.util.JournalRecordsColumns.ITEM_ENTITY_HRID;
@@ -248,6 +249,8 @@ public class JournalRecordDaoImpl implements JournalRecordDao {
         .withItemActionStatus(mapNameToEntityActionStatus(row.getString(ITEM_ACTION_STATUS)))
         .withOrderActionStatus(mapNameToEntityActionStatus(row.getString(ORDER_ACTION_STATUS)))
         .withInvoiceActionStatus(mapNameToEntityActionStatus(row.getString(INVOICE_ACTION_STATUS)))
+        .withInvoiceLineJournalRecordId(row.getValue(INVOICE_LINE_JOURNAL_RECORD_ID) != null
+          ? row.getValue(INVOICE_LINE_JOURNAL_RECORD_ID).toString() : null)
         .withError(row.getString(ERROR));
 
       jobLogEntryDtoCollection
@@ -295,14 +298,14 @@ public class JournalRecordDaoImpl implements JournalRecordDao {
 
   private RelatedInvoiceLineInfo constructInvoiceLineInfo(Row row) {
     return new RelatedInvoiceLineInfo()
+      .withActionStatus(mapNameToEntityActionStatus(row.getString(INVOICE_LINE_ACTION_STATUS)))
       .withId(row.getValue(INVOICE_LINE_ENTITY_ID) != null ? row.getValue(INVOICE_LINE_ENTITY_ID).toString() : null)
-//      .withHrid(row.getString(INVOICE_LINE_ENTITY_HRID))
       .withFullInvoiceLineNumber(row.getString(INVOICE_LINE_ENTITY_HRID))
       .withError(row.getString(INVOICE_LINE_ENTITY_ERROR));
   }
 
   private List<String> constructListFromColumn(Row row, String columnName) {
-    return row.getValue(columnName) == null ? Collections.emptyList() : Arrays.stream(row.getArrayOfStrings(columnName)).collect(Collectors.toList());
+    return row.getValue(columnName) == null ? Collections.emptyList() : Arrays.asList(row.getArrayOfStrings(columnName));
   }
 
   private org.folio.rest.jaxrs.model.ActionStatus mapNameToEntityActionStatus(String name) {

--- a/mod-source-record-manager-server/src/main/java/org/folio/dao/util/JournalRecordsColumns.java
+++ b/mod-source-record-manager-server/src/main/java/org/folio/dao/util/JournalRecordsColumns.java
@@ -25,6 +25,7 @@ public final class JournalRecordsColumns {
   public static final String ORDER_ACTION_STATUS = "order_action_status";
   public static final String INVOICE_ACTION_STATUS = "invoice_action_status";
   public static final String INVOICE_LINE_ACTION_STATUS = "invoice_line_action_status";
+  public static final String INVOICE_LINE_JOURNAL_RECORD_ID = "invoice_line_journal_record_id";
   public static final String TOTAL_COUNT = "total_count";
 
   public static final String SOURCE_ENTITY_ERROR = "source_entity_error";
@@ -46,7 +47,6 @@ public final class JournalRecordsColumns {
   public static final String INVOICE_LINE_ENTITY_ID = "invoice_line_entity_id";
   public static final String INVOICE_LINE_ENTITY_HRID = "invoice_line_entity_hrid";
   public static final String INVOICE_LINE_ENTITY_ERROR = "invoice_line_entity_error";
-
 
   private JournalRecordsColumns() {
   }

--- a/mod-source-record-manager-server/src/main/java/org/folio/dao/util/JournalRecordsColumns.java
+++ b/mod-source-record-manager-server/src/main/java/org/folio/dao/util/JournalRecordsColumns.java
@@ -24,6 +24,7 @@ public final class JournalRecordsColumns {
   public static final String ITEM_ACTION_STATUS = "item_action_status";
   public static final String ORDER_ACTION_STATUS = "order_action_status";
   public static final String INVOICE_ACTION_STATUS = "invoice_action_status";
+  public static final String INVOICE_LINE_ACTION_STATUS = "invoice_line_action_status";
   public static final String TOTAL_COUNT = "total_count";
 
   public static final String SOURCE_ENTITY_ERROR = "source_entity_error";
@@ -42,8 +43,9 @@ public final class JournalRecordsColumns {
   public static final String INVOICE_ENTITY_ID = "invoice_entity_id";
   public static final String INVOICE_ENTITY_HRID = "invoice_entity_hrid";
   public static final String INVOICE_ENTITY_ERROR = "invoice_entity_error";
-  public static final String INVOICE_LINES_ENTITY_ID = "invoice_lines_entity_id";
-  public static final String INVOICE_LINES_ENTITY_ERROR = "invoice_lines_entity_error";
+  public static final String INVOICE_LINE_ENTITY_ID = "invoice_line_entity_id";
+  public static final String INVOICE_LINE_ENTITY_HRID = "invoice_line_entity_hrid";
+  public static final String INVOICE_LINE_ENTITY_ERROR = "invoice_line_entity_error";
 
 
   private JournalRecordsColumns() {

--- a/mod-source-record-manager-server/src/main/java/org/folio/dao/util/JournalRecordsColumns.java
+++ b/mod-source-record-manager-server/src/main/java/org/folio/dao/util/JournalRecordsColumns.java
@@ -42,6 +42,8 @@ public final class JournalRecordsColumns {
   public static final String INVOICE_ENTITY_ID = "invoice_entity_id";
   public static final String INVOICE_ENTITY_HRID = "invoice_entity_hrid";
   public static final String INVOICE_ENTITY_ERROR = "invoice_entity_error";
+  public static final String INVOICE_LINES_ENTITY_ID = "invoice_lines_entity_id";
+  public static final String INVOICE_LINES_ENTITY_ERROR = "invoice_lines_entity_error";
 
 
   private JournalRecordsColumns() {

--- a/mod-source-record-manager-server/src/main/resources/templates/db_scripts/create_get_job_log_entries_function.sql
+++ b/mod-source-record-manager-server/src/main/resources/templates/db_scripts/create_get_job_log_entries_function.sql
@@ -20,7 +20,7 @@ $$ LANGUAGE plpgsql;
 
 -- Script to create function to get data import job log entries (jobLogEntry).
 CREATE OR REPLACE FUNCTION get_job_log_entries(jobExecutionId uuid, sortingField text, sortingDir text, limitVal bigint, offsetVal bigint)
-    RETURNS TABLE(job_execution_id uuid, source_id uuid, source_record_order text, title text, source_record_action_status text, instance_action_status text, holdings_action_status text, item_action_status text, order_action_status text, invoice_action_status text, error text, total_count bigint)
+    RETURNS TABLE(job_execution_id uuid, source_id uuid, source_record_order text, title text, source_record_action_status text, instance_action_status text, holdings_action_status text, item_action_status text, order_action_status text, invoice_action_status text, error text, total_count bigint, invoice_line_journal_record_id uuid)
 AS $$
 BEGIN
     RETURN QUERY EXECUTE format('
@@ -35,7 +35,8 @@ SELECT records_actions.job_execution_id, records_actions.source_id, (records_act
        get_entity_status(holdings_actions, holdings_errors_number) AS holdings_action_status,
        get_entity_status(item_actions, item_errors_number) AS item_action_status,
        get_entity_status(order_actions, order_errors_number) AS order_action_status,
-       null AS invoice_action_status, rec_errors.error, records_actions.total_count
+       null AS invoice_action_status, rec_errors.error, records_actions.total_count,
+       null AS invoiceLineJournalRecordId
 FROM (
          SELECT journal_records.source_id, journal_records.source_record_order, journal_records.job_execution_id,
                 array_agg(action_type ORDER BY action_date ASC) FILTER (WHERE entity_type = ''MARC_BIBLIOGRAPHIC'') AS marc_actions,
@@ -75,18 +76,19 @@ SELECT records_actions.job_execution_id, records_actions.source_id, entity_hrid 
        null AS item_action_status,
        null AS order_action_status,
        get_entity_status(invoice_actions, invoice_errors_number) AS invoice_action_status,
-       error, records_actions.total_count
+       error, records_actions.total_count, invoiceLineJournalRecordId
 FROM (
          SELECT journal_records.source_id, entity_hrid, journal_records.job_execution_id, title, error,
                 array[]::varchar[] AS marc_actions,
                 cast(0 as integer) AS marc_errors_number,
                 array_agg(action_type) FILTER (WHERE entity_type = ''INVOICE'') AS invoice_actions,
                 count(journal_records.source_id) FILTER (WHERE entity_type = ''INVOICE'' AND journal_records.error != '''') AS invoice_errors_number,
-                count(journal_records.source_id) OVER () AS total_count
+                count(journal_records.source_id) OVER () AS total_count,
+                id AS invoiceLineJournalRecordId
          FROM journal_records
          WHERE journal_records.job_execution_id = ''%s'' and entity_type = ''INVOICE'' and title != ''INVOICE''
          GROUP BY journal_records.source_id, journal_records.source_record_order, journal_records.job_execution_id,
-                  entity_hrid, title, error
+                  entity_hrid, title, error, id
      ) AS records_actions
 ORDER BY %I %s
 LIMIT %s OFFSET %s;',

--- a/mod-source-record-manager-server/src/main/resources/templates/db_scripts/create_get_record_processing_log_function.sql
+++ b/mod-source-record-manager-server/src/main/resources/templates/db_scripts/create_get_record_processing_log_function.sql
@@ -1,6 +1,8 @@
 -- Script to create function to get data import record processing log entries (recordProcessingLogDto).
+DROP FUNCTION IF EXISTS get_record_processing_log(uuid, uuid);
+
 CREATE OR REPLACE FUNCTION get_record_processing_log(jobExecutionId uuid, recordId uuid)
-    RETURNS TABLE(job_execution_id uuid, source_id uuid, source_record_order integer, title text, source_record_action_status text, source_entity_error text, instance_action_status text, instance_entity_id text[], instance_entity_hrid text[], instance_entity_error text, holdings_action_status text, holdings_entity_id text[], holdings_entity_hrid text[], holdings_entity_error text, item_action_status text, item_entity_id text[], item_entity_hrid text[], item_entity_error text, order_action_status text, order_entity_id text[], order_entity_hrid text[], order_entity_error text, invoice_action_status text, invoice_entity_id text[], invoice_entity_hrid text[], invoice_entity_error text)
+    RETURNS TABLE(job_execution_id uuid, source_id uuid, source_record_order integer, title text, source_record_action_status text, source_entity_error text, instance_action_status text, instance_entity_id text[], instance_entity_hrid text[], instance_entity_error text, holdings_action_status text, holdings_entity_id text[], holdings_entity_hrid text[], holdings_entity_error text, item_action_status text, item_entity_id text[], item_entity_hrid text[], item_entity_error text, order_action_status text, order_entity_id text[], order_entity_hrid text[], order_entity_error text, invoice_action_status text, invoice_entity_id text[], invoice_entity_hrid text[], invoice_entity_error text, invoice_lines_entity_id text[], invoice_lines_entity_hrid text[], invoice_lines_entity_error text[])
 AS $$
 BEGIN
     RETURN QUERY
@@ -32,10 +34,13 @@ BEGIN
 			   records_actions.order_entity_id,
 			   records_actions.order_entity_hrid,
 			   records_actions.order_entity_error[1],
-               get_entity_status(invoice_actions, invoice_errors_number)   AS invoice_action_status,
-			   records_actions.invoice_entity_id,
-			   records_actions.invoice_entity_hrid,
-			   records_actions.invoice_entity_error[1]
+               null AS invoice_action_status,
+			   null AS invoice_entity_id,
+			   null AS invoice_entity_hrid,
+			   null AS invoice_entity_error,
+               null AS invoice_lines_entity_id,
+               null AS invoice_lines_entity_hrid,
+               null AS invoice_lines_entity_error
         FROM (
                SELECT journal_records.source_id,
                       journal_records.source_record_order,
@@ -73,22 +78,68 @@ BEGIN
 
 					  array_agg(entity_hrid) FILTER (WHERE entity_type = 'ORDER') AS order_entity_hrid,
 			          array_agg(entity_id) FILTER (WHERE entity_type = 'ORDER') AS order_entity_id,
-					  array_agg(error) FILTER (WHERE entity_type = 'ORDER') AS order_entity_error,
-
-                      array_agg(action_type) FILTER (WHERE entity_type = 'INVOICE') AS invoice_actions,
-                      count(journal_records.source_id) FILTER (WHERE entity_type = 'INVOICE' AND journal_records.error != '') AS invoice_errors_number,
-
-					  array_agg(entity_hrid) FILTER (WHERE entity_type = 'INVOICE') AS invoice_entity_hrid,
-			          array_agg(entity_id) FILTER (WHERE entity_type = 'INVOICE') AS invoice_entity_id,
-					  array_agg(error) FILTER (WHERE entity_type = 'INVOICE') AS invoice_entity_error
-
+					  array_agg(error) FILTER (WHERE entity_type = 'ORDER') AS order_entity_error
                FROM journal_records
-               WHERE journal_records.job_execution_id = jobExecutionId AND journal_records.source_id = recordId
+               WHERE journal_records.job_execution_id = jobExecutionId AND journal_records.source_id = recordId AND journal_records.entity_type NOT IN ('EDIFACT', 'INVOICE')
                GROUP BY journal_records.source_id, journal_records.source_record_order, journal_records.job_execution_id)
 			   AS records_actions
         LEFT JOIN (
                     SELECT journal_records.source_id, journal_records.title FROM journal_records
                     WHERE journal_records.job_execution_id = jobExecutionId AND journal_records.source_id = recordId
-                  ) AS rec_titles ON rec_titles.source_id = records_actions.source_id AND rec_titles.title IS NOT NULL;
+                  ) AS rec_titles ON rec_titles.source_id = records_actions.source_id AND rec_titles.title IS NOT NULL
+        UNION
+            SELECT edifact_records_actions.job_execution_id,
+                   edifact_records_actions.source_id,
+                   edifact_records_actions.source_record_order[1],
+                   null as title,
+                   CASE WHEN edifact_errors_number != 0 THEN 'DISCARDED'
+                        WHEN edifact_actions[array_length(edifact_actions, 1)] = 'CREATE' THEN 'CREATED'
+                   END AS source_record_action_status,
+                   edifact_records_actions.source_entity_error[1],
+                   null AS instance_action_status,
+                   null AS instance_entity_id,
+                   null AS instance_entity_hrid,
+                   null AS instance_entity_error,
+                   null AS holdings_action_status,
+                   null AS holdings_entity_id,
+                   null AS holdings_entity_hrid,
+                   null AS holdings_entity_error,
+                   null AS item_action_status,
+                   null AS item_entity_id,
+                   null AS item_entity_hrid,
+                   null AS item_entity_error,
+                   null AS order_action_status,
+                   null AS order_entity_id,
+                   null AS order_entity_hrid,
+                   null AS order_entity_error,
+                   get_entity_status(invoice_actions, invoice_errors_number)   AS invoice_action_status,
+                   edifact_records_actions.invoice_entity_id,
+                   edifact_records_actions.invoice_entity_hrid,
+                   edifact_records_actions.invoice_entity_error[1],
+
+                   edifact_records_actions.invoice_lines_entity_id,
+                   edifact_records_actions.invoice_lines_entity_hrid,
+                   edifact_records_actions.invoice_lines_entity_error
+            FROM (
+                 SELECT journal_records.source_id,
+                        journal_records.job_execution_id,
+                        array_agg(journal_records.source_record_order) FILTER (WHERE entity_type = 'EDIFACT') as source_record_order,
+                        array_agg(action_type) FILTER (WHERE entity_type = 'EDIFACT') AS edifact_actions,
+                        count(journal_records.source_id) FILTER (WHERE entity_type = 'EDIFACT' AND journal_records.error != '') AS edifact_errors_number,
+                        array_agg(error) FILTER (WHERE entity_type = 'EDIFACT') AS source_entity_error,
+
+                        array_agg(action_type) FILTER (WHERE entity_type = 'INVOICE' AND journal_records.title = 'INVOICE') AS invoice_actions,
+                        count(journal_records.source_id) FILTER (WHERE entity_type = 'INVOICE' AND journal_records.title = 'INVOICE' AND journal_records.error != '') AS invoice_errors_number,
+                        array_agg(entity_hrid) FILTER (WHERE entity_type = 'INVOICE' AND journal_records.title = 'INVOICE') AS invoice_entity_hrid,
+                        array_agg(entity_id) FILTER (WHERE entity_type = 'INVOICE' AND journal_records.title = 'INVOICE') AS invoice_entity_id,
+                        array_agg(error) FILTER (WHERE entity_type = 'INVOICE' AND journal_records.title = 'INVOICE') AS invoice_entity_error,
+
+                        array_agg(entity_hrid ORDER BY journal_records.source_record_order ASC) FILTER (WHERE entity_type = 'INVOICE' AND journal_records.title != 'INVOICE') AS invoice_lines_entity_hrid,
+                        array_agg(entity_id ORDER BY journal_records.source_record_order ASC) FILTER (WHERE entity_type = 'INVOICE' AND journal_records.title != 'INVOICE') AS invoice_lines_entity_id,
+                        array_agg(error ORDER BY journal_records.source_record_order ASC) FILTER (WHERE entity_type = 'INVOICE' AND journal_records.title != 'INVOICE') AS invoice_lines_entity_error
+                 FROM journal_records
+                 WHERE journal_records.job_execution_id = jobExecutionId AND journal_records.source_id = recordId AND journal_records.entity_type IN ('EDIFACT', 'INVOICE')
+                 GROUP BY journal_records.source_id, journal_records.job_execution_id
+            ) AS edifact_records_actions;
 END;
 $$ LANGUAGE plpgsql;

--- a/mod-source-record-manager-server/src/main/resources/templates/db_scripts/create_get_record_processing_log_function.sql
+++ b/mod-source-record-manager-server/src/main/resources/templates/db_scripts/create_get_record_processing_log_function.sql
@@ -2,7 +2,7 @@
 DROP FUNCTION IF EXISTS get_record_processing_log(uuid, uuid);
 
 CREATE OR REPLACE FUNCTION get_record_processing_log(jobExecutionId uuid, recordId uuid)
-    RETURNS TABLE(job_execution_id uuid, source_id uuid, source_record_order integer, title text, source_record_action_status text, source_entity_error text, instance_action_status text, instance_entity_id text[], instance_entity_hrid text[], instance_entity_error text, holdings_action_status text, holdings_entity_id text[], holdings_entity_hrid text[], holdings_entity_error text, item_action_status text, item_entity_id text[], item_entity_hrid text[], item_entity_error text, order_action_status text, order_entity_id text[], order_entity_hrid text[], order_entity_error text, invoice_action_status text, invoice_entity_id text[], invoice_entity_hrid text[], invoice_entity_error text, invoice_lines_entity_id text[], invoice_lines_entity_hrid text[], invoice_lines_entity_error text[])
+    RETURNS TABLE(job_execution_id uuid, source_id uuid, source_record_order integer, title text, source_record_action_status text, source_entity_error text, instance_action_status text, instance_entity_id text[], instance_entity_hrid text[], instance_entity_error text, holdings_action_status text, holdings_entity_id text[], holdings_entity_hrid text[], holdings_entity_error text, item_action_status text, item_entity_id text[], item_entity_hrid text[], item_entity_error text, order_action_status text, order_entity_id text[], order_entity_hrid text[], order_entity_error text, invoice_action_status text, invoice_entity_id text[], invoice_entity_hrid text[], invoice_entity_error text, invoice_line_action_status text, invoice_line_entity_id text, invoice_line_entity_hrid text, invoice_line_entity_error text)
 AS $$
 BEGIN
     RETURN QUERY
@@ -38,9 +38,10 @@ BEGIN
 			   null AS invoice_entity_id,
 			   null AS invoice_entity_hrid,
 			   null AS invoice_entity_error,
-               null AS invoice_lines_entity_id,
-               null AS invoice_lines_entity_hrid,
-               null AS invoice_lines_entity_error
+               null AS invoice_line_action_status,
+               null AS invoice_line_entity_id,
+               null AS invoice_line_entity_hrid,
+               null AS invoice_line_entity_error
         FROM (
                SELECT journal_records.source_id,
                       journal_records.source_record_order,
@@ -88,14 +89,14 @@ BEGIN
                     WHERE journal_records.job_execution_id = jobExecutionId AND journal_records.source_id = recordId
                   ) AS rec_titles ON rec_titles.source_id = records_actions.source_id AND rec_titles.title IS NOT NULL
         UNION
-            SELECT edifact_records_actions.job_execution_id,
-                   edifact_records_actions.source_id,
-                   edifact_records_actions.source_record_order[1],
-                   null as title,
+            SELECT invoice_line_info.job_execution_id,
+                   invoice_line_info.source_id,
+                   records_actions.source_record_order,
+                   invoice_line_info.title,
                    CASE WHEN edifact_errors_number != 0 THEN 'DISCARDED'
                         WHEN edifact_actions[array_length(edifact_actions, 1)] = 'CREATE' THEN 'CREATED'
                    END AS source_record_action_status,
-                   edifact_records_actions.source_entity_error[1],
+                   records_actions.source_record_error[1],
                    null AS instance_action_status,
                    null AS instance_entity_id,
                    null AS instance_entity_hrid,
@@ -112,34 +113,43 @@ BEGIN
                    null AS order_entity_id,
                    null AS order_entity_hrid,
                    null AS order_entity_error,
-                   get_entity_status(invoice_actions, invoice_errors_number)   AS invoice_action_status,
-                   edifact_records_actions.invoice_entity_id,
-                   edifact_records_actions.invoice_entity_hrid,
-                   edifact_records_actions.invoice_entity_error[1],
-
-                   edifact_records_actions.invoice_lines_entity_id,
-                   edifact_records_actions.invoice_lines_entity_hrid,
-                   edifact_records_actions.invoice_lines_entity_error
+                   get_entity_status(records_actions.invoice_actions, records_actions.invoice_errors_number) AS invoice_action_status,
+                   records_actions.invoice_entity_id,
+                   records_actions.invoice_entity_hrid,
+                   records_actions.invoice_entity_error[1],
+                   CASE WHEN action_status = 'ERROR' THEN 'DISCARDED'
+                        WHEN inv_line_actions = 'CREATE' THEN 'CREATED'
+                   END AS invoice_line_action_status,
+                   invoice_line_info.invoice_line_entity_id,
+                   invoice_line_info.invoice_line_entity_hrid,
+                   invoice_line_info.invoice_line_entity_error
             FROM (
-                 SELECT journal_records.source_id,
-                        journal_records.job_execution_id,
-                        array_agg(journal_records.source_record_order) FILTER (WHERE entity_type = 'EDIFACT') as source_record_order,
-                        array_agg(action_type) FILTER (WHERE entity_type = 'EDIFACT') AS edifact_actions,
-                        count(journal_records.source_id) FILTER (WHERE entity_type = 'EDIFACT' AND journal_records.error != '') AS edifact_errors_number,
-                        array_agg(error) FILTER (WHERE entity_type = 'EDIFACT') AS source_entity_error,
+                   SELECT journal_records.source_id,
+                          journal_records.job_execution_id,
+                          journal_records.title,
+                          journal_records.action_type AS inv_line_actions,
+                          action_status,
+                          entity_hrid AS invoice_line_entity_hrid,
+                          entity_id AS invoice_line_entity_id,
+                          error AS invoice_line_entity_error
+                   FROM journal_records
+                   WHERE journal_records.id = recordId AND journal_records.entity_type = 'INVOICE' AND journal_records.title != 'INVOICE'
+            ) AS invoice_line_info
+            LEFT JOIN (
+                   SELECT journal_records.source_id,
+                          journal_records.source_record_order,
+                          array_agg(action_type) FILTER (WHERE entity_type = 'EDIFACT') AS edifact_actions,
+                          count(journal_records.source_id) FILTER (WHERE entity_type = 'EDIFACT' AND journal_records.error != '') AS edifact_errors_number,
+                          array_agg(error) FILTER (WHERE entity_type = 'EDIFACT') AS source_record_error,
 
-                        array_agg(action_type) FILTER (WHERE entity_type = 'INVOICE' AND journal_records.title = 'INVOICE') AS invoice_actions,
-                        count(journal_records.source_id) FILTER (WHERE entity_type = 'INVOICE' AND journal_records.title = 'INVOICE' AND journal_records.error != '') AS invoice_errors_number,
-                        array_agg(entity_hrid) FILTER (WHERE entity_type = 'INVOICE' AND journal_records.title = 'INVOICE') AS invoice_entity_hrid,
-                        array_agg(entity_id) FILTER (WHERE entity_type = 'INVOICE' AND journal_records.title = 'INVOICE') AS invoice_entity_id,
-                        array_agg(error) FILTER (WHERE entity_type = 'INVOICE' AND journal_records.title = 'INVOICE') AS invoice_entity_error,
-
-                        array_agg(entity_hrid ORDER BY journal_records.source_record_order ASC) FILTER (WHERE entity_type = 'INVOICE' AND journal_records.title != 'INVOICE') AS invoice_lines_entity_hrid,
-                        array_agg(entity_id ORDER BY journal_records.source_record_order ASC) FILTER (WHERE entity_type = 'INVOICE' AND journal_records.title != 'INVOICE') AS invoice_lines_entity_id,
-                        array_agg(error ORDER BY journal_records.source_record_order ASC) FILTER (WHERE entity_type = 'INVOICE' AND journal_records.title != 'INVOICE') AS invoice_lines_entity_error
-                 FROM journal_records
-                 WHERE journal_records.job_execution_id = jobExecutionId AND journal_records.source_id = recordId AND journal_records.entity_type IN ('EDIFACT', 'INVOICE')
-                 GROUP BY journal_records.source_id, journal_records.job_execution_id
-            ) AS edifact_records_actions;
+                          array_agg(action_type) FILTER (WHERE entity_type = 'INVOICE' AND journal_records.title = 'INVOICE') AS invoice_actions,
+                          count(journal_records.source_id) FILTER (WHERE entity_type = 'INVOICE' AND journal_records.title = 'INVOICE' AND journal_records.error != '') AS invoice_errors_number,
+                          array_agg(entity_hrid) FILTER (WHERE entity_type = 'INVOICE' AND journal_records.title = 'INVOICE') AS invoice_entity_hrid,
+                          array_agg(entity_id) FILTER (WHERE entity_type = 'INVOICE' AND journal_records.title = 'INVOICE') AS invoice_entity_id,
+                          array_agg(error) FILTER (WHERE entity_type = 'INVOICE' AND journal_records.title = 'INVOICE') AS invoice_entity_error
+                   FROM journal_records
+                   WHERE journal_records.job_execution_id = jobExecutionId and entity_type = 'EDIFACT' OR journal_records.title = 'INVOICE'
+                   GROUP BY journal_records.source_id, journal_records.job_execution_id, journal_records.source_record_order
+            ) AS records_actions ON records_actions.source_id = invoice_line_info.source_id;
 END;
 $$ LANGUAGE plpgsql;

--- a/mod-source-record-manager-server/src/main/resources/templates/db_scripts/schema.json
+++ b/mod-source-record-manager-server/src/main/resources/templates/db_scripts/schema.json
@@ -121,12 +121,12 @@
     {
       "run": "after",
       "snippetPath": "create_get_job_log_entries_function.sql",
-      "fromModuleVersion": "mod-source-record-manager-3.0.1"
+      "fromModuleVersion": "mod-source-record-manager-3.0.2"
     },
     {
       "run": "after",
       "snippetPath": "create_get_record_processing_log_function.sql",
-      "fromModuleVersion": "mod-source-record-manager-2.5.0"
+      "fromModuleVersion": "mod-source-record-manager-3.0.2"
     }
   ]
 }

--- a/ramls/metadata-provider.raml
+++ b/ramls/metadata-provider.raml
@@ -118,7 +118,7 @@ resourceTypes:
               example: "Bad request"
   /jobLogEntries/{jobExecutionId}/records/{recordId}:
     get:
-      description: get record processing log dto by job execution id and record id
+      description: get record processing log dto by job execution id and record id (to get EDIFACT import log data a journal record id is expected)
       responses:
         200:
           body:


### PR DESCRIPTION
## Purpose
to provide data of the particular invoice line for Invoice JSON screen

## Approach
* expanded get_job_log_entries() function to return invoiceLineJournalRecordId
* changed create_get_record_processing_log_function() function to retrieve data only for the certain invoice line
* covered with tests

## Learning
[MODSOURMAN-420](https://issues.folio.org/browse/MODSOURMAN-420)

Requires: https://github.com/folio-org/data-import-raml-storage/pull/212