### PR TITLE
MODSOURMAN-429 Add permission to `/change-manager/jobExecutions/{id}/jobProfile`

### DIFF
--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -172,7 +172,8 @@
             "change-manager.jobexecutions.put"
           ],
           "modulePermissions": [
-            "converter-storage.jobprofilesnapshots.post"
+            "converter-storage.jobprofilesnapshots.post",
+            "converter-storage.jobprofile.get"
           ]
         }
       ]


### PR DESCRIPTION
## Purpose
Endpoint `PUT /change-manager/jobExecutions/{id}/jobProfile` is making request to `GET /data-import-profiles/jobProfiles/{id}` so it should have one more modulePermission: `converter-storage.jobprofile.get`
