### PR TITLE
MODDATAIMP-403 - Some data import jobs stuck on folio-snapshot-load

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,6 @@
 ## 2021-03-18 v3.0.2-SNAPSHOT
 * [MODSOURMAN-420](https://issues.folio.org/browse/MODSOURMAN-420) Expand endpoint for retrieving recordProcessingLogDto to provide data for Invoice JSON screen
+* [MODDATAIMP-403](https://issues.folio.org/browse/MODDATAIMP-403) Some data import jobs stuck on folio-snapshot-load
 
 ## 2021-03-28 v3.0.1
 * [MODSOURMAN-421](https://issues.folio.org/browse/MODSOURMAN-421) Syntax problem for 561 field in default mapping rules

--- a/mod-source-record-manager-server/pom.xml
+++ b/mod-source-record-manager-server/pom.xml
@@ -136,7 +136,7 @@
     <dependency>
       <groupId>org.folio</groupId>
       <artifactId>data-import-utils</artifactId>
-      <version>1.8.0</version>
+      <version>1.9.0-SNAPSHOT</version>
       <type>jar</type>
       <exclusions>
         <exclusion>

--- a/mod-source-record-manager-server/src/main/java/org/folio/verticle/consumers/StoredRecordChunksKafkaHandler.java
+++ b/mod-source-record-manager-server/src/main/java/org/folio/verticle/consumers/StoredRecordChunksKafkaHandler.java
@@ -4,6 +4,7 @@ import java.io.IOException;
 import java.util.List;
 import java.util.Map;
 
+import io.vertx.core.json.Json;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.folio.dataimport.util.OkapiConnectionParams;
@@ -57,11 +58,11 @@ public class StoredRecordChunksKafkaHandler implements AsyncRecordHandler<String
     String correlationId = okapiConnectionParams.getHeaders().get("correlationId");
     String chunkNumber = okapiConnectionParams.getHeaders().get("chunkNumber");
 
-    Event event = new JsonObject(record.value()).mapTo(Event.class);
+    Event event = Json.decodeValue(record.value(), Event.class);
 
     try {
       String unzipped = ZIPArchiver.unzip(event.getEventPayload());
-      RecordsBatchResponse recordsBatchResponse = new JsonObject(unzipped).mapTo(RecordsBatchResponse.class);
+      RecordsBatchResponse recordsBatchResponse = Json.decodeValue(unzipped, RecordsBatchResponse.class);
       List<Record> storedRecords = recordsBatchResponse.getRecords();
 
       // we only know record type by inspecting the records, assuming records are homogeneous type and defaulting to previous static value

--- a/mod-source-record-manager-server/src/test/java/org/folio/verticle/consumers/DataImportJournalConsumerVerticleMockTest.java
+++ b/mod-source-record-manager-server/src/test/java/org/folio/verticle/consumers/DataImportJournalConsumerVerticleMockTest.java
@@ -60,6 +60,7 @@ public class DataImportJournalConsumerVerticleMockTest extends AbstractRestTest 
   public static final String ENTITY_TYPE_KEY = "entityType";
   public static final String ACTION_TYPE_KEY = "actionType";
   public static final String ACTION_STATUS_KEY = "actionStatus";
+  public static final String SOURCE_RECORD_ID_KEY = "sourceId";
   public static final String ENV_KEY = "folio";
 
   @Spy
@@ -209,6 +210,39 @@ public class DataImportJournalConsumerVerticleMockTest extends AbstractRestTest 
     Assert.assertEquals("Action Status:", ActionStatus.ERROR.value(), jsonObject.getString(ACTION_STATUS_KEY));
 
     async.complete();
+  }
+
+  @Test
+  public void shouldProcessErrorEventAsSourceRecordErrorWhenEventChainHasNoEvents() throws IOException {
+    // given
+    HashMap<String, String> dataImportEventPayloadContext = new HashMap<>() {{
+      put(MARC_BIBLIOGRAPHIC.value(), recordJson.encode());
+      put(ERROR_KEY, "java.lang.IllegalStateException: Unsupported Marc record type");
+    }};
+
+    DataImportEventPayload dataImportEventPayload = new DataImportEventPayload()
+      .withEventType(DI_ERROR.value())
+      .withJobExecutionId(jobExecution.getId())
+      .withContext(dataImportEventPayloadContext)
+      .withOkapiUrl(OKAPI_URL)
+      .withTenant(TENANT_ID)
+      .withToken("token");
+
+    Mockito.doNothing().when(journalService).save(ArgumentMatchers.any(JsonObject.class), ArgumentMatchers.any(String.class));
+
+    KafkaConsumerRecord<String, String> kafkaConsumerRecord = buildKafkaConsumerRecord(dataImportEventPayload);
+    dataImportJournalKafkaHandler.handle(kafkaConsumerRecord);
+
+    // when
+    Mockito.verify(journalService).save(journalRecordCaptor.capture(), Mockito.anyString());
+
+    // then
+    JsonObject jsonObject = journalRecordCaptor.getValue();
+    Assert.assertEquals("Entity Type:", EntityType.MARC_BIBLIOGRAPHIC.value(), jsonObject.getString(ENTITY_TYPE_KEY));
+    Assert.assertEquals("Action Type:", ActionType.CREATE.value(), jsonObject.getString(ACTION_TYPE_KEY));
+    Assert.assertEquals("Action Status:", ActionStatus.ERROR.value(), jsonObject.getString(ACTION_STATUS_KEY));
+    Assert.assertEquals("Source Record id:", recordJson.getString("id"), jsonObject.getString(SOURCE_RECORD_ID_KEY));
+    Assert.assertNotNull(jsonObject.getString("error"));
   }
 
   private KafkaConsumerRecord<String, String> buildKafkaConsumerRecord(DataImportEventPayload record) throws IOException {

--- a/mod-source-record-manager-server/src/test/java/org/folio/verticle/consumers/DataImportJournalConsumerVerticleMockTest.java
+++ b/mod-source-record-manager-server/src/test/java/org/folio/verticle/consumers/DataImportJournalConsumerVerticleMockTest.java
@@ -53,6 +53,7 @@ import static org.folio.rest.jaxrs.model.JournalRecord.EntityType.MARC_BIBLIOGRA
 import static org.folio.rest.util.OkapiConnectionParams.OKAPI_TENANT_HEADER;
 import static org.folio.rest.util.OkapiConnectionParams.OKAPI_TOKEN_HEADER;
 import static org.folio.services.journal.JournalUtil.ERROR_KEY;
+import static org.mockito.ArgumentMatchers.eq;
 
 @RunWith(VertxUnitRunner.class)
 public class DataImportJournalConsumerVerticleMockTest extends AbstractRestTest {
@@ -230,13 +231,13 @@ public class DataImportJournalConsumerVerticleMockTest extends AbstractRestTest 
 
     Mockito.doNothing().when(journalService).save(ArgumentMatchers.any(JsonObject.class), ArgumentMatchers.any(String.class));
 
+    // when
     KafkaConsumerRecord<String, String> kafkaConsumerRecord = buildKafkaConsumerRecord(dataImportEventPayload);
     dataImportJournalKafkaHandler.handle(kafkaConsumerRecord);
 
-    // when
-    Mockito.verify(journalService).save(journalRecordCaptor.capture(), Mockito.anyString());
-
     // then
+    Mockito.verify(journalService).save(journalRecordCaptor.capture(), eq(TENANT_ID));
+
     JsonObject jsonObject = journalRecordCaptor.getValue();
     Assert.assertEquals("Entity Type:", EntityType.MARC_BIBLIOGRAPHIC.value(), jsonObject.getString(ENTITY_TYPE_KEY));
     Assert.assertEquals("Action Type:", ActionType.CREATE.value(), jsonObject.getString(ACTION_TYPE_KEY));

--- a/mod-source-record-manager-server/src/test/java/org/folio/verticle/consumers/StoredRecordChunkConsumersVerticleTest.java
+++ b/mod-source-record-manager-server/src/test/java/org/folio/verticle/consumers/StoredRecordChunkConsumersVerticleTest.java
@@ -1,0 +1,90 @@
+package org.folio.verticle.consumers;
+
+import io.vertx.core.json.Json;
+import io.vertx.ext.unit.junit.VertxUnitRunner;
+import net.mguenther.kafka.junit.KeyValue;
+import net.mguenther.kafka.junit.ObserveKeyValues;
+import net.mguenther.kafka.junit.SendKeyValues;
+import org.folio.DataImportEventPayload;
+import org.folio.processing.events.utils.ZIPArchiver;
+import org.folio.rest.impl.AbstractRestTest;
+import org.folio.rest.jaxrs.model.EntityType;
+import org.folio.rest.jaxrs.model.Event;
+import org.folio.rest.jaxrs.model.InitJobExecutionsRsDto;
+import org.folio.rest.jaxrs.model.JobExecution;
+import org.folio.rest.jaxrs.model.ParsedRecord;
+import org.folio.rest.jaxrs.model.Record;
+import org.folio.rest.jaxrs.model.RecordsBatchResponse;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import java.io.IOException;
+import java.util.Collections;
+import java.util.List;
+import java.util.UUID;
+import java.util.concurrent.TimeUnit;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static org.folio.rest.jaxrs.model.DataImportEventTypes.DI_ERROR;
+import static org.folio.rest.jaxrs.model.DataImportEventTypes.DI_PARSED_RECORDS_CHUNK_SAVED;
+import static org.folio.rest.jaxrs.model.Record.RecordType.MARC;
+import static org.folio.rest.util.OkapiConnectionParams.OKAPI_TENANT_HEADER;
+import static org.folio.rest.util.OkapiConnectionParams.OKAPI_TOKEN_HEADER;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+
+@RunWith(VertxUnitRunner.class)
+public class StoredRecordChunkConsumersVerticleTest extends AbstractRestTest {
+
+  private static final String JOB_EXECUTION_ID_HEADER = "jobExecutionId";
+  private static final String ERROR_MSG_KEY = "ERROR";
+
+  @Test
+  public void shouldPublishDiErrorWhenLeaderRecordTypeValueIsInvalid() throws InterruptedException, IOException {
+    // given
+    // parsed content with invalid value '7' as record type identifier at the LEADER/06
+    String parsedContentWithInvalidRecordTypeValue = "{\"leader\": \"13112c7m a2200553Ii 4500\"}";
+
+    InitJobExecutionsRsDto response = constructAndPostInitJobExecutionRqDto(1);
+    List<JobExecution> createdJobExecutions = response.getJobExecutions();
+    assertThat(createdJobExecutions.size(), is(1));
+    JobExecution jobExec = createdJobExecutions.get(0);
+
+    RecordsBatchResponse recordsBatch = new RecordsBatchResponse()
+      .withTotalRecords(1)
+      .withRecords(List.of(new Record()
+        .withRecordType(MARC)
+        .withId(UUID.randomUUID().toString())
+        .withSnapshotId(jobExec.getId())
+        .withParsedRecord(new ParsedRecord().withContent(parsedContentWithInvalidRecordTypeValue))));
+
+    Event event = new Event().withEventPayload(ZIPArchiver.zip(Json.encode(recordsBatch)));
+    KeyValue<String, String> kafkaRecord = new KeyValue<>("42", Json.encode(event));
+    kafkaRecord.addHeader(OKAPI_TENANT_HEADER, TENANT_ID, UTF_8);
+    kafkaRecord.addHeader(OKAPI_TOKEN_HEADER, TOKEN, UTF_8);
+    kafkaRecord.addHeader(JOB_EXECUTION_ID_HEADER, jobExec.getId(), UTF_8);
+
+    String topic = formatToKafkaTopicName(DI_PARSED_RECORDS_CHUNK_SAVED.value());
+    SendKeyValues<String, String> request = SendKeyValues.to(topic, Collections.singletonList(kafkaRecord))
+      .useDefaults();
+
+    // when
+    kafkaCluster.send(request);
+
+    // then
+    String topicToObserve = formatToKafkaTopicName(DI_ERROR.value());
+    List<String> observedValues = kafkaCluster.observeValues(ObserveKeyValues.on(topicToObserve, 1)
+      .observeFor(30, TimeUnit.SECONDS)
+      .build());
+
+    Event obtainedEvent = Json.decodeValue(observedValues.get(0), Event.class);
+    DataImportEventPayload eventPayload = Json.decodeValue(ZIPArchiver.unzip(obtainedEvent.getEventPayload()), DataImportEventPayload.class);
+    assertEquals(DI_ERROR.value(), eventPayload.getEventType());
+    assertEquals(jobExec.getId(), eventPayload.getJobExecutionId());
+    assertEquals(TENANT_ID, eventPayload.getTenant());
+    assertNotNull(eventPayload.getContext().get(EntityType.MARC_BIBLIOGRAPHIC.value()));
+    assertNotNull(eventPayload.getContext().get(ERROR_MSG_KEY));
+  }
+}


### PR DESCRIPTION
## Purpose
to fix the hang of the job when MARC record type can not be determined

## Approach
* publish DI_ERROR event when record type can not be determined by value at LEADER/06

## Learning
[MODDATAIMP-403](https://issues.folio.org/browse/MODDATAIMP-403)

Requires: https://github.com/folio-org/data-import-utils/pull/40