### PR TITLE
MODSOURMAN-428 - Expand exactly one delivery approach for handler receiving stored records

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,7 @@
 ## 2021-03-18 v3.0.2-SNAPSHOT
 * [MODSOURMAN-420](https://issues.folio.org/browse/MODSOURMAN-420) Expand endpoint for retrieving recordProcessingLogDto to provide data for Invoice JSON screen
 * [MODSOURMAN-419](https://issues.folio.org/browse/MODSOURMAN-419) SQL Exception WRT count function [BUGFIX]
+* [MODSOURMAN-428](https://issues.folio.org/browse/MODSOURMAN-428) SQL Exception WRT count function
 
 ## 2021-03-28 v3.0.1
 * [MODSOURMAN-421](https://issues.folio.org/browse/MODSOURMAN-421) Syntax problem for 561 field in default mapping rules

--- a/mod-source-record-manager-server/pom.xml
+++ b/mod-source-record-manager-server/pom.xml
@@ -194,7 +194,7 @@
     <dependency>
       <groupId>org.folio</groupId>
       <artifactId>folio-kafka-wrapper</artifactId>
-      <version>2.0.1</version>
+      <version>2.0.2</version>
     </dependency>
     <dependency>
       <groupId>org.folio</groupId>

--- a/mod-source-record-manager-server/src/main/java/org/folio/config/ApplicationConfig.java
+++ b/mod-source-record-manager-server/src/main/java/org/folio/config/ApplicationConfig.java
@@ -35,7 +35,7 @@ public class ApplicationConfig {
   private String envId;
   @Value("${srm.kafkacache.cleanup.interval.ms:3600000}")
   private long cacheCleanupIntervalMillis;
-  @Value("${srm.kafkacache.expiration.time.hours:1}")
+  @Value("${srm.kafkacache.expiration.time.hours:3}")
   private int cachedEventExpirationTimeHours;
 
   @Bean(name = "newKafkaConfig")

--- a/mod-source-record-manager-server/src/main/java/org/folio/config/ApplicationConfig.java
+++ b/mod-source-record-manager-server/src/main/java/org/folio/config/ApplicationConfig.java
@@ -5,6 +5,8 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.folio.dataimport.util.marc.MarcRecordAnalyzer;
 import org.folio.kafka.KafkaConfig;
+import org.folio.kafka.cache.KafkaInternalCache;
+import org.folio.kafka.cache.util.CacheUtil;
 import org.folio.services.journal.JournalService;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
@@ -31,6 +33,10 @@ public class ApplicationConfig {
   private int replicationFactor;
   @Value("${ENV:folio}")
   private String envId;
+  @Value("${srm.kafkacache.cleanup.interval.ms:3600000}")
+  private long cacheCleanupIntervalMillis;
+  @Value("${srm.kafkacache.expiration.time.hours:1}")
+  private int cachedEventExpirationTimeHours;
 
   @Bean(name = "newKafkaConfig")
   public KafkaConfig kafkaConfigBean() {
@@ -58,5 +64,17 @@ public class ApplicationConfig {
   @Bean
   public MarcRecordAnalyzer marcRecordAnalyzer() {
     return new MarcRecordAnalyzer();
+  }
+
+  @Bean
+  public KafkaInternalCache kafkaInternalCache(KafkaConfig kafkaConfig) {
+    KafkaInternalCache kafkaInternalCache = KafkaInternalCache.builder()
+      .kafkaConfig(kafkaConfig)
+      .build();
+
+    kafkaInternalCache.initKafkaCache();
+    CacheUtil.initCacheCleanupPeriodicTask(vertx, kafkaInternalCache, cacheCleanupIntervalMillis, cachedEventExpirationTimeHours);
+
+    return kafkaInternalCache;
   }
 }

--- a/mod-source-record-manager-server/src/main/java/org/folio/verticle/consumers/StoredRecordChunksKafkaHandler.java
+++ b/mod-source-record-manager-server/src/main/java/org/folio/verticle/consumers/StoredRecordChunksKafkaHandler.java
@@ -9,6 +9,7 @@ import org.apache.logging.log4j.Logger;
 import org.folio.dataimport.util.OkapiConnectionParams;
 import org.folio.kafka.AsyncRecordHandler;
 import org.folio.kafka.KafkaHeaderUtils;
+import org.folio.kafka.cache.KafkaInternalCache;
 import org.folio.processing.events.utils.ZIPArchiver;
 import org.folio.rest.jaxrs.model.DataImportEventTypes;
 import org.folio.rest.jaxrs.model.Event;
@@ -42,11 +43,14 @@ public class StoredRecordChunksKafkaHandler implements AsyncRecordHandler<String
   );
 
   private RecordsPublishingService recordsPublishingService;
+  private KafkaInternalCache kafkaInternalCache;
   private Vertx vertx;
 
   public StoredRecordChunksKafkaHandler(@Autowired @Qualifier("recordsPublishingService") RecordsPublishingService recordsPublishingService,
-                                      @Autowired Vertx vertx) {
+                                        @Autowired KafkaInternalCache kafkaInternalCache,
+                                        @Autowired Vertx vertx) {
     this.recordsPublishingService = recordsPublishingService;
+    this.kafkaInternalCache = kafkaInternalCache;
     this.vertx = vertx;
   }
 
@@ -59,30 +63,34 @@ public class StoredRecordChunksKafkaHandler implements AsyncRecordHandler<String
 
     Event event = new JsonObject(record.value()).mapTo(Event.class);
 
-    try {
-      String unzipped = ZIPArchiver.unzip(event.getEventPayload());
-      RecordsBatchResponse recordsBatchResponse = new JsonObject(unzipped).mapTo(RecordsBatchResponse.class);
-      List<Record> storedRecords = recordsBatchResponse.getRecords();
+    if (!kafkaInternalCache.containsByKey(event.getId())) {
+      try {
+        kafkaInternalCache.putToCache(event.getId());
+        String unzipped = ZIPArchiver.unzip(event.getEventPayload());
+        RecordsBatchResponse recordsBatchResponse = new JsonObject(unzipped).mapTo(RecordsBatchResponse.class);
+        List<Record> storedRecords = recordsBatchResponse.getRecords();
 
-      // we only know record type by inspecting the records, assuming records are homogeneous type and defaulting to previous static value
-      DataImportEventTypes eventType = !storedRecords.isEmpty() && RECORD_TYPE_TO_EVENT_TYPE.containsKey(storedRecords.get(0).getRecordType())
-        ? RECORD_TYPE_TO_EVENT_TYPE.get(storedRecords.get(0).getRecordType())
-        : DI_SRS_MARC_BIB_RECORD_CREATED;
+        // we only know record type by inspecting the records, assuming records are homogeneous type and defaulting to previous static value
+        DataImportEventTypes eventType = !storedRecords.isEmpty() && RECORD_TYPE_TO_EVENT_TYPE.containsKey(storedRecords.get(0).getRecordType())
+          ? RECORD_TYPE_TO_EVENT_TYPE.get(storedRecords.get(0).getRecordType())
+          : DI_SRS_MARC_BIB_RECORD_CREATED;
 
-      LOGGER.debug("RecordsBatchResponse has been received, starting processing correlationId: {} chunkNumber: {}", correlationId, chunkNumber);
-      return recordsPublishingService.sendEventsWithRecords(storedRecords, okapiConnectionParams.getHeaders().get("jobExecutionId"),
-        okapiConnectionParams, eventType.value())
-        .compose(b -> {
-          LOGGER.debug("RecordsBatchResponse processing has been completed correlationId: {} chunkNumber: {}",correlationId, chunkNumber);
-          return Future.succeededFuture(correlationId);
-        }, th -> {
-          LOGGER.error("RecordsBatchResponse processing has failed with errors correlationId: {} chunkNumber: {}", correlationId, chunkNumber, th);
-          return Future.failedFuture(th);
-        });
-    } catch (IOException e) {
-      LOGGER.error("Can't process kafka record: ", e);
-      return Future.failedFuture(e);
+        LOGGER.debug("RecordsBatchResponse has been received, starting processing correlationId: {} chunkNumber: {}", correlationId, chunkNumber);
+        return recordsPublishingService.sendEventsWithRecords(storedRecords, okapiConnectionParams.getHeaders().get("jobExecutionId"),
+          okapiConnectionParams, eventType.value())
+          .compose(b -> {
+            LOGGER.debug("RecordsBatchResponse processing has been completed correlationId: {} chunkNumber: {}", correlationId, chunkNumber);
+            return Future.succeededFuture(correlationId);
+          }, th -> {
+            LOGGER.error("RecordsBatchResponse processing has failed with errors correlationId: {} chunkNumber: {}", correlationId, chunkNumber, th);
+            return Future.failedFuture(th);
+          });
+      } catch (IOException e) {
+        LOGGER.error("Can't process kafka record: ", e);
+        return Future.failedFuture(e);
+      }
     }
+    return Future.succeededFuture(record.key());
   }
 
 }

--- a/mod-source-record-manager-server/src/test/java/org/folio/verticle/consumers/StoredRecordChunkConsumersVerticleTest.java
+++ b/mod-source-record-manager-server/src/test/java/org/folio/verticle/consumers/StoredRecordChunkConsumersVerticleTest.java
@@ -60,7 +60,7 @@ public class StoredRecordChunkConsumersVerticleTest extends AbstractRestTest {
         .withSnapshotId(jobExec.getId())
         .withParsedRecord(new ParsedRecord().withContent(parsedContentWithInvalidRecordTypeValue))));
 
-    Event event = new Event().withEventPayload(ZIPArchiver.zip(Json.encode(recordsBatch)));
+    Event event = new Event().withId(UUID.randomUUID().toString()).withEventPayload(ZIPArchiver.zip(Json.encode(recordsBatch)));
     KeyValue<String, String> kafkaRecord = new KeyValue<>("42", Json.encode(event));
     kafkaRecord.addHeader(OKAPI_TENANT_HEADER, TENANT_ID, UTF_8);
     kafkaRecord.addHeader(OKAPI_TOKEN_HEADER, TOKEN, UTF_8);

--- a/mod-source-record-manager-server/src/test/java/org/folio/verticle/consumers/StoredRecordChunksKafkaHandlerTest.java
+++ b/mod-source-record-manager-server/src/test/java/org/folio/verticle/consumers/StoredRecordChunksKafkaHandlerTest.java
@@ -1,0 +1,80 @@
+package org.folio.verticle.consumers;
+
+import io.vertx.core.Future;
+import io.vertx.core.Vertx;
+import io.vertx.core.json.Json;
+import io.vertx.kafka.client.consumer.KafkaConsumerRecord;
+import org.folio.dataimport.util.OkapiConnectionParams;
+import org.folio.kafka.AsyncRecordHandler;
+import org.folio.kafka.cache.KafkaInternalCache;
+import org.folio.processing.events.utils.ZIPArchiver;
+import org.folio.rest.jaxrs.model.Event;
+import org.folio.rest.jaxrs.model.Record;
+import org.folio.rest.jaxrs.model.RecordsBatchResponse;
+import org.folio.services.RecordsPublishingService;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.UUID;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@RunWith(MockitoJUnitRunner.class)
+public class StoredRecordChunksKafkaHandlerTest {
+
+  @Mock
+  private RecordsPublishingService recordsPublishingService;
+  @Mock
+  private KafkaInternalCache kafkaInternalCache;
+  @Mock
+  private KafkaConsumerRecord<String, String> kafkaRecord;
+
+  private Vertx vertx = Vertx.vertx();
+  private AsyncRecordHandler<String, String> storedRecordChunksKafkaHandler;
+
+  @Before
+  public void setUp() {
+    storedRecordChunksKafkaHandler = new StoredRecordChunksKafkaHandler(recordsPublishingService, kafkaInternalCache, vertx);
+  }
+
+  @Test
+  public void shouldNotHandleEventWhenKafkaCacheContainsEventId() throws IOException {
+    // given
+    RecordsBatchResponse recordsBatch = new RecordsBatchResponse()
+      .withRecords(List.of(new Record()))
+      .withTotalRecords(1);
+
+    Event event = new Event()
+      .withId(UUID.randomUUID().toString())
+      .withEventPayload(ZIPArchiver.zip(Json.encode(recordsBatch)));
+
+    String expectedKafkaRecordKey = "1";
+    when(kafkaRecord.key()).thenReturn(expectedKafkaRecordKey);
+    when(kafkaRecord.value()).thenReturn(Json.encode(event));
+    when(kafkaInternalCache.containsByKey(eq(event.getId()))).thenReturn(true);
+
+    // when
+    Future<String> future = storedRecordChunksKafkaHandler.handle(kafkaRecord);
+
+    // then
+    verify(kafkaInternalCache, times(1)).containsByKey(eq(event.getId()));
+    verify(recordsPublishingService, never()).sendEventsWithRecords(anyList(), anyString(), any(OkapiConnectionParams.class), anyString());
+    assertTrue(future.succeeded());
+    assertEquals(expectedKafkaRecordKey, future.result());
+  }
+
+}


### PR DESCRIPTION
## Purpose
to expand exactly one delivery approach for chunks of saved records in srs

## Approach
* KafkaInternalCache was used to check whether an event was already consumed by the handler


## Learning
[MODSOURMAN-428](https://issues.folio.org/browse/MODSOURMAN-428)
