### PR TITLE
MODSOURMAN-430 - Expand exactly once delivery approach for data import log handler

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -3,6 +3,7 @@
 * [MODSOURMAN-419](https://issues.folio.org/browse/MODSOURMAN-419) SQL Exception WRT count function [BUGFIX]
 * [MODDATAIMP-403](https://issues.folio.org/browse/MODDATAIMP-403) Some data import jobs stuck on folio-snapshot-load
 * [MODSOURMAN-428](https://issues.folio.org/browse/MODSOURMAN-428) Ensure exactly one delivery approach for handler receiving stored records
+* [MODSOURMAN-430](https://issues.folio.org/browse/MODSOURMAN-430) Ensure exactly one delivery approach for for data import log handler
 
 ## 2021-03-28 v3.0.1
 * [MODSOURMAN-421](https://issues.folio.org/browse/MODSOURMAN-421) Syntax problem for 561 field in default mapping rules

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,9 +1,12 @@
-## 2021-03-18 v3.0.2-SNAPSHOT
+## 2021-03-18 v3.0.3-SNAPSHOT
 * [MODSOURMAN-420](https://issues.folio.org/browse/MODSOURMAN-420) Expand endpoint for retrieving recordProcessingLogDto to provide data for Invoice JSON screen
 * [MODSOURMAN-419](https://issues.folio.org/browse/MODSOURMAN-419) SQL Exception WRT count function [BUGFIX]
-* [MODDATAIMP-403](https://issues.folio.org/browse/MODDATAIMP-403) Some data import jobs stuck on folio-snapshot-load
+* [MODSOURMAN-435](https://issues.folio.org/browse/MODSOURMAN-435) Some data import jobs stuck on folio-snapshot-load
 * [MODSOURMAN-428](https://issues.folio.org/browse/MODSOURMAN-428) Ensure exactly one delivery approach for handler receiving stored records
 * [MODSOURMAN-430](https://issues.folio.org/browse/MODSOURMAN-430) Ensure exactly one delivery approach for for data import log handler
+
+## 2021-04-05 v3.0.2
+* [MODSOURMAN-429](https://issues.folio.org/browse/MODSOURMAN-429) Add permission to /change-manager/jobExecutions/{id}/jobProfile
 
 ## 2021-03-28 v3.0.1
 * [MODSOURMAN-421](https://issues.folio.org/browse/MODSOURMAN-421) Syntax problem for 561 field in default mapping rules

--- a/mod-source-record-manager-server/src/test/java/org/folio/verticle/consumers/DataImportJournalConsumerVerticleMockTest.java
+++ b/mod-source-record-manager-server/src/test/java/org/folio/verticle/consumers/DataImportJournalConsumerVerticleMockTest.java
@@ -14,6 +14,7 @@ import org.folio.DataImportEventPayload;
 import org.folio.dao.JournalRecordDaoImpl;
 import org.folio.dao.util.PostgresClientFactory;
 import org.folio.kafka.KafkaTopicNameHelper;
+import org.folio.kafka.cache.KafkaInternalCache;
 import org.folio.processing.events.utils.ZIPArchiver;
 import org.folio.rest.impl.AbstractRestTest;
 import org.folio.rest.jaxrs.model.Event;
@@ -30,6 +31,7 @@ import org.mockito.ArgumentCaptor;
 import org.mockito.ArgumentMatchers;
 import org.mockito.Captor;
 import org.mockito.InjectMocks;
+import org.mockito.Mock;
 import org.mockito.Mockito;
 import org.mockito.MockitoAnnotations;
 import org.mockito.Spy;
@@ -53,7 +55,15 @@ import static org.folio.rest.jaxrs.model.JournalRecord.EntityType.MARC_BIBLIOGRA
 import static org.folio.rest.util.OkapiConnectionParams.OKAPI_TENANT_HEADER;
 import static org.folio.rest.util.OkapiConnectionParams.OKAPI_TOKEN_HEADER;
 import static org.folio.services.journal.JournalUtil.ERROR_KEY;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 @RunWith(VertxUnitRunner.class)
 public class DataImportJournalConsumerVerticleMockTest extends AbstractRestTest {
@@ -72,6 +82,9 @@ public class DataImportJournalConsumerVerticleMockTest extends AbstractRestTest 
 
   @Spy
   private final PostgresClientFactory postgresClientFactory = new PostgresClientFactory(Vertx.vertx());
+
+  @Mock
+  private KafkaInternalCache kafkaInternalCache;
 
   @Spy
   private final JournalServiceImpl journalService = new JournalServiceImpl(journalRecordDao);
@@ -102,7 +115,8 @@ public class DataImportJournalConsumerVerticleMockTest extends AbstractRestTest 
   @Before
   public void setUp() {
     MockitoAnnotations.initMocks(this);
-    dataImportJournalKafkaHandler = new DataImportJournalKafkaHandler(vertx, journalService);
+    dataImportJournalKafkaHandler = new DataImportJournalKafkaHandler(vertx, kafkaInternalCache, journalService);
+    when(kafkaInternalCache.containsByKey(anyString())).thenReturn(false);
   }
 
   @Test
@@ -246,9 +260,31 @@ public class DataImportJournalConsumerVerticleMockTest extends AbstractRestTest 
     Assert.assertNotNull(jsonObject.getString("error"));
   }
 
+  @Test
+  public void shouldProcessEventWhenKafkaCacheContainsEventId() throws IOException {
+    // given
+    when(kafkaInternalCache.containsByKey(anyString())).thenReturn(true);
+    Mockito.doNothing().when(journalService).save(ArgumentMatchers.any(JsonObject.class), ArgumentMatchers.any(String.class));
+
+    DataImportEventPayload dataImportEventPayload = new DataImportEventPayload()
+      .withEventType(DI_INVENTORY_INSTANCE_CREATED.value())
+      .withJobExecutionId(jobExecution.getId())
+      .withContext(new HashMap<>())
+      .withOkapiUrl(OKAPI_URL)
+      .withTenant(TENANT_ID);
+
+    // when
+    KafkaConsumerRecord<String, String> kafkaConsumerRecord = buildKafkaConsumerRecord(dataImportEventPayload);
+    dataImportJournalKafkaHandler.handle(kafkaConsumerRecord);
+
+    // then
+    verify(kafkaInternalCache, times(1)).containsByKey(anyString());
+    verify(journalService, never()).save(any(JsonObject.class), eq(TENANT_ID));
+  }
+
   private KafkaConsumerRecord<String, String> buildKafkaConsumerRecord(DataImportEventPayload record) throws IOException {
     String topic = KafkaTopicNameHelper.formatTopicName(ENV_KEY, getDefaultNameSpace(), TENANT_ID, record.getEventType());
-    Event event = new Event().withEventPayload(ZIPArchiver.zip(Json.encode(record)));
+    Event event = new Event().withId(UUID.randomUUID().toString()).withEventPayload(ZIPArchiver.zip(Json.encode(record)));
     ConsumerRecord<String, String> consumerRecord = buildConsumerRecord(topic, event);
     return new KafkaConsumerRecordImpl<>(consumerRecord);
   }

--- a/mod-source-record-manager-server/src/test/java/org/folio/verticle/consumers/DataImportJournalConsumerVerticleTest.java
+++ b/mod-source-record-manager-server/src/test/java/org/folio/verticle/consumers/DataImportJournalConsumerVerticleTest.java
@@ -18,6 +18,7 @@ import org.folio.DataImportEventPayload;
 import org.folio.dao.JobExecutionDaoImpl;
 import org.folio.dao.JournalRecordDao;
 import org.folio.kafka.KafkaTopicNameHelper;
+import org.folio.kafka.cache.KafkaInternalCache;
 import org.folio.processing.events.utils.ZIPArchiver;
 import org.folio.rest.impl.AbstractRestTest;
 import org.folio.rest.jaxrs.model.Event;
@@ -60,6 +61,7 @@ import static org.folio.rest.util.OkapiConnectionParams.OKAPI_TOKEN_HEADER;
 @RunWith(VertxUnitRunner.class)
 public class DataImportJournalConsumerVerticleTest extends AbstractRestTest {
 
+  private KafkaInternalCache kafkaInternalCache;
   private JournalService journalService;
   private JobExecutionDaoImpl jobExecutionDao;
   private JournalRecordDao journalRecordDao;
@@ -100,7 +102,10 @@ public class DataImportJournalConsumerVerticleTest extends AbstractRestTest {
     journalService = getBeanFromSpringContext(vertx, org.folio.services.journal.JournalServiceImpl.class);
     Assert.assertNotNull(journalService);
 
-    dataImportJournalKafkaHandler = new DataImportJournalKafkaHandler(vertx, journalService);
+    kafkaInternalCache = getBeanFromSpringContext(vertx, KafkaInternalCache.class);
+    Assert.assertNotNull(kafkaInternalCache);
+
+    dataImportJournalKafkaHandler = new DataImportJournalKafkaHandler(vertx, kafkaInternalCache, journalService);
   }
 
   @Test

--- a/mod-source-record-manager-server/src/test/java/org/folio/verticle/consumers/ImportInvoiceJournalConsumerVerticleMockTest.java
+++ b/mod-source-record-manager-server/src/test/java/org/folio/verticle/consumers/ImportInvoiceJournalConsumerVerticleMockTest.java
@@ -19,6 +19,7 @@ import org.folio.Record;
 import org.folio.dao.JournalRecordDaoImpl;
 import org.folio.dao.util.PostgresClientFactory;
 import org.folio.kafka.KafkaTopicNameHelper;
+import org.folio.kafka.cache.KafkaInternalCache;
 import org.folio.processing.events.utils.ZIPArchiver;
 import org.folio.rest.impl.AbstractRestTest;
 import org.folio.rest.jaxrs.model.Event;
@@ -34,6 +35,7 @@ import org.mockito.ArgumentCaptor;
 import org.mockito.ArgumentMatchers;
 import org.mockito.Captor;
 import org.mockito.InjectMocks;
+import org.mockito.Mock;
 import org.mockito.Mockito;
 import org.mockito.MockitoAnnotations;
 import org.mockito.Spy;
@@ -64,6 +66,8 @@ import static org.folio.services.journal.InvoiceUtil.INVOICE_LINES_ERRORS_KEY;
 import static org.folio.services.journal.InvoiceUtil.INVOICE_LINES_KEY;
 import static org.folio.services.journal.InvoiceUtil.INVOICE_TITLE;
 import static org.folio.services.journal.JournalUtil.ERROR_KEY;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.when;
 
 @RunWith(VertxUnitRunner.class)
 public class ImportInvoiceJournalConsumerVerticleMockTest extends AbstractRestTest {
@@ -86,6 +90,9 @@ public class ImportInvoiceJournalConsumerVerticleMockTest extends AbstractRestTe
 
   @Spy
   private JournalServiceImpl journalService = new JournalServiceImpl(journalRecordDao);
+
+  @Mock
+  private KafkaInternalCache kafkaInternalCache;
 
   @Captor
   private ArgumentCaptor<JsonArray> invoiceRecordCaptor;
@@ -131,7 +138,8 @@ public class ImportInvoiceJournalConsumerVerticleMockTest extends AbstractRestTe
   @Before
   public void setUp() {
     MockitoAnnotations.initMocks(this);
-    dataImportJournalKafkaHandler = new DataImportJournalKafkaHandler(vertx, journalService);
+    when(kafkaInternalCache.containsByKey(anyString())).thenReturn(false);
+    dataImportJournalKafkaHandler = new DataImportJournalKafkaHandler(vertx, kafkaInternalCache, journalService);
   }
 
   @Test
@@ -234,7 +242,7 @@ public class ImportInvoiceJournalConsumerVerticleMockTest extends AbstractRestTe
   }
 
   @Test
-  public void shouldProcessInvoiceLineErrorEvent(TestContext context) throws IOException, JournalRecordMapperException {
+  public void shouldProcessInvoiceLineErrorEvent(TestContext context) throws IOException {
     Async async = context.async();
 
     // given

--- a/mod-source-record-manager-server/src/test/java/org/folio/verticle/consumers/ImportInvoiceJournalConsumerVerticleTest.java
+++ b/mod-source-record-manager-server/src/test/java/org/folio/verticle/consumers/ImportInvoiceJournalConsumerVerticleTest.java
@@ -20,6 +20,7 @@ import org.folio.Record;
 import org.folio.dao.JobExecutionDaoImpl;
 import org.folio.dao.JournalRecordDao;
 import org.folio.kafka.KafkaTopicNameHelper;
+import org.folio.kafka.cache.KafkaInternalCache;
 import org.folio.processing.events.utils.ZIPArchiver;
 import org.folio.rest.impl.AbstractRestTest;
 import org.folio.rest.jaxrs.model.Event;
@@ -64,6 +65,7 @@ import static org.folio.verticle.consumers.ImportInvoiceJournalConsumerVerticleM
 @RunWith(VertxUnitRunner.class)
 public class ImportInvoiceJournalConsumerVerticleTest extends AbstractRestTest {
 
+  private KafkaInternalCache kafkaInternalCache;
   private JournalService journalService;
   private JobExecutionDaoImpl jobExecutionDao;
   private JournalRecordDao journalRecordDao;
@@ -99,7 +101,10 @@ public class ImportInvoiceJournalConsumerVerticleTest extends AbstractRestTest {
     journalService = getBeanFromSpringContext(vertx, org.folio.services.journal.JournalServiceImpl.class);
     Assert.assertNotNull(journalService);
 
-    dataImportJournalKafkaHandler = new DataImportJournalKafkaHandler(vertx, journalService);
+    kafkaInternalCache = getBeanFromSpringContext(vertx, KafkaInternalCache.class);
+    Assert.assertNotNull(kafkaInternalCache);
+
+    dataImportJournalKafkaHandler = new DataImportJournalKafkaHandler(vertx, kafkaInternalCache, journalService);
   }
 
   String INVOICE_ID = UUID.randomUUID().toString();


### PR DESCRIPTION
## Purpose
to expand exactly one delivery approach for chunks of saved records in srs

## Approach
* KafkaInternalCache was used for event deduplication
* consumed event id is preceded with `DataImportJournalKafkaHandler` handler class name before placement to the cache to distinguish the same identifiers placed in the cache by other handlers (for instance by handler from mod-inventory)

## Learning
[MODSOURMAN-430](https://issues.folio.org/browse/MODSOURMAN-430)
