### PR TITLE
MODSOURMAN-437 - Add logging for event correlationId

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -4,6 +4,7 @@
 * [MODSOURMAN-435](https://issues.folio.org/browse/MODSOURMAN-435) Some data import jobs stuck on folio-snapshot-load
 * [MODSOURMAN-428](https://issues.folio.org/browse/MODSOURMAN-428) Ensure exactly one delivery approach for handler receiving stored records
 * [MODSOURMAN-430](https://issues.folio.org/browse/MODSOURMAN-430) Ensure exactly one delivery approach for for data import log handler
+* [MODSOURMAN-437](https://issues.folio.org/browse/MODSOURMAN-437) Add logging for event correlationId
 
 ## 2021-04-05 v3.0.2
 * [MODSOURMAN-429](https://issues.folio.org/browse/MODSOURMAN-429) Add permission to /change-manager/jobExecutions/{id}/jobProfile

--- a/mod-source-record-manager-server/pom.xml
+++ b/mod-source-record-manager-server/pom.xml
@@ -204,7 +204,7 @@
     <dependency>
       <groupId>org.folio</groupId>
       <artifactId>data-import-processing-core</artifactId>
-      <version>3.0.0</version>
+      <version>3.1.0-SNAPSHOT</version>
     </dependency>
   </dependencies>
   <build>

--- a/mod-source-record-manager-server/src/main/java/org/folio/verticle/consumers/DataImportJournalKafkaHandler.java
+++ b/mod-source-record-manager-server/src/main/java/org/folio/verticle/consumers/DataImportJournalKafkaHandler.java
@@ -17,7 +17,6 @@ import org.folio.kafka.cache.KafkaInternalCache;
 import org.folio.processing.events.utils.ZIPArchiver;
 import org.folio.rest.jaxrs.model.Event;
 import org.folio.services.journal.JournalService;
-import org.folio.services.util.EventHandlingUtil;
 import org.folio.verticle.consumers.util.EventTypeHandlerSelector;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
@@ -26,7 +25,7 @@ import org.springframework.stereotype.Component;
 import java.util.List;
 
 import static java.lang.String.format;
-import static org.folio.services.util.EventHandlingUtil.CORRELATION_ID_HEADER;
+import static org.folio.services.RecordsPublishingServiceImpl.CORRELATION_ID_HEADER;
 
 @Component
 @Qualifier("DataImportJournalKafkaHandler")

--- a/mod-source-record-manager-server/src/main/java/org/folio/verticle/consumers/DataImportJournalKafkaHandler.java
+++ b/mod-source-record-manager-server/src/main/java/org/folio/verticle/consumers/DataImportJournalKafkaHandler.java
@@ -17,6 +17,7 @@ import org.folio.kafka.cache.KafkaInternalCache;
 import org.folio.processing.events.utils.ZIPArchiver;
 import org.folio.rest.jaxrs.model.Event;
 import org.folio.services.journal.JournalService;
+import org.folio.services.util.EventHandlingUtil;
 import org.folio.verticle.consumers.util.EventTypeHandlerSelector;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
@@ -25,6 +26,7 @@ import org.springframework.stereotype.Component;
 import java.util.List;
 
 import static java.lang.String.format;
+import static org.folio.services.util.EventHandlingUtil.CORRELATION_ID_HEADER;
 
 @Component
 @Qualifier("DataImportJournalKafkaHandler")
@@ -50,8 +52,9 @@ public class DataImportJournalKafkaHandler implements AsyncRecordHandler<String,
     Promise<String> result = Promise.promise();
     List<KafkaHeader> kafkaHeaders = record.headers();
     OkapiConnectionParams okapiConnectionParams = new OkapiConnectionParams(KafkaHeaderUtils.kafkaHeadersToMap(kafkaHeaders), vertx);
+    String correlationId = okapiConnectionParams.getHeaders().get(CORRELATION_ID_HEADER);
     Event event = new JsonObject(record.value()).mapTo(Event.class);
-    LOGGER.debug("Event was received: {}", event.getEventType());
+    LOGGER.debug("Event was received with correlationId: {} event type: {}", correlationId, event.getEventType());
     String handlerBasedEventId = format("%s-%s", EVENT_ID_PREFIX, event.getId());
 
     try {

--- a/mod-source-record-manager-server/src/main/java/org/folio/verticle/consumers/DataImportKafkaHandler.java
+++ b/mod-source-record-manager-server/src/main/java/org/folio/verticle/consumers/DataImportKafkaHandler.java
@@ -4,23 +4,22 @@ import io.vertx.core.Future;
 import io.vertx.core.Promise;
 import io.vertx.core.Vertx;
 import io.vertx.core.json.JsonObject;
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
 import io.vertx.kafka.client.consumer.KafkaConsumerRecord;
 import io.vertx.kafka.client.producer.KafkaHeader;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.folio.dataimport.util.OkapiConnectionParams;
 import org.folio.kafka.AsyncRecordHandler;
 import org.folio.kafka.KafkaHeaderUtils;
 import org.folio.rest.jaxrs.model.Event;
 import org.folio.services.EventHandlingService;
-import org.folio.services.util.EventHandlingUtil;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.stereotype.Component;
 
 import java.util.List;
 
-import static org.folio.services.util.EventHandlingUtil.CORRELATION_ID_HEADER;
+import static org.folio.services.RecordsPublishingServiceImpl.CORRELATION_ID_HEADER;
 
 @Component
 @Qualifier("DataImportKafkaHandler")


### PR DESCRIPTION
## Purpose
to facilitate tracing of processing of a particular record

## Approach
* new correlationId is set before publishing event with particular record
* correlationId is logged from a kafka event header


## Learning
[MODSOURMAN-437](https://issues.folio.org/browse/MODSOURMAN-437)
