### PR TITLE
MODSOURMAN-436 Slow Query Invoked on DI Home Page

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -5,6 +5,7 @@
 * [MODSOURMAN-428](https://issues.folio.org/browse/MODSOURMAN-428) Ensure exactly one delivery approach for handler receiving stored records
 * [MODSOURMAN-430](https://issues.folio.org/browse/MODSOURMAN-430) Ensure exactly one delivery approach for for data import log handler
 * [MODSOURMAN-437](https://issues.folio.org/browse/MODSOURMAN-437) Add logging for event correlationId
+* [MODSOURMAN-436](https://issues.folio.org/browse/MODSOURMAN-436) Slow Query Invoked on DI Home Page
 
 ## 2021-04-05 v3.0.2
 * [MODSOURMAN-429](https://issues.folio.org/browse/MODSOURMAN-429) Add permission to /change-manager/jobExecutions/{id}/jobProfile

--- a/mod-source-record-manager-server/src/main/java/org/folio/rest/impl/MetadataProviderImpl.java
+++ b/mod-source-record-manager-server/src/main/java/org/folio/rest/impl/MetadataProviderImpl.java
@@ -13,6 +13,7 @@ import org.folio.rest.jaxrs.model.MetadataProviderJournalRecordsJobExecutionIdGe
 import org.folio.rest.jaxrs.resource.MetadataProvider;
 import org.folio.rest.tools.utils.TenantTool;
 import org.folio.services.JobExecutionService;
+import org.folio.services.JobExecutionsCache;
 import org.folio.services.JournalRecordService;
 import org.folio.spring.SpringContextUtil;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -29,6 +30,8 @@ public class MetadataProviderImpl implements MetadataProvider {
   @Autowired
   private JournalRecordService journalRecordService;
   private String tenantId;
+  @Autowired
+  private JobExecutionsCache jobExecutionsCache;
 
   public MetadataProviderImpl(Vertx vertx, String tenantId) { //NOSONAR
     SpringContextUtil.autowireDependencies(this, Vertx.currentContext());
@@ -40,7 +43,7 @@ public class MetadataProviderImpl implements MetadataProvider {
                                                Handler<AsyncResult<Response>> asyncResultHandler, Context vertxContext) {
     vertxContext.runOnContext(v -> {
       try {
-        jobExecutionService.getJobExecutionsWithoutParentMultiple(query, offset, limit, tenantId)
+        jobExecutionsCache.get(tenantId, query, offset, limit)
           .map(GetMetadataProviderJobExecutionsResponse::respond200WithApplicationJson)
           .map(Response.class::cast)
           .otherwise(ExceptionHelper::mapExceptionToResponse)
@@ -72,7 +75,7 @@ public class MetadataProviderImpl implements MetadataProvider {
 
   @Override
   public void getMetadataProviderJournalRecordsByJobExecutionId(String jobExecutionId, String sortBy, MetadataProviderJournalRecordsJobExecutionIdGetOrder order,
-    Map<String, String> okapiHeaders, Handler<AsyncResult<Response>> asyncResultHandler, Context vertxContext) {
+                                                                Map<String, String> okapiHeaders, Handler<AsyncResult<Response>> asyncResultHandler, Context vertxContext) {
 
     vertxContext.runOnContext(v -> {
       try {
@@ -92,7 +95,7 @@ public class MetadataProviderImpl implements MetadataProvider {
 
   @Override
   public void getMetadataProviderJobLogEntriesByJobExecutionId(String jobExecutionId, String sortBy, MetadataProviderJobLogEntriesJobExecutionIdGetOrder order,
-    int offset, int limit, Map<String, String> okapiHeaders, Handler<AsyncResult<Response>> asyncResultHandler, Context vertxContext) {
+                                                               int offset, int limit, Map<String, String> okapiHeaders, Handler<AsyncResult<Response>> asyncResultHandler, Context vertxContext) {
 
     vertxContext.runOnContext(v -> {
       try {

--- a/mod-source-record-manager-server/src/main/java/org/folio/services/JobExecutionsCache.java
+++ b/mod-source-record-manager-server/src/main/java/org/folio/services/JobExecutionsCache.java
@@ -36,12 +36,6 @@ public class JobExecutionsCache {
     cache = buildCache();
   }
 
-  /**
-   * Returns mapping rules associated with specified tenant id
-   *
-   * @param tenantId tenant id
-   * @return optional with mapping rules
-   */
   public Future<JobExecutionCollection> get(String tenantId, String cqlQuery, int offset, int limit) {
     Promise<JobExecutionCollection> promise = Promise.promise();
     cache.get(Pair.of(tenantId, cqlQuery)).whenComplete((jobExecutionOptional, e) -> {

--- a/mod-source-record-manager-server/src/main/java/org/folio/services/JobExecutionsCache.java
+++ b/mod-source-record-manager-server/src/main/java/org/folio/services/JobExecutionsCache.java
@@ -1,0 +1,80 @@
+package org.folio.services;
+
+import com.github.benmanes.caffeine.cache.AsyncLoadingCache;
+import com.github.benmanes.caffeine.cache.Caffeine;
+import io.vertx.core.Future;
+import io.vertx.core.Promise;
+import io.vertx.core.Vertx;
+import org.apache.commons.lang3.tuple.Pair;
+import org.folio.rest.jaxrs.model.JobExecutionCollection;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+import java.util.Optional;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * In-memory cache for the job executions and DI landing page
+ */
+@Component
+public class JobExecutionsCache {
+
+  private Integer expireInSeconds;
+  private JobExecutionService jobExecutionService;
+  // Pair of tenant id and cql query
+  private AsyncLoadingCache<Pair<String, String>, Optional<JobExecutionCollection>> cache;
+  private Vertx vertx;
+
+  @Autowired
+  public JobExecutionsCache(JobExecutionService jobExecutionService, Vertx vertx,
+                            @Value("${srm.job.execution.cache.expire.seconds:30}") Integer expireInSeconds) {
+    this.expireInSeconds = expireInSeconds;
+    this.jobExecutionService = jobExecutionService;
+    this.vertx = vertx;
+    cache = buildCache();
+  }
+
+  /**
+   * Returns mapping rules associated with specified tenant id
+   *
+   * @param tenantId tenant id
+   * @return optional with mapping rules
+   */
+  public Future<JobExecutionCollection> get(String tenantId, String cqlQuery, int offset, int limit) {
+    Promise<JobExecutionCollection> promise = Promise.promise();
+    cache.get(Pair.of(tenantId, cqlQuery)).whenComplete((jobExecutionOptional, e) -> {
+      if (e == null) {
+        if (jobExecutionOptional != null && jobExecutionOptional.isPresent()) {
+          promise.complete(jobExecutionOptional.get());
+        } else {
+          jobExecutionService.getJobExecutionsWithoutParentMultiple(cqlQuery, offset, limit, tenantId)
+            .onSuccess(ar -> {
+              put(tenantId, cqlQuery, ar);
+              promise.complete(ar);
+            })
+            .onFailure(promise::fail);
+        }
+      } else {
+        promise.fail(e);
+      }
+    });
+    return promise.future();
+  }
+
+  private void put(String tenantId, String cqlQuery, JobExecutionCollection jobExecutionCollection) {
+    cache.put(Pair.of(tenantId, cqlQuery), CompletableFuture.completedFuture(Optional.of(jobExecutionCollection)));
+  }
+
+  private AsyncLoadingCache<Pair<String, String>, Optional<JobExecutionCollection>> buildCache() {
+    return Caffeine.newBuilder()
+      .executor(task -> vertx.runOnContext(ar -> task.run()))
+      .expireAfterWrite(expireInSeconds, TimeUnit.SECONDS)
+      .buildAsync((key, executor) -> CompletableFuture.completedFuture(Optional.empty()));
+  }
+
+  public void evictCache() {
+    cache = buildCache();
+  }
+}

--- a/mod-source-record-manager-server/src/test/java/org/folio/rest/impl/metadataProvider/MetadataProviderJobExecutionAPITest.java
+++ b/mod-source-record-manager-server/src/test/java/org/folio/rest/impl/metadataProvider/MetadataProviderJobExecutionAPITest.java
@@ -22,6 +22,7 @@ import org.folio.rest.jaxrs.model.Progress;
 import org.folio.rest.jaxrs.model.RawRecordsDto;
 import org.folio.rest.jaxrs.model.RecordsMetadata;
 import org.folio.rest.jaxrs.model.StatusDto;
+import org.folio.services.JobExecutionsCache;
 import org.hamcrest.Matchers;
 import org.junit.Assert;
 import org.junit.Ignore;
@@ -75,6 +76,7 @@ public class MetadataProviderJobExecutionAPITest extends AbstractRestTest {
 
   @Test
   public void shouldReturnEmptyListIfNoJobExecutionsExist() {
+    getBeanFromSpringContext(vertx, JobExecutionsCache.class).evictCache();
     RestAssured.given()
       .spec(spec)
       .when()
@@ -106,6 +108,7 @@ public class MetadataProviderJobExecutionAPITest extends AbstractRestTest {
     List<JobExecution> createdJobExecution = constructAndPostInitJobExecutionRqDto(5).getJobExecutions();
     int givenJobExecutionsNumber = createdJobExecution.size();
     // We do not expect to get JobExecution with subordinationType=PARENT_MULTIPLE
+    getBeanFromSpringContext(vertx, JobExecutionsCache.class).evictCache();
     int expectedJobExecutionsNumber = givenJobExecutionsNumber - 1;
     RestAssured.given()
       .spec(spec)

--- a/mod-source-record-manager-server/src/test/java/org/folio/verticle/consumers/DataImportJournalConsumerVerticleTest.java
+++ b/mod-source-record-manager-server/src/test/java/org/folio/verticle/consumers/DataImportJournalConsumerVerticleTest.java
@@ -256,21 +256,4 @@ public class DataImportJournalConsumerVerticleTest extends AbstractRestTest {
     return consumerRecord;
   }
 
-  private <T> T getBeanFromSpringContext(Vertx vtx, Class<T> clazz) {
-
-    String parentVerticleUUID = vertx.deploymentIDs().stream()
-      .filter(v -> !((VertxImpl) vertx).getDeployment(v).isChild())
-      .findFirst()
-      .orElseThrow(() -> new NotFoundException("Couldn't find the parent verticle."));
-
-    Optional<Object> context = Optional.of(((VertxImpl) vtx).getDeployment(parentVerticleUUID).getContexts().stream()
-      .findFirst().map(v -> v.get("springContext")))
-      .orElseThrow(() -> new NotFoundException("Couldn't find the spring context."));
-
-    if (context.isPresent()) {
-      return ((AnnotationConfigApplicationContext) context.get()).getBean(clazz);
-    }
-    throw new NotFoundException(String.format("Couldn't find bean %s", clazz.getName()));
-  }
-
 }

--- a/mod-source-record-manager-server/src/test/java/org/folio/verticle/consumers/ImportInvoiceJournalConsumerVerticleTest.java
+++ b/mod-source-record-manager-server/src/test/java/org/folio/verticle/consumers/ImportInvoiceJournalConsumerVerticleTest.java
@@ -192,21 +192,4 @@ public class ImportInvoiceJournalConsumerVerticleTest extends AbstractRestTest {
     return consumerRecord;
   }
 
-  private <T> T getBeanFromSpringContext(Vertx vtx, Class<T> clazz) {
-
-    String parentVerticleUUID = vertx.deploymentIDs().stream()
-      .filter(v -> !((VertxImpl) vertx).getDeployment(v).isChild())
-      .findFirst()
-      .orElseThrow(() -> new NotFoundException("Couldn't find the parent verticle."));
-
-    Optional<Object> context = Optional.of(((VertxImpl) vtx).getDeployment(parentVerticleUUID).getContexts().stream()
-      .findFirst().map(v -> v.get("springContext")))
-      .orElseThrow(() -> new NotFoundException("Couldn't find the spring context."));
-
-    if (context.isPresent()) {
-      return ((AnnotationConfigApplicationContext) context.get()).getBean(clazz);
-    }
-    throw new NotFoundException(String.format("Couldn't find bean %s", clazz.getName()));
-  }
-
 }


### PR DESCRIPTION
## Purpose
The Data Import landing page queries the back-end SRM for the job's status. The SQL query to poll is not performant and can use up to 10% of CPU for one user. 

## Approach
Cache was added
