### PR TITLE
MODSOURMAN-509 - Data import stopped process before finishing: deadlock for job_monitoring

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,4 +1,5 @@
-## xxxx-xx-xx v3.2.0-SNAPSHOT
+## 2021-07-06 v3.2.0-SNAPSHOT
+* [MODSOURMAN-509](https://issues.folio.org/browse/MODSOURMAN-509) Data import stopped process before finishing: deadlock for "job_monitoring"
 
 ## 2021-06-17 v3.1.0
 * [MODSOURMAN-411](https://issues.folio.org/browse/MODSOURMAN-411) Dynamically define the payload of DI event depending on MARC record type (Bib, Authority, Holding)

--- a/mod-source-record-manager-server/src/main/java/org/folio/services/progress/JobExecutionProgressServiceImpl.java
+++ b/mod-source-record-manager-server/src/main/java/org/folio/services/progress/JobExecutionProgressServiceImpl.java
@@ -3,7 +3,6 @@ package org.folio.services.progress;
 import io.vertx.core.Future;
 import org.folio.dao.JobExecutionProgressDao;
 import org.folio.rest.jaxrs.model.JobExecutionProgress;
-import org.folio.rest.jaxrs.model.JobMonitoring;
 import org.folio.services.JobMonitoringService;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
@@ -42,8 +41,7 @@ public class JobExecutionProgressServiceImpl implements JobExecutionProgressServ
 
   @Override
   public Future<JobExecutionProgress> updateJobExecutionProgress(String jobExecutionId, UnaryOperator<JobExecutionProgress> progressMutator, String tenantId) {
-    return jobExecutionProgressDao.updateByJobExecutionId(jobExecutionId, progressMutator, tenantId)
-      .compose(jobExecutionProgress -> jobMonitoringService.updateByJobExecutionId(jobExecutionId, new Date(), false, tenantId)
-        .map(jobExecutionProgress));
+    jobMonitoringService.updateByJobExecutionId(jobExecutionId, new Date(), false, tenantId);
+    return jobExecutionProgressDao.updateByJobExecutionId(jobExecutionId, progressMutator, tenantId);
   }
 }


### PR DESCRIPTION
## Purpose
The purpose is to fix the deadlock that is caused by updating the "job_monitoring" and  "job_execution_progress" tables
See https://issues.folio.org/browse/MODSOURMAN-509 for more details.

## Approach
The approach is to update "job_monitoring" and  "job_execution_progress" tables independently so that exceptions from updating "job_monitoring" will not affect updates for "job_execution_progress".

The approach is tested on the local machine,  now we need to verify it on reference envs using various import properties and marc files

#### TODOS and Open Questions
- [ ] Use GitHub checklists. When solved, check the box and explain the answer.

## Learning
_Describe the research stage. Add links to blog posts, patterns, libraries or addons used to solve this problem._
