### PR TITLE
MODSOURMAN-508 - Log details for Inventory single record imports for Overlays - Part 2

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,13 @@
 ## 2021-07-06 v3.2.0-SNAPSHOT
 * [MODSOURMAN-509](https://issues.folio.org/browse/MODSOURMAN-509) Data import stopped process before finishing: deadlock for "job_monitoring"
 
+## xxxx-xx-xx v3.1.2-SNAPSHOT
+* [MODSOURMAN-508](https://issues.folio.org/browse/MODSOURMAN-508) Log details for Inventory single record imports for Overlays
+
+## 2021-06-25 v3.1.1
+* [MODSOURMAN-497](https://issues.folio.org/browse/MODSOURMAN-497) Apply MarcRecordAnalyzer to determine MARC related specific type
+* [MODSOURMAN-501](https://issues.folio.org/browse/MODSOURMAN-501) Change dataType to have have common type for MARC related subtypes
+
 ## 2021-06-17 v3.1.0
 * [MODSOURMAN-411](https://issues.folio.org/browse/MODSOURMAN-411) Dynamically define the payload of DI event depending on MARC record type (Bib, Authority, Holding)
 * [MODSOURMAN-448](https://issues.folio.org/browse/MODSOURMAN-448) Update default field mapping for 647 field

--- a/mod-source-record-manager-server/src/main/java/org/folio/services/ChangeEngineServiceImpl.java
+++ b/mod-source-record-manager-server/src/main/java/org/folio/services/ChangeEngineServiceImpl.java
@@ -126,12 +126,8 @@ public class ChangeEngineServiceImpl implements ChangeEngineService {
     if (updateMarcActionExists) {
       LOGGER.info("Records have not been saved in record-storage, because jobProfileSnapshotWrapper contains action for Marc-Bibliographic update");
       recordsPublishingService.sendEventsWithRecords(parsedRecords, jobExecution.getId(), params, DI_MARC_BIB_FOR_UPDATE_RECEIVED.value())
-        .compose(ar -> buildJournalRecordsForProcessedRecords(parsedRecords, parsedRecords, CREATE, params.getTenantId())
-          .compose(journalRecords -> {
-            journalService.saveBatch(new JsonArray(journalRecords), params.getTenantId());
-            promise.complete(parsedRecords);
-            return Future.succeededFuture();
-          }));
+        .onSuccess(ar -> promise.complete(parsedRecords))
+        .onFailure(promise::fail);
     } else {
       saveRecords(params, jobExecution, parsedRecords)
         .onComplete(postAr -> {

--- a/mod-source-record-manager-server/src/main/java/org/folio/verticle/DataImportJournalConsumersVerticle.java
+++ b/mod-source-record-manager-server/src/main/java/org/folio/verticle/DataImportJournalConsumersVerticle.java
@@ -34,7 +34,6 @@ public class DataImportJournalConsumersVerticle extends AbstractConsumersVerticl
   @Override
   public List<String> getEvents() {
     return List.of(
-      DI_SRS_MARC_BIB_RECORD_UPDATED.value(),
       DI_SRS_MARC_BIB_RECORD_MODIFIED.value(),
       DI_SRS_MARC_BIB_RECORD_NOT_MATCHED.value(),
       DI_INVENTORY_INSTANCE_CREATED.value(),

--- a/mod-source-record-manager-server/src/main/java/org/folio/verticle/DataImportJournalConsumersVerticle.java
+++ b/mod-source-record-manager-server/src/main/java/org/folio/verticle/DataImportJournalConsumersVerticle.java
@@ -18,6 +18,8 @@ import static org.folio.rest.jaxrs.model.DataImportEventTypes.DI_INVENTORY_INSTA
 import static org.folio.rest.jaxrs.model.DataImportEventTypes.DI_INVENTORY_ITEM_CREATED;
 import static org.folio.rest.jaxrs.model.DataImportEventTypes.DI_INVENTORY_ITEM_NOT_MATCHED;
 import static org.folio.rest.jaxrs.model.DataImportEventTypes.DI_INVENTORY_ITEM_UPDATED;
+import static org.folio.rest.jaxrs.model.DataImportEventTypes.DI_LOG_SRS_MARC_BIB_RECORD_CREATED;
+import static org.folio.rest.jaxrs.model.DataImportEventTypes.DI_LOG_SRS_MARC_BIB_RECORD_UPDATED;
 import static org.folio.rest.jaxrs.model.DataImportEventTypes.DI_SRS_MARC_BIB_RECORD_MODIFIED;
 import static org.folio.rest.jaxrs.model.DataImportEventTypes.DI_SRS_MARC_BIB_RECORD_MODIFIED_READY_FOR_POST_PROCESSING;
 import static org.folio.rest.jaxrs.model.DataImportEventTypes.DI_SRS_MARC_BIB_RECORD_NOT_MATCHED;
@@ -46,6 +48,8 @@ public class DataImportJournalConsumersVerticle extends AbstractConsumersVerticl
       DI_INVENTORY_ITEM_UPDATED.value(),
       DI_INVENTORY_ITEM_NOT_MATCHED.value(),
       DI_INVOICE_CREATED.value(),
+      DI_LOG_SRS_MARC_BIB_RECORD_CREATED.value(),
+      DI_LOG_SRS_MARC_BIB_RECORD_UPDATED.value(),
       DI_COMPLETED.value(),
       DI_ERROR.value()
     );

--- a/mod-source-record-manager-server/src/main/java/org/folio/verticle/consumers/DataImportJournalKafkaHandler.java
+++ b/mod-source-record-manager-server/src/main/java/org/folio/verticle/consumers/DataImportJournalKafkaHandler.java
@@ -36,7 +36,6 @@ public class DataImportJournalKafkaHandler implements AsyncRecordHandler<String,
   private Vertx vertx;
   private JournalService journalService;
   private KafkaInternalCache kafkaInternalCache;
-//  private EventTypeHandlerSelector eventTypeHandlerSelector = new EventTypeHandlerSelector();
   private EventTypeHandlerSelector eventTypeHandlerSelector;
 
   public DataImportJournalKafkaHandler(@Autowired Vertx vertx,
@@ -46,7 +45,6 @@ public class DataImportJournalKafkaHandler implements AsyncRecordHandler<String,
     this.vertx = vertx;
     this.journalService = journalService;
     this.kafkaInternalCache = kafkaInternalCache;
-
     this.eventTypeHandlerSelector = eventTypeHandlerSelector;
   }
 

--- a/mod-source-record-manager-server/src/main/java/org/folio/verticle/consumers/DataImportJournalKafkaHandler.java
+++ b/mod-source-record-manager-server/src/main/java/org/folio/verticle/consumers/DataImportJournalKafkaHandler.java
@@ -36,14 +36,18 @@ public class DataImportJournalKafkaHandler implements AsyncRecordHandler<String,
   private Vertx vertx;
   private JournalService journalService;
   private KafkaInternalCache kafkaInternalCache;
-  private EventTypeHandlerSelector eventTypeHandlerSelector = new EventTypeHandlerSelector();
+//  private EventTypeHandlerSelector eventTypeHandlerSelector = new EventTypeHandlerSelector();
+  private EventTypeHandlerSelector eventTypeHandlerSelector;
 
   public DataImportJournalKafkaHandler(@Autowired Vertx vertx,
                                        @Autowired KafkaInternalCache kafkaInternalCache,
+                                       @Autowired EventTypeHandlerSelector eventTypeHandlerSelector,
                                        @Autowired @Qualifier("journalServiceProxy") JournalService journalService) {
     this.vertx = vertx;
     this.journalService = journalService;
     this.kafkaInternalCache = kafkaInternalCache;
+
+    this.eventTypeHandlerSelector = eventTypeHandlerSelector;
   }
 
   @Override

--- a/mod-source-record-manager-server/src/main/java/org/folio/verticle/consumers/util/EventTypeHandlerSelector.java
+++ b/mod-source-record-manager-server/src/main/java/org/folio/verticle/consumers/util/EventTypeHandlerSelector.java
@@ -2,6 +2,8 @@ package org.folio.verticle.consumers.util;
 
 import org.folio.DataImportEventPayload;
 import org.folio.rest.jaxrs.model.DataImportEventTypes;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
 
 import java.util.List;
 import java.util.Map;
@@ -10,14 +12,16 @@ import static org.folio.rest.jaxrs.model.DataImportEventTypes.DI_COMPLETED;
 import static org.folio.rest.jaxrs.model.DataImportEventTypes.DI_ERROR;
 import static org.folio.rest.jaxrs.model.DataImportEventTypes.DI_INVOICE_CREATED;
 
+@Component
 public class EventTypeHandlerSelector {
 
   public static final String DEFAULT_HANDLER_KEY = "DEFAULT";
   private final Map<String, SpecificEventHandler> handlers;
 
-  public EventTypeHandlerSelector() {
+  @Autowired
+  public EventTypeHandlerSelector(MarcImportEventsHandler marcImportEventsHandler) {
     this.handlers = Map.of(DI_INVOICE_CREATED.toString(), new InvoiceImportEventHandler(),
-      DEFAULT_HANDLER_KEY, new MarcImportEventsHandler());
+      DEFAULT_HANDLER_KEY, marcImportEventsHandler);
   }
 
   public SpecificEventHandler getHandler(DataImportEventPayload eventPayload) {

--- a/mod-source-record-manager-server/src/main/java/org/folio/verticle/consumers/util/EventTypeHandlerSelector.java
+++ b/mod-source-record-manager-server/src/main/java/org/folio/verticle/consumers/util/EventTypeHandlerSelector.java
@@ -1,14 +1,14 @@
 package org.folio.verticle.consumers.util;
 
 import org.folio.DataImportEventPayload;
-import org.folio.DataImportEventTypes;
+import org.folio.rest.jaxrs.model.DataImportEventTypes;
 
 import java.util.List;
 import java.util.Map;
 
-import static org.folio.DataImportEventTypes.DI_COMPLETED;
-import static org.folio.DataImportEventTypes.DI_ERROR;
-import static org.folio.DataImportEventTypes.DI_INVOICE_CREATED;
+import static org.folio.rest.jaxrs.model.DataImportEventTypes.DI_COMPLETED;
+import static org.folio.rest.jaxrs.model.DataImportEventTypes.DI_ERROR;
+import static org.folio.rest.jaxrs.model.DataImportEventTypes.DI_INVOICE_CREATED;
 
 public class EventTypeHandlerSelector {
 

--- a/mod-source-record-manager-server/src/main/java/org/folio/verticle/consumers/util/JournalParams.java
+++ b/mod-source-record-manager-server/src/main/java/org/folio/verticle/consumers/util/JournalParams.java
@@ -147,6 +147,22 @@ public class JournalParams {
           JournalRecord.ActionStatus.COMPLETED));
       }
     },
+    DI_LOG_SRS_MARC_BIB_RECORD_CREATED {
+      @Override
+      public Optional<JournalParams> getJournalParams(DataImportEventPayload eventPayload) {
+        return Optional.of(new JournalParams(JournalRecord.ActionType.CREATE,
+          JournalRecord.EntityType.MARC_BIBLIOGRAPHIC,
+          JournalRecord.ActionStatus.COMPLETED));
+      }
+    },
+    DI_LOG_SRS_MARC_BIB_RECORD_UPDATED {
+      @Override
+      public Optional<JournalParams> getJournalParams(DataImportEventPayload eventPayload) {
+        return Optional.of(new JournalParams(JournalRecord.ActionType.UPDATE,
+          JournalRecord.EntityType.MARC_BIBLIOGRAPHIC,
+          JournalRecord.ActionStatus.COMPLETED));
+      }
+    },
     DI_COMPLETED {
       @Override
       public Optional<JournalParams> getJournalParams(DataImportEventPayload eventPayload) {

--- a/mod-source-record-manager-server/src/main/java/org/folio/verticle/consumers/util/MarcImportEventsHandler.java
+++ b/mod-source-record-manager-server/src/main/java/org/folio/verticle/consumers/util/MarcImportEventsHandler.java
@@ -1,15 +1,26 @@
 package org.folio.verticle.consumers.util;
 
+import io.vertx.core.json.Json;
 import io.vertx.core.json.JsonObject;
+import org.apache.commons.lang3.StringUtils;
 import org.folio.DataImportEventPayload;
+import org.folio.rest.jaxrs.model.ActionProfile;
 import org.folio.rest.jaxrs.model.JournalRecord;
+import org.folio.rest.jaxrs.model.Record;
 import org.folio.services.journal.JournalRecordMapperException;
 import org.folio.services.journal.JournalService;
 import org.folio.services.journal.JournalUtil;
+import org.folio.services.util.ParsedRecordUtil;
 
+import java.util.List;
 import java.util.Optional;
 
+import static org.folio.rest.jaxrs.model.JournalRecord.EntityType.MARC_BIBLIOGRAPHIC;
+
 public class MarcImportEventsHandler implements SpecificEventHandler {
+
+  private List<String> titleSubfields = List.of("a", "n", "p", "b", "c", "f", "g", "h", "k", "s");
+  public static final String MARC_BIB_CREATED_LOG_EVENT = "DI_LOG_SRS_MARC_BIB_RECORD_CREATED";
 
   @Override
   public void handle(JournalService journalService, DataImportEventPayload eventPayload, String tenantId)
@@ -23,7 +34,19 @@ public class MarcImportEventsHandler implements SpecificEventHandler {
       JournalRecord journalRecord = JournalUtil.buildJournalRecordByEvent(eventPayload,
         journalParams.journalActionType, journalParams.journalEntityType, journalParams.journalActionStatus);
 
+      ensureRecordTitleIfNeeded(journalRecord, eventPayload);
       journalService.save(JsonObject.mapFrom(journalRecord), tenantId);
+    }
+  }
+
+  private void ensureRecordTitleIfNeeded(JournalRecord journalRecord, DataImportEventPayload eventPayload) {
+    String recordAsString = eventPayload.getContext().get(ActionProfile.FolioRecord.MARC_BIBLIOGRAPHIC.value());
+
+    if (journalRecord.getEntityType().equals(MARC_BIBLIOGRAPHIC) && StringUtils.isNotBlank(recordAsString)) {
+      Record record = Json.decodeValue(recordAsString, Record.class);
+      if (record.getParsedRecord() != null) {
+        journalRecord.setTitle(ParsedRecordUtil.retrieveDataByField(record.getParsedRecord(), "245", titleSubfields));
+      }
     }
   }
 }

--- a/mod-source-record-manager-server/src/main/java/org/folio/verticle/consumers/util/MarcImportEventsHandler.java
+++ b/mod-source-record-manager-server/src/main/java/org/folio/verticle/consumers/util/MarcImportEventsHandler.java
@@ -1,5 +1,6 @@
 package org.folio.verticle.consumers.util;
 
+import io.vertx.core.Future;
 import io.vertx.core.json.Json;
 import io.vertx.core.json.JsonObject;
 import org.apache.commons.lang3.StringUtils;
@@ -7,20 +8,31 @@ import org.folio.DataImportEventPayload;
 import org.folio.rest.jaxrs.model.ActionProfile;
 import org.folio.rest.jaxrs.model.JournalRecord;
 import org.folio.rest.jaxrs.model.Record;
+import org.folio.services.MappingRuleCache;
 import org.folio.services.journal.JournalRecordMapperException;
 import org.folio.services.journal.JournalService;
 import org.folio.services.journal.JournalUtil;
 import org.folio.services.util.ParsedRecordUtil;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
 
 import java.util.List;
 import java.util.Optional;
+import java.util.stream.Collectors;
 
 import static org.folio.rest.jaxrs.model.JournalRecord.EntityType.MARC_BIBLIOGRAPHIC;
 
+@Component
 public class MarcImportEventsHandler implements SpecificEventHandler {
 
-  private List<String> titleSubfields = List.of("a", "n", "p", "b", "c", "f", "g", "h", "k", "s");
-  public static final String MARC_BIB_CREATED_LOG_EVENT = "DI_LOG_SRS_MARC_BIB_RECORD_CREATED";
+  private static final String INSTANCE_TITLE_FIELD_PATH = "title";
+
+  private MappingRuleCache mappingRuleCache;
+
+  @Autowired
+  public MarcImportEventsHandler(MappingRuleCache mappingRuleCache) {
+    this.mappingRuleCache = mappingRuleCache;
+  }
 
   @Override
   public void handle(JournalService journalService, DataImportEventPayload eventPayload, String tenantId)
@@ -34,19 +46,49 @@ public class MarcImportEventsHandler implements SpecificEventHandler {
       JournalRecord journalRecord = JournalUtil.buildJournalRecordByEvent(eventPayload,
         journalParams.journalActionType, journalParams.journalEntityType, journalParams.journalActionStatus);
 
-      ensureRecordTitleIfNeeded(journalRecord, eventPayload);
-      journalService.save(JsonObject.mapFrom(journalRecord), tenantId);
+      ensureRecordTitleIfNeeded(journalRecord, eventPayload)
+        .onComplete(ar -> journalService.save(JsonObject.mapFrom(journalRecord), tenantId));
     }
   }
 
-  private void ensureRecordTitleIfNeeded(JournalRecord journalRecord, DataImportEventPayload eventPayload) {
+  private Future<JournalRecord> ensureRecordTitleIfNeeded(JournalRecord journalRecord, DataImportEventPayload eventPayload) {
     String recordAsString = eventPayload.getContext().get(ActionProfile.FolioRecord.MARC_BIBLIOGRAPHIC.value());
 
     if (journalRecord.getEntityType().equals(MARC_BIBLIOGRAPHIC) && StringUtils.isNotBlank(recordAsString)) {
       Record record = Json.decodeValue(recordAsString, Record.class);
       if (record.getParsedRecord() != null) {
-        journalRecord.setTitle(ParsedRecordUtil.retrieveDataByField(record.getParsedRecord(), "245", titleSubfields));
+        return mappingRuleCache.get(eventPayload.getTenant())
+          .compose(ruleOptional -> ruleOptional
+            .map(mappingRules -> retrieveTitle(record, mappingRules))
+            .map(title -> Future.succeededFuture(journalRecord.withTitle(title)))
+            .orElse(Future.succeededFuture(journalRecord)));
       }
     }
+    return Future.succeededFuture(journalRecord);
+  }
+
+  private String retrieveTitle(Record record, JsonObject mappingRules) {
+    Optional<String> titleFieldOptional = getTitleFieldTagByInstanceFieldPath(mappingRules);
+
+    if (titleFieldOptional.isPresent()) {
+      String titleFieldTag = titleFieldOptional.get();
+      List<String>  subfieldCodes = mappingRules.getJsonArray(titleFieldTag).stream()
+        .map(JsonObject.class::cast)
+        .filter(fieldMappingRule -> fieldMappingRule.getString("target").equals(INSTANCE_TITLE_FIELD_PATH))
+        .flatMap(fieldMappingRule -> fieldMappingRule.getJsonArray("subfield").stream())
+        .map(Object::toString)
+        .collect(Collectors.toList());
+
+      return subfieldCodes.isEmpty() ? null : ParsedRecordUtil.retrieveDataByField(record.getParsedRecord(), titleFieldTag, subfieldCodes);
+    }
+    return null;
+  }
+
+  private Optional<String> getTitleFieldTagByInstanceFieldPath(JsonObject mappingRules) {
+    return mappingRules.getMap().keySet().stream()
+      .filter(fieldTag -> mappingRules.getJsonArray(fieldTag).stream()
+        .map(o -> (JsonObject) o)
+        .anyMatch(fieldMappingRule -> INSTANCE_TITLE_FIELD_PATH.equals(fieldMappingRule.getString("target"))))
+      .findFirst();
   }
 }

--- a/mod-source-record-manager-server/src/test/java/org/folio/verticle/consumers/DataImportJournalConsumerVerticleMockTest.java
+++ b/mod-source-record-manager-server/src/test/java/org/folio/verticle/consumers/DataImportJournalConsumerVerticleMockTest.java
@@ -1,5 +1,6 @@
 package org.folio.verticle.consumers;
 
+import io.vertx.core.Future;
 import io.vertx.core.Vertx;
 import io.vertx.core.json.Json;
 import io.vertx.core.json.JsonObject;
@@ -25,7 +26,10 @@ import org.folio.rest.jaxrs.model.JournalRecord;
 import org.folio.rest.jaxrs.model.JournalRecord.ActionStatus;
 import org.folio.rest.jaxrs.model.JournalRecord.EntityType;
 import org.folio.rest.jaxrs.model.Record;
+import org.folio.services.MappingRuleCache;
 import org.folio.services.journal.JournalServiceImpl;
+import org.folio.verticle.consumers.util.EventTypeHandlerSelector;
+import org.folio.verticle.consumers.util.MarcImportEventsHandler;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
@@ -43,6 +47,7 @@ import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.util.HashMap;
 import java.util.List;
+import java.util.Optional;
 import java.util.UUID;
 
 import static org.folio.dataimport.util.RestUtil.OKAPI_URL_HEADER;
@@ -59,8 +64,6 @@ import static org.folio.rest.jaxrs.model.JournalRecord.EntityType.MARC_BIBLIOGRA
 import static org.folio.rest.util.OkapiConnectionParams.OKAPI_TENANT_HEADER;
 import static org.folio.rest.util.OkapiConnectionParams.OKAPI_TOKEN_HEADER;
 import static org.folio.services.journal.JournalUtil.ERROR_KEY;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
@@ -78,6 +81,7 @@ public class DataImportJournalConsumerVerticleMockTest extends AbstractRestTest 
   public static final String SOURCE_RECORD_ID_KEY = "sourceId";
   public static final String ENV_KEY = "folio";
   public static final String RECORD_PATH = "src/test/resources/org/folio/rest/record.json";
+  public static final String MAPPING_RULES_PATH = "src/test/resources/org/folio/services/rules.json";
 
   @Spy
   private Vertx vertx = Vertx.vertx();
@@ -91,6 +95,13 @@ public class DataImportJournalConsumerVerticleMockTest extends AbstractRestTest 
   @Mock
   private KafkaInternalCache kafkaInternalCache;
 
+  @Mock
+  private MappingRuleCache mappingRuleCache;
+
+  @Spy
+  @InjectMocks
+  private MarcImportEventsHandler marcImportEventsHandler;
+
   @Spy
   private final JournalServiceImpl journalService = new JournalServiceImpl(journalRecordDao);
 
@@ -100,8 +111,6 @@ public class DataImportJournalConsumerVerticleMockTest extends AbstractRestTest 
   private DataImportJournalKafkaHandler dataImportJournalKafkaHandler;
 
   private final String jobExecutionUUID = "5105b55a-b9a3-4f76-9402-a5243ea63c95";
-
-  private Record record;
 
   private final JobExecution jobExecution = new JobExecution()
     .withId(jobExecutionUUID)
@@ -119,12 +128,17 @@ public class DataImportJournalConsumerVerticleMockTest extends AbstractRestTest 
     .put("snapshotId", jobExecutionUUID)
     .put("order", 1);
 
+  private Record record;
+
   @Before
   public void setUp() throws IOException {
     MockitoAnnotations.initMocks(this);
-    dataImportJournalKafkaHandler = new DataImportJournalKafkaHandler(vertx, kafkaInternalCache, journalService);
-    when(kafkaInternalCache.containsByKey(anyString())).thenReturn(false);
+    EventTypeHandlerSelector eventTypeHandlerSelector = new EventTypeHandlerSelector(marcImportEventsHandler);
+    dataImportJournalKafkaHandler = new DataImportJournalKafkaHandler(vertx, kafkaInternalCache, eventTypeHandlerSelector, journalService);
     record = Json.decodeValue(TestUtil.readFileFromPath(RECORD_PATH), Record.class);
+    JsonObject mappingRules = new JsonObject(TestUtil.readFileFromPath(MAPPING_RULES_PATH));
+    when(mappingRuleCache.get(anyString())).thenReturn(Future.succeededFuture(Optional.of(mappingRules)));
+    when(kafkaInternalCache.containsByKey(anyString())).thenReturn(false);
   }
 
   @Test

--- a/mod-source-record-manager-server/src/test/java/org/folio/verticle/consumers/DataImportJournalConsumerVerticleTest.java
+++ b/mod-source-record-manager-server/src/test/java/org/folio/verticle/consumers/DataImportJournalConsumerVerticleTest.java
@@ -27,6 +27,7 @@ import org.folio.rest.jaxrs.model.JobExecutionLogDto;
 import org.folio.rest.jaxrs.model.JobProfileInfo;
 import org.folio.rest.jaxrs.model.ProfileSnapshotWrapper;
 import org.folio.services.journal.JournalService;
+import org.folio.verticle.consumers.util.EventTypeHandlerSelector;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
@@ -105,7 +106,10 @@ public class DataImportJournalConsumerVerticleTest extends AbstractRestTest {
     kafkaInternalCache = getBeanFromSpringContext(vertx, KafkaInternalCache.class);
     Assert.assertNotNull(kafkaInternalCache);
 
-    dataImportJournalKafkaHandler = new DataImportJournalKafkaHandler(vertx, kafkaInternalCache, journalService);
+    EventTypeHandlerSelector eventTypeHandlerSelector = getBeanFromSpringContext(vertx, EventTypeHandlerSelector.class);
+    Assert.assertNotNull(eventTypeHandlerSelector);
+
+    dataImportJournalKafkaHandler = new DataImportJournalKafkaHandler(vertx, kafkaInternalCache, eventTypeHandlerSelector, journalService);
   }
 
   @Test

--- a/mod-source-record-manager-server/src/test/java/org/folio/verticle/consumers/ImportInvoiceJournalConsumerVerticleMockTest.java
+++ b/mod-source-record-manager-server/src/test/java/org/folio/verticle/consumers/ImportInvoiceJournalConsumerVerticleMockTest.java
@@ -25,8 +25,11 @@ import org.folio.rest.impl.AbstractRestTest;
 import org.folio.rest.jaxrs.model.Event;
 import org.folio.rest.jaxrs.model.JournalRecord.ActionStatus;
 import org.folio.rest.jaxrs.model.ProfileSnapshotWrapper;
+import org.folio.services.MappingRuleCache;
 import org.folio.services.journal.JournalRecordMapperException;
 import org.folio.services.journal.JournalServiceImpl;
+import org.folio.verticle.consumers.util.EventTypeHandlerSelector;
+import org.folio.verticle.consumers.util.MarcImportEventsHandler;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
@@ -94,6 +97,12 @@ public class ImportInvoiceJournalConsumerVerticleMockTest extends AbstractRestTe
   @Mock
   private KafkaInternalCache kafkaInternalCache;
 
+  @Mock
+  private MappingRuleCache mappingRuleCache;
+
+  @InjectMocks
+  private MarcImportEventsHandler marcImportEventsHandler;
+
   @Captor
   private ArgumentCaptor<JsonArray> invoiceRecordCaptor;
 
@@ -139,7 +148,8 @@ public class ImportInvoiceJournalConsumerVerticleMockTest extends AbstractRestTe
   public void setUp() {
     MockitoAnnotations.initMocks(this);
     when(kafkaInternalCache.containsByKey(anyString())).thenReturn(false);
-    dataImportJournalKafkaHandler = new DataImportJournalKafkaHandler(vertx, kafkaInternalCache, journalService);
+    EventTypeHandlerSelector eventTypeHandlerSelector = new EventTypeHandlerSelector(marcImportEventsHandler);
+    dataImportJournalKafkaHandler = new DataImportJournalKafkaHandler(vertx, kafkaInternalCache, eventTypeHandlerSelector, journalService);
   }
 
   @Test

--- a/mod-source-record-manager-server/src/test/java/org/folio/verticle/consumers/ImportInvoiceJournalConsumerVerticleTest.java
+++ b/mod-source-record-manager-server/src/test/java/org/folio/verticle/consumers/ImportInvoiceJournalConsumerVerticleTest.java
@@ -1,9 +1,6 @@
 package org.folio.verticle.consumers;
 
-import com.github.tomakehurst.wiremock.admin.NotFoundException;
 import io.vertx.core.Future;
-import io.vertx.core.Vertx;
-import io.vertx.core.impl.VertxImpl;
 import io.vertx.core.json.Json;
 import io.vertx.core.json.JsonArray;
 import io.vertx.core.json.JsonObject;
@@ -29,11 +26,11 @@ import org.folio.rest.jaxrs.model.JobExecutionLogDto;
 import org.folio.rest.jaxrs.model.JobProfileInfo;
 import org.folio.rest.jaxrs.model.ProfileSnapshotWrapper;
 import org.folio.services.journal.JournalService;
+import org.folio.verticle.consumers.util.EventTypeHandlerSelector;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.springframework.context.annotation.AnnotationConfigApplicationContext;
 
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
@@ -104,7 +101,10 @@ public class ImportInvoiceJournalConsumerVerticleTest extends AbstractRestTest {
     kafkaInternalCache = getBeanFromSpringContext(vertx, KafkaInternalCache.class);
     Assert.assertNotNull(kafkaInternalCache);
 
-    dataImportJournalKafkaHandler = new DataImportJournalKafkaHandler(vertx, kafkaInternalCache, journalService);
+    EventTypeHandlerSelector eventTypeHandlerSelector = getBeanFromSpringContext(vertx, EventTypeHandlerSelector.class);
+    Assert.assertNotNull(eventTypeHandlerSelector);
+
+    dataImportJournalKafkaHandler = new DataImportJournalKafkaHandler(vertx, kafkaInternalCache, eventTypeHandlerSelector, journalService);
   }
 
   String INVOICE_ID = UUID.randomUUID().toString();

--- a/mod-source-record-manager-server/src/test/java/org/folio/verticle/consumers/util/EventTypeHandlerSelectorTest.java
+++ b/mod-source-record-manager-server/src/test/java/org/folio/verticle/consumers/util/EventTypeHandlerSelectorTest.java
@@ -17,7 +17,7 @@ import static org.folio.rest.jaxrs.model.DataImportEventTypes.DI_INVENTORY_INSTA
 @RunWith(BlockJUnit4ClassRunner.class)
 public class EventTypeHandlerSelectorTest {
 
-  EventTypeHandlerSelector eventTypeHandlerSelector = new EventTypeHandlerSelector();
+  EventTypeHandlerSelector eventTypeHandlerSelector = new EventTypeHandlerSelector(new MarcImportEventsHandler(null));
 
   @Test
   public void shouldReturnMarcImportEventHandler() {


### PR DESCRIPTION
## Purpose
to adjust statuses on the summary page after updating an existing Instance and creating a new SRS MARC implicitly using single record imports for Overlays

## Approach
* ensure title log when logging an event that record has been updated
* introduce events that notify that a record has been created/updated implicitly after updating an instance

## Learning
[MODSOURMAN-508](https://issues.folio.org/browse/MODSOURMAN-508)