### PR TITLE
MODSOURMAN-517 - Change quickMarc producers not to close

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,6 @@
 ## 2021-07-06 v3.2.0-SNAPSHOT
 * [MODSOURMAN-509](https://issues.folio.org/browse/MODSOURMAN-509) Data import stopped process before finishing: deadlock for "job_monitoring"
+* [MODSOURMAN-517](https://issues.folio.org/browse/MODSOURMAN-517) Change quickMarc producers not to close after message sent
 
 ## xxxx-xx-xx v3.1.2-SNAPSHOT
 * [MODSOURMAN-508](https://issues.folio.org/browse/MODSOURMAN-508) Log details for Inventory single record imports for Overlays

--- a/mod-source-record-manager-server/src/main/java/org/folio/services/QuickMarcEventProducerService.java
+++ b/mod-source-record-manager-server/src/main/java/org/folio/services/QuickMarcEventProducerService.java
@@ -1,0 +1,25 @@
+package org.folio.services;
+
+import java.util.List;
+
+import io.vertx.core.Future;
+import io.vertx.kafka.client.producer.KafkaHeader;
+
+/**
+ * Service for processing quick marc events
+ */
+public interface QuickMarcEventProducerService {
+
+  /**
+   * Publishes an event with each of the passed records to the specified topic
+   *
+   * @param eventPayload payload
+   * @param eventType    event type
+   * @param key          key with which the specified event
+   * @param tenantId     tenant id
+   * @param kafkaHeaders kafka headers
+   * @return true if successful
+   */
+  Future<Boolean> sendEvent(String eventPayload, String eventType, String key, String tenantId,
+                            List<KafkaHeader> kafkaHeaders);
+}

--- a/mod-source-record-manager-server/src/main/java/org/folio/services/QuickMarcEventProducerServiceImpl.java
+++ b/mod-source-record-manager-server/src/main/java/org/folio/services/QuickMarcEventProducerServiceImpl.java
@@ -1,0 +1,62 @@
+package org.folio.services;
+
+import static org.folio.services.util.EventHandlingUtil.createEvent;
+import static org.folio.services.util.EventHandlingUtil.createProducer;
+import static org.folio.services.util.EventHandlingUtil.createProducerRecord;
+import static org.folio.services.util.EventHandlingUtil.createTopicName;
+import static org.folio.verticle.consumers.util.QMEventTypes.QM_RECORD_UPDATED;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import io.vertx.core.Future;
+import io.vertx.core.Promise;
+import io.vertx.kafka.client.producer.KafkaHeader;
+import io.vertx.kafka.client.producer.KafkaProducer;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.springframework.stereotype.Service;
+
+import org.folio.kafka.KafkaConfig;
+
+@Service
+public class QuickMarcEventProducerServiceImpl implements QuickMarcEventProducerService {
+
+  private static final Logger LOGGER = LogManager.getLogger();
+  private final KafkaConfig kafkaConfig;
+  private final Map<String, KafkaProducer<String, String>> kafkaProducers = new HashMap<>();
+
+  public QuickMarcEventProducerServiceImpl(KafkaConfig kafkaConfig) {
+    this.kafkaConfig = kafkaConfig;
+    kafkaProducers.put(QM_RECORD_UPDATED.name(), createProducer(QM_RECORD_UPDATED.name(), kafkaConfig));
+  }
+
+  @Override
+  public Future<Boolean> sendEvent(String eventPayload, String eventType, String key, String tenantId, List<KafkaHeader> kafkaHeaders) {
+    Promise<Boolean> promise = Promise.promise();
+    try {
+      var event = createEvent(eventPayload, eventType, tenantId);
+      var topicName = createTopicName(eventType, tenantId, kafkaConfig);
+      var record = createProducerRecord(event, key, topicName, kafkaHeaders);
+      var producer = kafkaProducers.get(eventType);
+      if (producer != null) {
+        producer.write(record)
+          .onSuccess(unused -> {
+            LOGGER.info("Event with type {} was sent to kafka", eventType);
+            promise.complete(true);
+          })
+          .onFailure(throwable -> {
+            var cause = throwable.getCause();
+            LOGGER.error("Error while send event {}: {}", eventType, cause);
+            promise.fail(cause);
+          });
+      } else {
+        promise.fail("No producer found for event: " + eventType);
+      }
+    } catch (Exception e) {
+      promise.fail(e);
+    }
+    return promise.future();
+  }
+}

--- a/mod-source-record-manager-server/src/main/java/org/folio/services/util/EventHandlingUtil.java
+++ b/mod-source-record-manager-server/src/main/java/org/folio/services/util/EventHandlingUtil.java
@@ -19,8 +19,11 @@ import org.folio.util.pubsub.PubSubClientUtils;
 import java.io.IOException;
 import java.util.List;
 import java.util.UUID;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
 
 public final class EventHandlingUtil {
+  private final static ConcurrentMap<String, KafkaProducer<String, String>> KAFKA_PRODUCERS = new ConcurrentHashMap<>();
 
   private EventHandlingUtil() {
   }
@@ -64,11 +67,10 @@ public final class EventHandlingUtil {
 
     String correlationId = extractCorrelationId(kafkaHeaders);
     String producerName = eventType + "_Producer";
-    KafkaProducer<String, String> producer =
-      KafkaProducer.createShared(Vertx.currentContext().owner(), producerName, kafkaConfig.getProducerProps());
+    KafkaProducer<String, String> producer = getKafkaProducer(producerName, kafkaConfig);
 
     producer.write(record, war -> {
-      producer.end(ear -> producer.close());
+      producer.end();
       if (war.succeeded()) {
         LOGGER.info("Event with type: {} and correlationId: {} was sent to kafka", eventType, correlationId);
         promise.complete(true);
@@ -89,4 +91,13 @@ public final class EventHandlingUtil {
       .orElse(null);
   }
 
+  private static KafkaProducer<String, String> getKafkaProducer(String producerName, KafkaConfig kafkaConfig) {
+    if (KAFKA_PRODUCERS.containsKey(producerName)) {
+      return KAFKA_PRODUCERS.get(producerName);
+    } else {
+      KafkaProducer<String, String> kafkaProducer = KafkaProducer.createShared(Vertx.currentContext().owner(), producerName, kafkaConfig.getProducerProps());
+      KAFKA_PRODUCERS.put(producerName, kafkaProducer);
+      return kafkaProducer;
+    }
+  }
 }


### PR DESCRIPTION
https://issues.folio.org/browse/MODSOURMAN-517

## Purpose
Change quickMarc producers not to close after message sent. Currently, they are created each time the event send and then closed

## Approach
Create shared producers and store them in map
Do not close producer after message sent

#### TODOS and Open Questions
- [ ] Use GitHub checklists. When solved, check the box and explain the answer.

## Learning
_Describe the research stage. Add links to blog posts, patterns, libraries or addons used to solve this problem._
