### PR TITLE
MODPUBSUB-187 Add support for max.request.size configuration for Kafk…

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,11 +1,15 @@
 ## 2021-07-06 v3.2.0-SNAPSHOT
-* [MODSOURMAN-509](https://issues.folio.org/browse/MODSOURMAN-509) Data import stopped process before finishing: deadlock for "job_monitoring"
 * [MODSOURMAN-516](https://issues.folio.org/browse/MODSOURMAN-516) Send QM_COMPLETED event after processing finished
 * [MODSOURMAN-517](https://issues.folio.org/browse/MODSOURMAN-517) Change quickMarc producers not to close after message sent
 
-## xxxx-xx-xx v3.1.2-SNAPSHOT
+## XXXX-XX-XX v3.1.3
+* [MODPUBSUB-187](https://issues.folio.org/browse/MODPUBSUB-187) Add support for max.request.size configuration for Kafka messages
+
+## 2021-07-21 v3.1.2
+* [MODSOURMAN-513](https://issues.folio.org/browse/MODSOURMAN-513) (Juniper) Data import stopped process before finishing: deadlock for "job_monitoring"
 * [MODSOURMAN-508](https://issues.folio.org/browse/MODSOURMAN-508) Log details for Inventory single record imports for Overlays
 * [MODSOURMAN-527](https://issues.folio.org/browse/MODSOURMAN-527) Cannot import EDIFACT invoices
+* Update data-import-processing-core dependency to v3.1.3
 
 ## 2021-06-25 v3.1.1
 * [MODSOURMAN-497](https://issues.folio.org/browse/MODSOURMAN-497) Apply MarcRecordAnalyzer to determine MARC related specific type

--- a/mod-source-record-manager-server/pom.xml
+++ b/mod-source-record-manager-server/pom.xml
@@ -203,7 +203,7 @@
     <dependency>
       <groupId>org.folio</groupId>
       <artifactId>folio-kafka-wrapper</artifactId>
-      <version>2.3.1</version>
+      <version>2.4.0-SNAPSHOT</version>
     </dependency>
     <dependency>
       <groupId>org.folio</groupId>

--- a/mod-source-record-manager-server/src/main/java/org/folio/config/ApplicationConfig.java
+++ b/mod-source-record-manager-server/src/main/java/org/folio/config/ApplicationConfig.java
@@ -31,6 +31,8 @@ public class ApplicationConfig {
   private String okapiUrl;
   @Value("${REPLICATION_FACTOR:1}")
   private int replicationFactor;
+  @Value("${MAX_REQUEST_SIZE:1048576}")
+  private int maxRequestSize;
   @Value("${ENV:folio}")
   private String envId;
   @Value("${srm.kafkacache.cleanup.interval.ms:3600000}")
@@ -46,6 +48,7 @@ public class ApplicationConfig {
       .kafkaPort(kafkaPort)
       .okapiUrl(okapiUrl)
       .replicationFactor(replicationFactor)
+      .maxRequestSize(maxRequestSize)
       .build();
 
     LOGGER.debug("kafkaConfig: " + kafkaConfig);


### PR DESCRIPTION
…a messages

## Purpose
When attempting to import a file the import job does not complete due to the following error
org.apache.kafka.common.errors.RecordTooLargeException: The message is 1287037 bytes when serialized which is larger than 1048576, which is the value of the max.request.size configuration.

## Approach
Add support for max.request.size configuration for Kafka messages

## Learning
https://docs.confluent.io/platform/current/installation/configuration/producer-configs.html#producerconfigs_max.request.size
