### PR TITLE
MODDICORE-166: Near the day boundary data import calculates today incorrectly.

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -2,6 +2,7 @@
 * [MODSOURMAN-516](https://issues.folio.org/browse/MODSOURMAN-516) Send QM_COMPLETED event after processing finished
 * [MODSOURMAN-517](https://issues.folio.org/browse/MODSOURMAN-517) Change quickMarc producers not to close after message sent
 * [MODSOURMAN-524](https://issues.folio.org/browse/MODSOURMAN-524) Support MARC Holdings
+* [MODDICORE-166](https://issues.folio.org/browse/MODDICORE-166)  Near the day boundary data import calculates today incorrectly.
 
 ## XXXX-XX-XX v3.1.3
 * [MODPUBSUB-187](https://issues.folio.org/browse/MODPUBSUB-187) Add support for max.request.size configuration for Kafka messages

--- a/NEWS.md
+++ b/NEWS.md
@@ -2,10 +2,10 @@
 * [MODSOURMAN-516](https://issues.folio.org/browse/MODSOURMAN-516) Send QM_COMPLETED event after processing finished
 * [MODSOURMAN-517](https://issues.folio.org/browse/MODSOURMAN-517) Change quickMarc producers not to close after message sent
 * [MODSOURMAN-524](https://issues.folio.org/browse/MODSOURMAN-524) Support MARC Holdings
-* [MODDICORE-166](https://issues.folio.org/browse/MODDICORE-166)  Near the day boundary data import calculates today incorrectly.
 
 ## XXXX-XX-XX v3.1.3
 * [MODPUBSUB-187](https://issues.folio.org/browse/MODPUBSUB-187) Add support for max.request.size configuration for Kafka messages
+* [MODDICORE-166](https://issues.folio.org/browse/MODDICORE-166)  Near the day boundary data import calculates today incorrectly.
 
 ## 2021-07-21 v3.1.2
 * [MODSOURMAN-513](https://issues.folio.org/browse/MODSOURMAN-513) (Juniper) Data import stopped process before finishing: deadlock for "job_monitoring"

--- a/mod-source-record-manager-server/src/test/java/org/folio/rest/impl/AbstractRestTest.java
+++ b/mod-source-record-manager-server/src/test/java/org/folio/rest/impl/AbstractRestTest.java
@@ -53,6 +53,8 @@ import org.junit.Rule;
 import org.springframework.context.annotation.AnnotationConfigApplicationContext;
 
 import java.io.IOException;
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
 import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
@@ -115,6 +117,7 @@ public abstract class AbstractRestTest {
   protected static final String LOAN_TYPES_URL = "/loan-types?limit=500";
   protected static final String ITEM_NOTE_TYPES_URL = "/item-note-types?limit=500";
   protected static final String FIELD_PROTECTION_SETTINGS_URL = "/field-protection-settings/marc?limit=500";
+  protected static final String TENANT_CONFIGURATIONS_SETTINGS_URL = "/configurations/entries?query=" + URLEncoder.encode("(module==ORG and configName==localeSettings)", StandardCharsets.UTF_8);;
 
 
   protected static final String FILES_PATH = "src/test/resources/org/folio/rest/files.sample";
@@ -323,6 +326,7 @@ public abstract class AbstractRestTest {
     WireMock.stubFor(get(LOAN_TYPES_URL).willReturn(okJson(new JsonObject().put("loantypes", new JsonArray()).toString())));
     WireMock.stubFor(get(ITEM_NOTE_TYPES_URL).willReturn(okJson(new JsonObject().put("itemNoteTypes", new JsonArray()).toString())));
     WireMock.stubFor(get(FIELD_PROTECTION_SETTINGS_URL).willReturn(okJson(new JsonObject().put("marcFieldProtectionSettings", new JsonArray()).toString())));
+    WireMock.stubFor(get(TENANT_CONFIGURATIONS_SETTINGS_URL).willReturn(okJson(new JsonObject().put("configs", new JsonArray()).toString())));
 
 
     WireMock.stubFor(WireMock.delete(new UrlPathPattern(new RegexPattern("/source-storage/snapshots/.{36}/records"), true))

--- a/mod-source-record-manager-server/src/test/java/org/folio/rest/impl/changeManager/ChangeManagerAPITest.java
+++ b/mod-source-record-manager-server/src/test/java/org/folio/rest/impl/changeManager/ChangeManagerAPITest.java
@@ -1135,6 +1135,7 @@ public class ChangeManagerAPITest extends AbstractRestTest {
     verify(1, getRequestedFor(urlEqualTo(LOAN_TYPES_URL)));
     verify(1, getRequestedFor(urlEqualTo(ITEM_NOTE_TYPES_URL)));
     verify(1, getRequestedFor(urlEqualTo(FIELD_PROTECTION_SETTINGS_URL)));
+    verify(1, getRequestedFor(urlEqualTo(TENANT_CONFIGURATIONS_SETTINGS_URL)));
     async.complete();
   }
 
@@ -1174,6 +1175,7 @@ public class ChangeManagerAPITest extends AbstractRestTest {
     WireMock.stubFor(get(LOAN_TYPES_URL).willReturn(serverError()));
     WireMock.stubFor(get(ITEM_NOTE_TYPES_URL).willReturn(serverError()));
     WireMock.stubFor(get(FIELD_PROTECTION_SETTINGS_URL).willReturn(serverError()));
+    WireMock.stubFor(get(TENANT_CONFIGURATIONS_SETTINGS_URL).willReturn(serverError()));
 
     Async async = testContext.async();
     RestAssured.given()


### PR DESCRIPTION
## Purpose
When calculating ##TODAY## in a profile run at the end of the day, data import used the next day's date. Perhaps not using DST correctly. Observed on Cornell's tenant which is America/New York.

## Approach
Created brand new mechanism:

1. Retrieve tenant configuration from "/configurations/entries" in srm. There will be a current timezone for the tenant. (By default, it is empty, so it'll proceeded with UTC-timezone). Put this into MappingParameters to the dataImportEventPayload.
2. In di-core while processing ##TODAY##-expression retrieve from dataImportEventPayload current timezone for the tenant, calculate current dateTime in UTC(default) and convert to the timezone for the tenant.

## Learning
**This PR should be merged after this PR will be merged: https://github.com/folio-org/data-import-processing-core/pull/163** 
JIRA-ticket: https://issues.folio.org/browse/MODDICORE-166
