### PR TITLE
MODSOURMAN-538 Updated descriptor for PUT /change-manager/parsedRecords/{id}

### DIFF
--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -51,6 +51,10 @@
       "version": "1.0"
     },
     {
+      "id": "instance-preceding-succeeding-titles",
+      "version": "0.2"
+    },
+    {
       "id": "alternative-title-types",
       "version": "1.0"
     },
@@ -292,6 +296,7 @@
             "converter-storage.field-protection-settings.get",
             "inventory-storage.instances.item.get",
             "inventory-storage.instances.item.put",
+            "inventory-storage.instances.preceding-succeeding-titles.collection.put",
             "configuration.entries.collection.get"
           ]
         }


### PR DESCRIPTION
## Purpose
Changed quickMarc update flow requires changes in SRM to support the new inventory-storage endpoint.

## Approach
- add "inventory-storage.instances.preceding-succeeding-titles.collection.put" to module permissions for the *PUT /change-manager/parsedRecords/ {id}
endpoint*

- add "instance-preceding-succeeding-titles v0.2" interface to descriptor's requires section

## Learning
[MODSOURMAN-538](https://issues.folio.org/browse/MODSOURMAN-538)
