### PR TITLE
MODSOURMAN-542 Update existing CLI endpoint PUT /mapping-rules to support MARC Holdings default rules

### DIFF
--- a/mod-source-record-manager-server/src/main/java/org/folio/dao/MappingRuleDao.java
+++ b/mod-source-record-manager-server/src/main/java/org/folio/dao/MappingRuleDao.java
@@ -33,8 +33,9 @@ public interface MappingRuleDao {
    * Updates rules if exist
    *
    * @param rules    rules
+   * @param recordType type of rules (MARC_BIB or MARK_HOLDING)
    * @param tenantId tenant
    * @return updated rules
    */
-  Future<JsonObject> update(JsonObject rules, String tenantId);
+  Future<JsonObject> update(JsonObject rules, Record.RecordType recordType, String tenantId);
 }

--- a/mod-source-record-manager-server/src/main/java/org/folio/rest/impl/MappingRulesProviderImpl.java
+++ b/mod-source-record-manager-server/src/main/java/org/folio/rest/impl/MappingRulesProviderImpl.java
@@ -13,6 +13,7 @@ import io.vertx.core.Handler;
 import io.vertx.core.Vertx;
 import org.springframework.beans.factory.annotation.Autowired;
 
+import org.folio.Record;
 import org.folio.dataimport.util.ExceptionHelper;
 import org.folio.rest.jaxrs.resource.MappingRules;
 import org.folio.rest.tools.utils.TenantTool;
@@ -33,11 +34,13 @@ public class MappingRulesProviderImpl implements MappingRules {
 
   @Override
   public void getMappingRulesByRecordType(String recordType, Map<String, String> okapiHeaders, Handler<AsyncResult<Response>> asyncResultHandler, Context vertxContext) {
+    Record.RecordType enumRecordType = QueryPathUtil.toRecordType(recordType)
+      .orElseThrow(() -> new BadRequestException("Only marc-bib or marc-holdings supports"));
+
     succeededFuture()
-      .compose(ar -> mappingRuleService.get(QueryPathUtil.toRecordType(recordType).orElseThrow(() ->
-        new BadRequestException("Only marc-bib or marc-holdings supports")), tenantId))
+      .compose(ar -> mappingRuleService.get(enumRecordType, tenantId))
       .map(optionalRules -> optionalRules.orElseThrow(() ->
-        new NotFoundException(String.format("Can not find mapping rules with type '%s' for tenant '%s'", recordType.toString(), tenantId))))
+        new NotFoundException(String.format("Can not find mapping rules with type '%s' for tenant '%s'", recordType, tenantId))))
       .map(rules -> GetMappingRulesByRecordTypeResponse.respond200WithApplicationJson(rules.encode()))
       .map(Response.class::cast)
       .otherwise(ExceptionHelper::mapExceptionToResponse)
@@ -46,10 +49,13 @@ public class MappingRulesProviderImpl implements MappingRules {
 
 
   @Override
-  public void putMappingRules(String entity, Map<String, String> okapiHeaders, Handler<AsyncResult<Response>> asyncResultHandler, Context vertxContext) {
+  public void putMappingRulesByRecordType(String recordType, String entity, Map<String, String> okapiHeaders, Handler<AsyncResult<Response>> asyncResultHandler, Context vertxContext) {
+    Record.RecordType enumRecordType = QueryPathUtil.toRecordType(recordType)
+      .orElseThrow(() -> new BadRequestException("Only marc-bib or marc-holdings supports"));
+
     succeededFuture()
-      .compose(ar -> mappingRuleService.update(entity, tenantId))
-      .map(rules -> PutMappingRulesResponse.respond200WithApplicationJson(rules.encode()))
+      .compose(ar -> mappingRuleService.update(entity, enumRecordType, tenantId))
+      .map(rules -> PutMappingRulesByRecordTypeResponse.respond200WithApplicationJson(rules.encode()))
       .map(Response.class::cast)
       .otherwise(ExceptionHelper::mapExceptionToResponse)
       .onComplete(asyncResultHandler);

--- a/mod-source-record-manager-server/src/main/java/org/folio/services/MappingRuleService.java
+++ b/mod-source-record-manager-server/src/main/java/org/folio/services/MappingRuleService.java
@@ -35,9 +35,10 @@ public interface MappingRuleService {
    *
    * @param rules    rules
    * @param tenantId tenant
+   * @param recordType type of rules (MARC_BIB or MARK_HOLDING)
    * @return rules in JsonObject
    */
-  Future<JsonObject> update(String rules, String tenantId);
+  Future<JsonObject> update(String rules, Record.RecordType recordType, String tenantId);
 
   /**
    * Updates existing rules with default rules

--- a/mod-source-record-manager-server/src/main/java/org/folio/services/MappingRuleServiceImpl.java
+++ b/mod-source-record-manager-server/src/main/java/org/folio/services/MappingRuleServiceImpl.java
@@ -77,10 +77,10 @@ public class MappingRuleServiceImpl implements MappingRuleService {
   }
 
   @Override
-  public Future<JsonObject> update(String rules, String tenantId) {
+  public Future<JsonObject> update(String rules, Record.RecordType recordType, String tenantId) {
     Promise<JsonObject> promise = Promise.promise();
     if (isValidJson(rules)) {
-      mappingRuleDao.update(new JsonObject(rules), tenantId)
+      mappingRuleDao.update(new JsonObject(rules), recordType, tenantId)
         .onSuccess(updatedRules -> mappingRuleCache.put(tenantId, updatedRules))
         .onComplete(promise);
     } else {
@@ -98,7 +98,7 @@ public class MappingRuleServiceImpl implements MappingRuleService {
     Optional<String> optionalRules = readResourceFromPath(DEFAULT_BIB_RULES_PATH);
     if (optionalRules.isPresent()) {
       String rules = optionalRules.get();
-      update(rules, tenantId).onComplete(promise);
+      update(rules, Record.RecordType.MARC_BIB, tenantId).onComplete(promise);
     } else {
       String errorMessage = "No rules found in resources";
       LOGGER.error(errorMessage);

--- a/mod-source-record-manager-server/src/test/java/org/folio/rest/impl/mappingRulesProvider/MappingRulesProviderAPITest.java
+++ b/mod-source-record-manager-server/src/test/java/org/folio/rest/impl/mappingRulesProvider/MappingRulesProviderAPITest.java
@@ -63,12 +63,12 @@ public class MappingRulesProviderAPITest extends AbstractRestTest {
 
   @Test
   public void shouldReturnErrorOnGetByInvalidPath() {
-      RestAssured.given()
-        .spec(spec)
-        .when()
-        .get(SERVICE_PATH + "/invalid")
-        .then()
-        .statusCode(HttpStatus.SC_BAD_REQUEST);
+    RestAssured.given()
+      .spec(spec)
+      .when()
+      .get(SERVICE_PATH + "/invalid")
+      .then()
+      .statusCode(HttpStatus.SC_BAD_REQUEST);
   }
 
   @Test
@@ -84,7 +84,7 @@ public class MappingRulesProviderAPITest extends AbstractRestTest {
       .spec(spec)
       .body(expectedRules.encode())
       .when()
-      .put(SERVICE_PATH)
+      .put(SERVICE_PATH + MARC_BIB)
       .then()
       .statusCode(HttpStatus.SC_OK)
       .log().everything();
@@ -119,7 +119,7 @@ public class MappingRulesProviderAPITest extends AbstractRestTest {
       .spec(spec)
       .body(rulesToUpdate)
       .when()
-      .put(SERVICE_PATH)
+      .put(SERVICE_PATH  + MARC_BIB)
       .then()
       .statusCode(HttpStatus.SC_BAD_REQUEST);
     // then

--- a/ramls/mapping-rules-provider.raml
+++ b/ramls/mapping-rules-provider.raml
@@ -11,8 +11,6 @@ documentation:
 
 types:
   errors: !include raml-storage/raml-util/schemas/errors.schema
-  recordType:
-    enum: [ marc-bib, marc-holdings ]
 
 traits:
   validate: !include raml-storage/raml-util/traits/validation.raml
@@ -45,26 +43,26 @@ resourceTypes:
           body:
             text/plain:
               example: "Internal server error"
-  put:
-    is: [validate]
-    body:
-      application/json:
-        type: string
-    responses:
-      200:
-        body:
-          application/json:
-            type: string
-      400:
-        description: "Bad request"
-        body:
-          text/plain:
-            example: "Bad request"
-      500:
-        description: "Internal server error"
-        body:
-          text/plain:
-            example: "Internal server error"
+    put:
+      is: [validate]
+      body:
+        application/json:
+          type: string
+      responses:
+        200:
+          body:
+            application/json:
+              type: string
+        400:
+          description: "Not supports"
+          body:
+            text/plain:
+              example: "Only marc-bib or marc-holdings supports"
+        500:
+          description: "Internal server error"
+          body:
+            text/plain:
+              example: "Internal server error"
   /restore:
     put:
       is: [validate]


### PR DESCRIPTION
## Purpose
Update existing CLI endpoint PUT /mapping-rules to support MARC Holdings default rules

## Approach
modify existing PUT /mapping-rules endpoint to PUT /mapping-rules/marc-holdings
An endpoint should support URI path parameters:
marc-holdings
marc-bib
and put corresponding rules

## Learning
[MODSOURMAN-542](https://issues.folio.org/browse/MODSOURMAN-542)
