### PR TITLE
MODSOURMAN-553 Update GET /change-manager/parsedRecords to have externalId param

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -17,6 +17,7 @@
   support MARC Holdings default rules
 * [MODSOURMAN-543](https://issues.folio.org/browse/MODSOURMAN-543) Update existing CLI endpoint PUT
   /mapping-rules/restore to support MARC Holdings default rules
+* [MODSOURMAN-553](https://issues.folio.org/browse/MODSOURMAN-553) Update GET /change-manager/parsedRecords to have externalId param
 
 ## XXXX-XX-XX v3.1.3
 * [MODPUBSUB-187](https://issues.folio.org/browse/MODPUBSUB-187) Add support for max.request.size configuration for Kafka messages

--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -243,7 +243,7 @@
     },
     {
       "id": "source-manager-parsed-records",
-      "version": "2.0",
+      "version": "3.0",
       "handlers": [
         {
           "methods": [

--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -446,7 +446,7 @@
     },
     {
       "permissionName": "change-manager.parsedrecords.get",
-      "displayName": "Change Manager - get parsed records by instanceId",
+      "displayName": "Change Manager - get parsed records by externalId",
       "description": "Get parsed record"
     },
     {

--- a/mod-source-record-manager-server/src/main/java/org/folio/rest/impl/ChangeManagerImpl.java
+++ b/mod-source-record-manager-server/src/main/java/org/folio/rest/impl/ChangeManagerImpl.java
@@ -204,17 +204,17 @@ public class ChangeManagerImpl implements ChangeManager {
   }
 
   @Override
-  public void getChangeManagerParsedRecords(String instanceId, Map<String, String> okapiHeaders,
+  public void getChangeManagerParsedRecords(String externalId, Map<String, String> okapiHeaders,
                                             Handler<AsyncResult<Response>> asyncResultHandler, Context vertxContext) {
     vertxContext.runOnContext(v -> {
       try {
-        parsedRecordService.getRecordByInstanceId(instanceId, new OkapiConnectionParams(okapiHeaders, vertxContext.owner()))
+        parsedRecordService.getRecordByExternalId(externalId, new OkapiConnectionParams(okapiHeaders, vertxContext.owner()))
           .map(GetChangeManagerParsedRecordsResponse::respond200WithApplicationJson)
           .map(Response.class::cast)
           .otherwise(ExceptionHelper::mapExceptionToResponse)
           .onComplete(asyncResultHandler);
       } catch (Exception e) {
-        LOGGER.error(getMessage("Failed to retrieve parsed record by instanceId {}", e, instanceId));
+        LOGGER.error(getMessage("Failed to retrieve parsed record by externalId {}", e, externalId));
         asyncResultHandler.handle(Future.succeededFuture(ExceptionHelper.mapExceptionToResponse(e)));
       }
     });

--- a/mod-source-record-manager-server/src/main/java/org/folio/services/ParsedRecordService.java
+++ b/mod-source-record-manager-server/src/main/java/org/folio/services/ParsedRecordService.java
@@ -10,13 +10,13 @@ import org.folio.rest.jaxrs.model.ParsedRecordDto;
 public interface ParsedRecordService {
 
   /**
-   * Get {@link ParsedRecordDto} by instanceId
+   * Get {@link ParsedRecordDto} by externalId
    *
-   * @param instanceId - instanceId
+   * @param externalId - externalId
    * @param params     - OkapiConnectionParams
    * @return future with ParsedRecordDto, which was mapped from SourceRecord from SRS
    */
-  Future<ParsedRecordDto> getRecordByInstanceId(String instanceId, OkapiConnectionParams params);
+  Future<ParsedRecordDto> getRecordByExternalId(String externalId, OkapiConnectionParams params);
 
   /**
    * Creates new Record in SRS with higher generation, updates status of the OLD Record and sends event with updated Record

--- a/mod-source-record-manager-server/src/main/java/org/folio/services/ParsedRecordServiceImpl.java
+++ b/mod-source-record-manager-server/src/main/java/org/folio/services/ParsedRecordServiceImpl.java
@@ -55,11 +55,11 @@ public class ParsedRecordServiceImpl implements ParsedRecordService {
   }
 
   @Override
-  public Future<ParsedRecordDto> getRecordByInstanceId(String instanceId, OkapiConnectionParams params) {
+  public Future<ParsedRecordDto> getRecordByExternalId(String externalId, OkapiConnectionParams params) {
     Promise<ParsedRecordDto> promise = Promise.promise();
     var client = new SourceStorageSourceRecordsClient(params.getOkapiUrl(), params.getTenantId(), params.getToken());
     try {
-      client.getSourceStorageSourceRecordsById(instanceId, "INSTANCE", response -> {
+      client.getSourceStorageSourceRecordsById(externalId, "EXTERNAL", response -> {
         if (HTTP_OK.toInt() == response.result().statusCode()) {
           Buffer bodyAsBuffer = response.result().bodyAsBuffer();
           Try.itGet(() -> mapSourceRecordToParsedRecordDto(bodyAsBuffer))
@@ -76,8 +76,8 @@ public class ParsedRecordServiceImpl implements ParsedRecordService {
               }
             });
         } else {
-          String message = format("Error retrieving Record by instanceId: '%s', response code %s, %s",
-            instanceId, response.result().statusCode(), response.result().statusMessage());
+          String message = format("Error retrieving Record by externalId: '%s', response code %s, %s",
+            externalId, response.result().statusCode(), response.result().statusMessage());
           if (HTTP_NOT_FOUND.toInt() == response.result().statusCode()) {
             promise.fail(new NotFoundException(message));
           } else {

--- a/ramls/change-manager.raml
+++ b/ramls/change-manager.raml
@@ -210,10 +210,10 @@ resourceTypes:
                   example: "Internal server error"
   /parsedRecords:
     get:
-      description: "Retrieve ParsedRecord by instanceId"
+      description: "Retrieve ParsedRecord by externalId"
       queryParameters:
-        instanceId:
-          description: "instanceId parameter"
+        externalId:
+          description: "externalId parameter"
           pattern: "^[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[1-5][a-fA-F0-9]{3}-[89abAB][a-fA-F0-9]{3}-[a-fA-F0-9]{12}$"
           required: true
       responses:


### PR DESCRIPTION
## Purpose
Update GET /change-manager/parsedRecords  to have externalId param instead instanceId. It will give quick-marc an ability to fetch records by its externalId from SRS.

## Approach
instanceId parameter is replaced with externalId 

## Learning
[MODSOURMAN-553](https://issues.folio.org/browse/MODSOURMAN-553)
[API Documentation](https://s3.amazonaws.com/foliodocs/api/mod-source-record-manager/change-manager.html#change_manager_parsedrecords_get)
