### PR TITLE
MODSOURCE-286 - Provided module permission for retrieving mapping metadata

### DIFF
--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -228,7 +228,8 @@
             "inventory-storage.instances.item.put",
             "inventory-storage.preceding-succeeding-titles.item.post",
             "configuration.entries.collection.get",
-            "source-storage.verified.records"
+            "source-storage.verified.records",
+            "mapping-metadata.get"
           ]
         },
         {


### PR DESCRIPTION
## Purpose
since mapping metadata (mapping rules and parameters) should be deleted from the data-import payload it is  necessary to provide permission for modules participating in data-import to retrieve mapping metadata in case, when data-import is  initiated with sourceType="ONLINE" (bypassing the mod-data-import)

## Learning
[MODSOURCE-286](https://issues.folio.org/browse/MODSOURCE-286)