### PR TITLE
MODSOURMAN-560 Fix getting rules for records

### DIFF
--- a/mod-source-record-manager-server/src/main/java/org/folio/dao/MappingRuleDaoImpl.java
+++ b/mod-source-record-manager-server/src/main/java/org/folio/dao/MappingRuleDaoImpl.java
@@ -39,7 +39,7 @@ public class MappingRuleDaoImpl implements MappingRuleDao {
     Promise<RowSet<Row>> promise = Promise.promise();
     try {
       String query = format(SELECT_BY_TYPE_QUERY, convertToPsqlStandard(tenantId), TABLE_NAME);
-      Tuple queryParams = Tuple.of(recordType.toString());
+      Tuple queryParams = Tuple.of(recordType != null ? recordType.toString() : null);
       pgClientFactory.createInstance(tenantId).select(query, queryParams, promise);
     } catch (Exception e) {
       LOGGER.error("Error getting mapping rules", e);

--- a/mod-source-record-manager-server/src/main/java/org/folio/services/MappingRuleCache.java
+++ b/mod-source-record-manager-server/src/main/java/org/folio/services/MappingRuleCache.java
@@ -26,12 +26,10 @@ public class MappingRuleCache {
 
   private static final Logger LOGGER = LogManager.getLogger();
 
-  private MappingRuleDao mappingRuleDao;
-  private AsyncLoadingCache<MappingRuleCacheKey, Optional<JsonObject>> cache;
+  private final AsyncLoadingCache<MappingRuleCacheKey, Optional<JsonObject>> cache;
 
   @Autowired
   public MappingRuleCache(MappingRuleDao mappingRuleDao, Vertx vertx) {
-    this.mappingRuleDao = mappingRuleDao;
     cache = Caffeine.newBuilder()
       .executor(task -> vertx.runOnContext(ar -> task.run()))
       .buildAsync((key, executor) -> loadMappingRules(key, executor, mappingRuleDao));

--- a/mod-source-record-manager-server/src/main/java/org/folio/services/entity/MappingRuleCacheKey.java
+++ b/mod-source-record-manager-server/src/main/java/org/folio/services/entity/MappingRuleCacheKey.java
@@ -1,8 +1,5 @@
 package org.folio.services.entity;
 
-import javax.ws.rs.BadRequestException;
-
-import lombok.AllArgsConstructor;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
 
@@ -12,12 +9,17 @@ import org.folio.rest.jaxrs.model.ParsedRecordDto;
 
 @Getter
 @EqualsAndHashCode
-@AllArgsConstructor
 public class MappingRuleCacheKey {
+
   private String tenantId;
   private Record.RecordType recordType;
 
-  private static final String ERROR_MESSAGE = "Only marc-bib or marc-holdings supported";
+  public MappingRuleCacheKey(String tenantId, Record.RecordType recordType) {
+    this.tenantId = tenantId;
+    if (Record.RecordType.MARC_BIB.equals(recordType) || Record.RecordType.MARC_HOLDING.equals(recordType)) {
+      this.recordType = recordType;
+    }
+  }
 
   public MappingRuleCacheKey(String tenantId, ParsedRecordDto.RecordType recordType) {
     this.tenantId = tenantId;
@@ -25,8 +27,6 @@ public class MappingRuleCacheKey {
       this.recordType = Record.RecordType.MARC_BIB;
     } else if (ParsedRecordDto.RecordType.MARC_HOLDING.equals(recordType)) {
       this.recordType = Record.RecordType.MARC_HOLDING;
-    } else {
-      throw new BadRequestException(ERROR_MESSAGE);
     }
   }
 
@@ -36,8 +36,6 @@ public class MappingRuleCacheKey {
       this.recordType = Record.RecordType.MARC_BIB;
     } else if (JournalRecord.EntityType.MARC_HOLDINGS.equals(entityType)) {
       this.recordType = Record.RecordType.MARC_HOLDING;
-    } else {
-      throw new BadRequestException(ERROR_MESSAGE);
     }
   }
 
@@ -47,8 +45,6 @@ public class MappingRuleCacheKey {
       this.recordType = Record.RecordType.MARC_BIB;
     } else if (org.folio.rest.jaxrs.model.Record.RecordType.MARC_HOLDING.equals(recordType)) {
       this.recordType = Record.RecordType.MARC_HOLDING;
-    } else {
-      throw new BadRequestException(ERROR_MESSAGE);
     }
   }
 }

--- a/mod-source-record-manager-server/src/test/java/org/folio/dao/MappingRuleDaoImplTest.java
+++ b/mod-source-record-manager-server/src/test/java/org/folio/dao/MappingRuleDaoImplTest.java
@@ -1,0 +1,62 @@
+package org.folio.dao;
+
+import static org.junit.Assert.*;
+
+import java.io.IOException;
+import java.util.Optional;
+
+import io.vertx.core.Future;
+import io.vertx.core.Vertx;
+import io.vertx.core.json.JsonObject;
+import io.vertx.ext.unit.Async;
+import io.vertx.ext.unit.TestContext;
+import io.vertx.ext.unit.junit.VertxUnitRunner;
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.InjectMocks;
+import org.mockito.MockitoAnnotations;
+import org.mockito.Spy;
+
+import org.folio.dao.util.PostgresClientFactory;
+import org.folio.rest.impl.AbstractRestTest;
+
+@RunWith(VertxUnitRunner.class)
+public class MappingRuleDaoImplTest extends AbstractRestTest {
+
+  @Spy
+  private PostgresClientFactory postgresClientFactory = new PostgresClientFactory(Vertx.vertx());
+
+  @InjectMocks
+  private MappingRuleDao mappingRuleDao = new MappingRuleDaoImpl();
+
+  private AutoCloseable mocks;
+
+  @Before
+  public void setUp(TestContext context) throws IOException {
+    mocks = MockitoAnnotations.openMocks(this);
+    super.setUp(context);
+  }
+
+  @After
+  public void tearDown() throws Exception {
+    mocks.close();
+  }
+
+  @Test
+  public void name(TestContext testContext) {
+    Async async = testContext.async();
+
+    var future = mappingRuleDao.get(null, TENANT_ID);
+
+    future.onComplete(ar -> {
+      testContext.verify(v -> {
+        Assert.assertTrue(ar.succeeded());
+        Assert.assertTrue(ar.result().isEmpty());
+      });
+      async.complete();
+    });
+  }
+}

--- a/mod-source-record-manager-server/src/test/java/org/folio/rest/impl/changeManager/ChangeManagerParsedRecordsAPITest.java
+++ b/mod-source-record-manager-server/src/test/java/org/folio/rest/impl/changeManager/ChangeManagerParsedRecordsAPITest.java
@@ -152,26 +152,6 @@ public class ChangeManagerParsedRecordsAPITest extends AbstractRestTest {
   }
 
   @Test
-  public void shouldReturnBadRequestOnPutIfRecordTypeIsNotSupported(TestContext testContext) {
-    Async async = testContext.async();
-
-    ParsedRecordDto parsedRecordDto = new ParsedRecordDto()
-      .withId(UUID.randomUUID().toString())
-      .withParsedRecord(new ParsedRecord().withId(UUID.randomUUID().toString())
-        .withContent("{\"leader\":\"01240cas a2200397   4500\",\"fields\":[]}"))
-      .withRecordType(ParsedRecordDto.RecordType.MARC_AUTHORITY);
-
-    RestAssured.given()
-      .spec(spec)
-      .body(parsedRecordDto)
-      .when()
-      .put(PARSED_RECORDS_URL + "/" + parsedRecordDto.getId())
-      .then()
-      .statusCode(HttpStatus.SC_BAD_REQUEST);
-    async.complete();
-  }
-
-  @Test
   public void shouldUpdateParsedRecordOnPut(TestContext testContext) throws InterruptedException {
     Async async = testContext.async();
 

--- a/mod-source-record-manager-server/src/test/java/org/folio/verticle/consumers/StoredRecordChunksKafkaHandlerTest.java
+++ b/mod-source-record-manager-server/src/test/java/org/folio/verticle/consumers/StoredRecordChunksKafkaHandlerTest.java
@@ -126,9 +126,8 @@ public class StoredRecordChunksKafkaHandlerTest {
   }
 
   @Test
-  public void shouldThrowBadRequestWhileSavedMarcAuthorityRecordsInfoToImportJournal() {
-    assertThrows("Only marc-bib or marc-holdings supported", BadRequestException.class,
-      () -> writeSavedMarcRecordsInfoToImportJournal(MARC_AUTHORITY_RECORD_PATH, EntityType.MARC_AUTHORITY));
+  public void shouldWriteSavedMarcAuthorityRecordsInfoToImportJournal() throws IOException {
+    writeSavedMarcRecordsInfoToImportJournal(MARC_AUTHORITY_RECORD_PATH, EntityType.MARC_AUTHORITY);
   }
 
   private void writeSavedMarcRecordsInfoToImportJournal(String marcBibRecordPath, EntityType entityType)


### PR DESCRIPTION
## Bug description
After introducing mapping rules for MARC_HOLDINGS a new logic was added for saving mapping rules for different MARC files. The implementation didn't take into account that there is no mapping rules for EDIFACT, and this step should be skipped for such records.
