### PR TITLE
MODSOURMAN-561 Can`t map record into journal

### DIFF
--- a/mod-source-record-manager-server/src/main/java/org/folio/services/RecordsPublishingServiceImpl.java
+++ b/mod-source-record-manager-server/src/main/java/org/folio/services/RecordsPublishingServiceImpl.java
@@ -195,8 +195,7 @@ public class RecordsPublishingServiceImpl implements RecordsPublishingService {
       .withEventType(eventType)
       .withProfileSnapshot(profileSnapshotWrapper)
       .withCurrentNode(
-        // TODO check for Holdings should be removed after implementing linkage with mod-inventory holdings records
-        MARC_AUTHORITY.equals(record.getRecordType()) || MARC_HOLDING.equals(record.getRecordType())
+        MARC_AUTHORITY.equals(record.getRecordType())
           ? new ProfileSnapshotWrapper()
           : profileSnapshotWrapper.getChildSnapshotWrappers().get(0))
       .withJobExecutionId(record.getSnapshotId())

--- a/mod-source-record-manager-server/src/main/java/org/folio/verticle/consumers/util/JournalParams.java
+++ b/mod-source-record-manager-server/src/main/java/org/folio/verticle/consumers/util/JournalParams.java
@@ -200,6 +200,8 @@ public class JournalParams {
             sourceRecordType = JournalRecord.EntityType.EDIFACT;
           } else if (eventPayload.getContext().containsKey(JournalRecord.EntityType.MARC_HOLDINGS.value())) {
             sourceRecordType = JournalRecord.EntityType.MARC_HOLDINGS;
+          } else if (eventPayload.getContext().containsKey(JournalRecord.EntityType.MARC_AUTHORITY.value())) {
+            sourceRecordType = JournalRecord.EntityType.MARC_AUTHORITY;
           } else sourceRecordType = JournalRecord.EntityType.MARC_BIBLIOGRAPHIC;
           return Optional.of(new JournalParams(CREATE, sourceRecordType, ERROR));
         }

--- a/mod-source-record-manager-server/src/main/java/org/folio/verticle/consumers/util/JournalParams.java
+++ b/mod-source-record-manager-server/src/main/java/org/folio/verticle/consumers/util/JournalParams.java
@@ -1,8 +1,8 @@
 package org.folio.verticle.consumers.util;
 
-import org.apache.commons.collections4.CollectionUtils;
-import org.folio.DataImportEventPayload;
-import org.folio.rest.jaxrs.model.JournalRecord;
+import static org.folio.rest.jaxrs.model.EntityType.EDIFACT_INVOICE;
+import static org.folio.rest.jaxrs.model.JournalRecord.ActionStatus.ERROR;
+import static org.folio.rest.jaxrs.model.JournalRecord.ActionType.CREATE;
 
 import java.util.Arrays;
 import java.util.Map;
@@ -11,9 +11,10 @@ import java.util.function.Function;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
-import static org.folio.rest.jaxrs.model.EntityType.EDIFACT_INVOICE;
-import static org.folio.rest.jaxrs.model.JournalRecord.ActionStatus.ERROR;
-import static org.folio.rest.jaxrs.model.JournalRecord.ActionType.CREATE;
+import org.apache.commons.collections4.CollectionUtils;
+
+import org.folio.DataImportEventPayload;
+import org.folio.rest.jaxrs.model.JournalRecord;
 
 public class JournalParams {
 
@@ -194,8 +195,12 @@ public class JournalParams {
       @Override
       public Optional<JournalParams> getJournalParams(DataImportEventPayload eventPayload) {
         if (CollectionUtils.isEmpty(eventPayload.getEventsChain())) {
-          JournalRecord.EntityType sourceRecordType = eventPayload.getContext().containsKey(EDIFACT_INVOICE.value())
-            ? JournalRecord.EntityType.EDIFACT : JournalRecord.EntityType.MARC_BIBLIOGRAPHIC;
+          JournalRecord.EntityType sourceRecordType;
+          if (eventPayload.getContext().containsKey(EDIFACT_INVOICE.value())) {
+            sourceRecordType = JournalRecord.EntityType.EDIFACT;
+          } else if (eventPayload.getContext().containsKey(JournalRecord.EntityType.MARC_HOLDINGS.value())) {
+            sourceRecordType = JournalRecord.EntityType.MARC_HOLDINGS;
+          } else sourceRecordType = JournalRecord.EntityType.MARC_BIBLIOGRAPHIC;
           return Optional.of(new JournalParams(CREATE, sourceRecordType, ERROR));
         }
 

--- a/mod-source-record-manager-server/src/test/java/org/folio/verticle/consumers/util/JournalParamsTest.java
+++ b/mod-source-record-manager-server/src/test/java/org/folio/verticle/consumers/util/JournalParamsTest.java
@@ -60,9 +60,9 @@ public class JournalParamsTest {
 
     var journalParams = journalParamsOptional.get();
 
-    Assert.assertEquals(journalParams.journalEntityType, JournalRecord.EntityType.MARC_HOLDINGS);
-    Assert.assertEquals(journalParams.journalActionType, JournalRecord.ActionType.CREATE);
-    Assert.assertEquals(journalParams.journalActionStatus, JournalRecord.ActionStatus.ERROR);
+    Assert.assertEquals(JournalRecord.EntityType.MARC_HOLDINGS, journalParams.journalEntityType);
+    Assert.assertEquals(JournalRecord.ActionType.CREATE, journalParams.journalActionType);
+    Assert.assertEquals(JournalRecord.ActionStatus.ERROR, journalParams.journalActionStatus);
   }
 
   @Test
@@ -76,9 +76,9 @@ public class JournalParamsTest {
 
     var journalParams = journalParamsOptional.get();
 
-    Assert.assertEquals(journalParams.journalEntityType, JournalRecord.EntityType.MARC_BIBLIOGRAPHIC);
-    Assert.assertEquals(journalParams.journalActionType, JournalRecord.ActionType.CREATE);
-    Assert.assertEquals(journalParams.journalActionStatus, JournalRecord.ActionStatus.ERROR);
+    Assert.assertEquals(JournalRecord.EntityType.MARC_BIBLIOGRAPHIC, journalParams.journalEntityType);
+    Assert.assertEquals(JournalRecord.ActionType.CREATE, journalParams.journalActionType);
+    Assert.assertEquals(JournalRecord.ActionStatus.ERROR, journalParams.journalActionStatus);
   }
 
   @Test
@@ -92,9 +92,9 @@ public class JournalParamsTest {
 
     var journalParams = journalParamsOptional.get();
 
-    Assert.assertEquals(journalParams.journalEntityType, JournalRecord.EntityType.EDIFACT);
-    Assert.assertEquals(journalParams.journalActionType, JournalRecord.ActionType.CREATE);
-    Assert.assertEquals(journalParams.journalActionStatus, JournalRecord.ActionStatus.ERROR);
+    Assert.assertEquals(JournalRecord.EntityType.EDIFACT, journalParams.journalEntityType);
+    Assert.assertEquals(JournalRecord.ActionType.CREATE, journalParams.journalActionType);
+    Assert.assertEquals(JournalRecord.ActionStatus.ERROR, journalParams.journalActionStatus);
   }
 
   @Test
@@ -107,9 +107,9 @@ public class JournalParamsTest {
       JournalParams.JournalParamsEnum.getValue(eventPayload.getEventType()).getJournalParams(eventPayload);
 
     var journalParams = journalParamsOptional.get();
-    Assert.assertEquals(journalParams.journalEntityType, JournalRecord.EntityType.MARC_AUTHORITY);
-    Assert.assertEquals(journalParams.journalActionType, JournalRecord.ActionType.CREATE);
-    Assert.assertEquals(journalParams.journalActionStatus, JournalRecord.ActionStatus.ERROR);
+    Assert.assertEquals(JournalRecord.EntityType.MARC_AUTHORITY, journalParams.journalEntityType);
+    Assert.assertEquals(JournalRecord.ActionType.CREATE, journalParams.journalActionType);
+    Assert.assertEquals(JournalRecord.ActionStatus.ERROR, journalParams.journalActionStatus);
   }
 
   @Test
@@ -122,9 +122,9 @@ public class JournalParamsTest {
 
     var journalParams = journalParamsOptional.get();
 
-    Assert.assertEquals(journalParams.journalEntityType, JournalRecord.EntityType.MARC_HOLDINGS);
-    Assert.assertEquals(journalParams.journalActionType, JournalRecord.ActionType.CREATE);
-    Assert.assertEquals(journalParams.journalActionStatus, JournalRecord.ActionStatus.ERROR);
+    Assert.assertEquals(JournalRecord.EntityType.MARC_HOLDINGS, journalParams.journalEntityType);
+    Assert.assertEquals(JournalRecord.ActionType.CREATE, journalParams.journalActionType);
+    Assert.assertEquals(JournalRecord.ActionStatus.ERROR, journalParams.journalActionStatus);
   }
 
   @Test
@@ -138,9 +138,9 @@ public class JournalParamsTest {
       JournalParams.JournalParamsEnum.getValue(eventPayload.getEventType()).getJournalParams(eventPayload);
 
     var journalParams = journalParamsOptional.get();
-    Assert.assertEquals(journalParams.journalEntityType, JournalRecord.EntityType.MARC_HOLDINGS);
-    Assert.assertEquals(journalParams.journalActionType, JournalRecord.ActionType.CREATE);
-    Assert.assertEquals(journalParams.journalActionStatus, JournalRecord.ActionStatus.COMPLETED);
+    Assert.assertEquals(JournalRecord.EntityType.MARC_HOLDINGS, journalParams.journalEntityType);
+    Assert.assertEquals(JournalRecord.ActionType.CREATE, journalParams.journalActionType);
+    Assert.assertEquals(JournalRecord.ActionStatus.COMPLETED, journalParams.journalActionStatus);
   }
 
   @Test
@@ -153,7 +153,7 @@ public class JournalParamsTest {
     var journalParamsOptional =
       JournalParams.JournalParamsEnum.getValue(eventPayload.getEventType()).getJournalParams(eventPayload);
 
-    Assert.assertEquals(journalParamsOptional, Optional.empty());
+    Assert.assertEquals(Optional.empty(), journalParamsOptional);
   }
 
   @Test
@@ -254,9 +254,9 @@ public class JournalParamsTest {
 
     var journalParams = journalParamsOptional.get();
 
-    Assert.assertEquals(journalParams.journalEntityType, entityType);
-    Assert.assertEquals(journalParams.journalActionType, actionType);
-    Assert.assertEquals(journalParams.journalActionStatus, JournalRecord.ActionStatus.COMPLETED);
+    Assert.assertEquals(entityType, journalParams.journalEntityType);
+    Assert.assertEquals(actionType, journalParams.journalActionType);
+    Assert.assertEquals(JournalRecord.ActionStatus.COMPLETED, journalParams.journalActionStatus);
   }
 
   @Test(expected = IllegalArgumentException.class)

--- a/mod-source-record-manager-server/src/test/java/org/folio/verticle/consumers/util/JournalParamsTest.java
+++ b/mod-source-record-manager-server/src/test/java/org/folio/verticle/consumers/util/JournalParamsTest.java
@@ -1,0 +1,266 @@
+package org.folio.verticle.consumers.util;
+
+import static org.folio.DataImportEventTypes.DI_COMPLETED;
+import static org.folio.DataImportEventTypes.DI_ERROR;
+import static org.folio.rest.jaxrs.model.DataImportEventTypes.DI_INVENTORY_HOLDING_CREATED;
+import static org.folio.rest.jaxrs.model.DataImportEventTypes.DI_INVENTORY_HOLDING_NOT_MATCHED;
+import static org.folio.rest.jaxrs.model.DataImportEventTypes.DI_INVENTORY_HOLDING_UPDATED;
+import static org.folio.rest.jaxrs.model.DataImportEventTypes.DI_INVENTORY_INSTANCE_CREATED;
+import static org.folio.rest.jaxrs.model.DataImportEventTypes.DI_INVENTORY_INSTANCE_NOT_MATCHED;
+import static org.folio.rest.jaxrs.model.DataImportEventTypes.DI_INVENTORY_INSTANCE_UPDATED;
+import static org.folio.rest.jaxrs.model.DataImportEventTypes.DI_INVENTORY_ITEM_CREATED;
+import static org.folio.rest.jaxrs.model.DataImportEventTypes.DI_INVENTORY_ITEM_NOT_MATCHED;
+import static org.folio.rest.jaxrs.model.DataImportEventTypes.DI_INVENTORY_ITEM_UPDATED;
+import static org.folio.rest.jaxrs.model.DataImportEventTypes.DI_LOG_SRS_MARC_BIB_RECORD_CREATED;
+import static org.folio.rest.jaxrs.model.DataImportEventTypes.DI_LOG_SRS_MARC_BIB_RECORD_UPDATED;
+import static org.folio.rest.jaxrs.model.DataImportEventTypes.DI_SRS_MARC_AUTHORITY_RECORD_CREATED;
+import static org.folio.rest.jaxrs.model.DataImportEventTypes.DI_SRS_MARC_BIB_RECORD_MATCHED;
+import static org.folio.rest.jaxrs.model.DataImportEventTypes.DI_SRS_MARC_BIB_RECORD_MODIFIED;
+import static org.folio.rest.jaxrs.model.DataImportEventTypes.DI_SRS_MARC_BIB_RECORD_MODIFIED_READY_FOR_POST_PROCESSING;
+import static org.folio.rest.jaxrs.model.DataImportEventTypes.DI_SRS_MARC_BIB_RECORD_NOT_MATCHED;
+import static org.folio.rest.jaxrs.model.DataImportEventTypes.DI_SRS_MARC_BIB_RECORD_UPDATED;
+import static org.folio.rest.jaxrs.model.DataImportEventTypes.DI_SRS_MARC_HOLDING_RECORD_CREATED;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Optional;
+
+import io.vertx.core.json.JsonObject;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.BlockJUnit4ClassRunner;
+
+import org.folio.DataImportEventPayload;
+import org.folio.rest.jaxrs.model.DataImportEventTypes;
+import org.folio.rest.jaxrs.model.EntityType;
+import org.folio.rest.jaxrs.model.JournalRecord;
+
+@RunWith(BlockJUnit4ClassRunner.class)
+public class JournalParamsTest {
+
+  public DataImportEventPayload eventPayload;
+  public HashMap<String, String> context;
+
+  @Before
+  public void setUp() {
+    eventPayload = new DataImportEventPayload();
+    context = new HashMap<>();
+  }
+
+  @Test
+  public void shouldPopulateEntityTypeMarcHoldingsWhenEventTypeIsDiError() {
+    eventPayload.setEventType(DI_ERROR.value());
+    context.put(EntityType.MARC_HOLDINGS.value(), new JsonObject().encode());
+    eventPayload.setContext(context);
+
+    var journalParamsOptional =
+      JournalParams.JournalParamsEnum.getValue(eventPayload.getEventType()).getJournalParams(eventPayload);
+
+    var journalParams = journalParamsOptional.get();
+
+    Assert.assertEquals(journalParams.journalEntityType, JournalRecord.EntityType.MARC_HOLDINGS);
+    Assert.assertEquals(journalParams.journalActionType, JournalRecord.ActionType.CREATE);
+    Assert.assertEquals(journalParams.journalActionStatus, JournalRecord.ActionStatus.ERROR);
+  }
+
+  @Test
+  public void shouldPopulateEntityTypeMarcBibWhenEventTypeIsDiError() {
+    eventPayload.setEventType(DI_ERROR.value());
+    context.put(EntityType.MARC_BIBLIOGRAPHIC.value(), new JsonObject().encode());
+    eventPayload.setContext(context);
+
+    var journalParamsOptional =
+      JournalParams.JournalParamsEnum.getValue(eventPayload.getEventType()).getJournalParams(eventPayload);
+
+    var journalParams = journalParamsOptional.get();
+
+    Assert.assertEquals(journalParams.journalEntityType, JournalRecord.EntityType.MARC_BIBLIOGRAPHIC);
+    Assert.assertEquals(journalParams.journalActionType, JournalRecord.ActionType.CREATE);
+    Assert.assertEquals(journalParams.journalActionStatus, JournalRecord.ActionStatus.ERROR);
+  }
+
+  @Test
+  public void shouldPopulateEntityTypeEdifactWhenEventTypeIsDiError() {
+    eventPayload.setEventType(DI_ERROR.value());
+    context.put(EntityType.EDIFACT_INVOICE.value(), new JsonObject().encode());
+    eventPayload.setContext(context);
+
+    var journalParamsOptional =
+      JournalParams.JournalParamsEnum.getValue(eventPayload.getEventType()).getJournalParams(eventPayload);
+
+    var journalParams = journalParamsOptional.get();
+
+    Assert.assertEquals(journalParams.journalEntityType, JournalRecord.EntityType.EDIFACT);
+    Assert.assertEquals(journalParams.journalActionType, JournalRecord.ActionType.CREATE);
+    Assert.assertEquals(journalParams.journalActionStatus, JournalRecord.ActionStatus.ERROR);
+  }
+
+  @Test
+  public void shouldPopulateEntityTypeMarcAuthorityWhenEventTypeIsDiError() {
+    eventPayload.setEventType(DI_ERROR.value());
+    context.put(EntityType.MARC_AUTHORITY.value(), new JsonObject().encode());
+    eventPayload.setContext(context);
+
+    var journalParamsOptional =
+      JournalParams.JournalParamsEnum.getValue(eventPayload.getEventType()).getJournalParams(eventPayload);
+
+    var journalParams = journalParamsOptional.get();
+    Assert.assertEquals(journalParams.journalEntityType, JournalRecord.EntityType.MARC_AUTHORITY);
+    Assert.assertEquals(journalParams.journalActionType, JournalRecord.ActionType.CREATE);
+    Assert.assertEquals(journalParams.journalActionStatus, JournalRecord.ActionStatus.ERROR);
+  }
+
+  @Test
+  public void shouldPopulateEntityTypeMarcHoldingsWhenEventChainIsNotEmpty() {
+    eventPayload.setEventType(DI_ERROR.value());
+    eventPayload.setEventsChain(Collections.singletonList("DI_SRS_MARC_HOLDING_RECORD_CREATED"));
+
+    Optional<JournalParams> journalParamsOptional =
+      JournalParams.JournalParamsEnum.getValue(eventPayload.getEventType()).getJournalParams(eventPayload);
+
+    var journalParams = journalParamsOptional.get();
+
+    Assert.assertEquals(journalParams.journalEntityType, JournalRecord.EntityType.MARC_HOLDINGS);
+    Assert.assertEquals(journalParams.journalActionType, JournalRecord.ActionType.CREATE);
+    Assert.assertEquals(journalParams.journalActionStatus, JournalRecord.ActionStatus.ERROR);
+  }
+
+  @Test
+  public void shouldPopulateEntityTypeMarcAuthorityWhenEventTypeIsDiCompleted() {
+    eventPayload.setEventType(DI_COMPLETED.value());
+    context.put(EntityType.MARC_HOLDINGS.value(), new JsonObject().encode());
+    eventPayload.setContext(context);
+    eventPayload.setEventsChain(Collections.singletonList("DI_SRS_MARC_HOLDING_RECORD_CREATED"));
+
+    var journalParamsOptional =
+      JournalParams.JournalParamsEnum.getValue(eventPayload.getEventType()).getJournalParams(eventPayload);
+
+    var journalParams = journalParamsOptional.get();
+    Assert.assertEquals(journalParams.journalEntityType, JournalRecord.EntityType.MARC_HOLDINGS);
+    Assert.assertEquals(journalParams.journalActionType, JournalRecord.ActionType.CREATE);
+    Assert.assertEquals(journalParams.journalActionStatus, JournalRecord.ActionStatus.COMPLETED);
+  }
+
+  @Test
+  public void shouldPopulateOptionalForIncorrectEventTypeWhenEventTypeIsDiCompleted() {
+    eventPayload.setEventType(DI_COMPLETED.value());
+    context.put(EntityType.MARC_HOLDINGS.value(), new JsonObject().encode());
+    eventPayload.setContext(context);
+    eventPayload.setEventsChain(Collections.singletonList("incorrect_event_type_name"));
+
+    var journalParamsOptional =
+      JournalParams.JournalParamsEnum.getValue(eventPayload.getEventType()).getJournalParams(eventPayload);
+
+    Assert.assertEquals(journalParamsOptional, Optional.empty());
+  }
+
+  @Test
+  public void shouldPopulateEntityTypeMarcHoldingsWhenEventTypeIsDiMarcHoldingRecordCreated() {
+    populateEntityTypeAndActionTypeByEventType(DI_SRS_MARC_HOLDING_RECORD_CREATED, JournalRecord.EntityType.MARC_HOLDINGS, JournalRecord.ActionType.CREATE);
+  }
+
+  @Test
+  public void shouldPopulateEntityTypeMarcBibWhenEventTypeIsDiLogSrsMarcBibRecordUpdated() {
+    populateEntityTypeAndActionTypeByEventType(DI_LOG_SRS_MARC_BIB_RECORD_UPDATED, JournalRecord.EntityType.MARC_BIBLIOGRAPHIC, JournalRecord.ActionType.UPDATE);
+  }
+
+  @Test
+  public void shouldPopulateEntityTypeMarcBibWhenEventTypeIsDiLogSrsMarcBibRecordCreated() {
+    populateEntityTypeAndActionTypeByEventType(DI_LOG_SRS_MARC_BIB_RECORD_CREATED, JournalRecord.EntityType.MARC_BIBLIOGRAPHIC, JournalRecord.ActionType.CREATE);
+  }
+
+  @Test
+  public void shouldPopulateEntityTypeMarcAuthorityWhenEventTypeIsDiSrsMarcAuthorityRecordCreated() {
+    populateEntityTypeAndActionTypeByEventType(DI_SRS_MARC_AUTHORITY_RECORD_CREATED, JournalRecord.EntityType.MARC_AUTHORITY, JournalRecord.ActionType.CREATE);
+  }
+
+  @Test
+  public void shouldPopulateEntityTypeItemWhenEventTypeIsDiInventoryItemNonMatched() {
+    populateEntityTypeAndActionTypeByEventType(DI_INVENTORY_ITEM_NOT_MATCHED, JournalRecord.EntityType.ITEM, JournalRecord.ActionType.NON_MATCH);
+  }
+
+  @Test
+  public void shouldPopulateEntityTypeItemWhenEventTypeIsDiInventoryItemUpdated() {
+    populateEntityTypeAndActionTypeByEventType(DI_INVENTORY_ITEM_UPDATED, JournalRecord.EntityType.ITEM, JournalRecord.ActionType.UPDATE);
+  }
+
+  @Test
+  public void shouldPopulateEntityTypeItemWhenEventTypeIsDiInventoryItemCreated() {
+    populateEntityTypeAndActionTypeByEventType(DI_INVENTORY_ITEM_CREATED, JournalRecord.EntityType.ITEM, JournalRecord.ActionType.CREATE);
+  }
+
+  @Test
+  public void shouldPopulateEntityTypeHoldingsWhenEventTypeIsDiInventoryHoldingNotMarched() {
+    populateEntityTypeAndActionTypeByEventType(DI_INVENTORY_HOLDING_NOT_MATCHED, JournalRecord.EntityType.HOLDINGS, JournalRecord.ActionType.NON_MATCH);
+  }
+
+  @Test
+  public void shouldPopulateEntityTypeHoldingsWhenEventTypeIsDiInventoryHoldingUpdated() {
+    populateEntityTypeAndActionTypeByEventType(DI_INVENTORY_HOLDING_UPDATED, JournalRecord.EntityType.HOLDINGS, JournalRecord.ActionType.UPDATE);
+  }
+
+  @Test
+  public void shouldPopulateEntityTypeHoldingsWhenEventTypeIsDiInventoryHoldingCreated() {
+    populateEntityTypeAndActionTypeByEventType(DI_INVENTORY_HOLDING_CREATED, JournalRecord.EntityType.HOLDINGS, JournalRecord.ActionType.CREATE);
+  }
+
+  @Test
+  public void shouldPopulateEntityTypeInstanceWhenEventTypeIsDiInventoryInstanceNonMatched() {
+    populateEntityTypeAndActionTypeByEventType(DI_INVENTORY_INSTANCE_NOT_MATCHED, JournalRecord.EntityType.INSTANCE, JournalRecord.ActionType.NON_MATCH);
+  }
+
+  @Test
+  public void shouldPopulateEntityTypeInstanceWhenEventTypeIsDiInventoryInstanceUpdated() {
+    populateEntityTypeAndActionTypeByEventType(DI_INVENTORY_INSTANCE_UPDATED, JournalRecord.EntityType.INSTANCE, JournalRecord.ActionType.UPDATE);
+  }
+
+  @Test
+  public void shouldPopulateEntityTypeMarcBibWhenEventTypeIsDiSrsMarcBibReadyFOrPostProcessing() {
+    populateEntityTypeAndActionTypeByEventType(DI_SRS_MARC_BIB_RECORD_MODIFIED_READY_FOR_POST_PROCESSING, JournalRecord.EntityType.INSTANCE, JournalRecord.ActionType.UPDATE);
+  }
+
+  @Test
+  public void shouldPopulateEntityTypeInstanceWhenEventTypeIsDiInventoryInstanceCreated() {
+    populateEntityTypeAndActionTypeByEventType(DI_INVENTORY_INSTANCE_CREATED, JournalRecord.EntityType.INSTANCE, JournalRecord.ActionType.CREATE);
+  }
+
+  @Test
+  public void shouldPopulateEntityTypeMarcBibWhenEventTypeIsDiSrsMarcBibRecordNotMatched() {
+    populateEntityTypeAndActionTypeByEventType(DI_SRS_MARC_BIB_RECORD_NOT_MATCHED, JournalRecord.EntityType.MARC_BIBLIOGRAPHIC, JournalRecord.ActionType.NON_MATCH);
+  }
+
+  @Test
+  public void shouldPopulateEntityTypeMarcBibWhenEventTypeIsDiSrsMarcBibRecordMatched() {
+    populateEntityTypeAndActionTypeByEventType(DI_SRS_MARC_BIB_RECORD_MATCHED, JournalRecord.EntityType.MARC_BIBLIOGRAPHIC, JournalRecord.ActionType.MATCH);
+  }
+
+  @Test
+  public void shouldPopulateEntityTypeMarcBibWhenEventTypeIsDiSrsMarcBibRecordModified() {
+    populateEntityTypeAndActionTypeByEventType(DI_SRS_MARC_BIB_RECORD_MODIFIED, JournalRecord.EntityType.MARC_BIBLIOGRAPHIC, JournalRecord.ActionType.MODIFY);
+  }
+
+  @Test
+  public void shouldPopulateEntityTypeMarcBibWhenEventTypeIsDiSrsMarcBibRecordUpdated() {
+    populateEntityTypeAndActionTypeByEventType(DI_SRS_MARC_BIB_RECORD_UPDATED, JournalRecord.EntityType.MARC_BIBLIOGRAPHIC, JournalRecord.ActionType.UPDATE);
+  }
+
+  private void populateEntityTypeAndActionTypeByEventType(DataImportEventTypes eventType, JournalRecord.EntityType entityType, JournalRecord.ActionType actionType) {
+    eventPayload.setEventType(eventType.value());
+
+    var journalParamsOptional =
+      JournalParams.JournalParamsEnum.getValue(eventPayload.getEventType()).getJournalParams(eventPayload);
+
+    var journalParams = journalParamsOptional.get();
+
+    Assert.assertEquals(journalParams.journalEntityType, entityType);
+    Assert.assertEquals(journalParams.journalActionType, actionType);
+    Assert.assertEquals(journalParams.journalActionStatus, JournalRecord.ActionStatus.COMPLETED);
+  }
+
+  @Test(expected = IllegalArgumentException.class)
+  public void shouldThrowExceptionWhenJournalParamsNameIsNotAvailable() {
+    JournalParams.JournalParamsEnum.getValue("not available event");
+  }
+}


### PR DESCRIPTION
## Purpose
During import marc holding by using data-import-flow, on the snapshot environment we receive error while data-import try to build journal record/instance.

## Approach
- added entity type for marc holding during throw di_error
- removed checking on the marc holdings from payload

#### TODOS and Open Questions
- [ ] Use GitHub checklists. When solved, check the box and explain the answer.

## Learning
https://issues.folio.org/browse/MODSOURMAN-561
