### PR TITLE
MODSOURMAN-563 Add MARC-Instance field mapping for Cancelled system control number

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -23,6 +23,7 @@
 * [MODSOURMAN-544](https://issues.folio.org/browse/MODSOURMAN-544) Validate MARC Holdings 004 field from MARC Bib HRID
 * [MODSOURMAN-546](https://issues.folio.org/browse/MODSOURMAN-546) Support edit Holdings via quickMarc
 * [MODSOURMAN-464](https://issues.folio.org/browse/MODSOURMAN-464) Store snapshots of MappingRules and MappingParams to the database
+* [MODSOURMAN-563](https://issues.folio.org/browse/MODSOURMAN-563) Add MARC-Instance field mapping for Cancelled system control number
 
 ## XXXX-XX-XX v3.1.3
 * [MODPUBSUB-187](https://issues.folio.org/browse/MODPUBSUB-187) Add support for max.request.size configuration for Kafka messages

--- a/mod-source-record-manager-server/src/main/resources/rules/marc_bib_rules.json
+++ b/mod-source-record-manager-server/src/main/resources/rules/marc_bib_rules.json
@@ -113,6 +113,48 @@
       ]
     }
   ],
+  "019": [
+    {
+      "entityPerRepeatedSubfield": true,
+      "entity": [
+        {
+          "target": "identifiers.identifierTypeId",
+          "description": "Type for Cancelled system control number",
+          "subfield": [
+            "a"
+          ],
+          "rules": [
+            {
+              "conditions": [
+                {
+                  "type": "set_identifier_type_id_by_name",
+                  "parameter": {
+                    "name": "Cancelled system control number"
+                  }
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "target": "identifiers.value",
+          "description": "Cancelled system control number",
+          "subfield": [
+            "a"
+          ],
+          "rules": [
+            {
+              "conditions": [
+                {
+                  "type": "trim"
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    }
+  ],
   "020": [
     {
       "entity": [
@@ -463,6 +505,46 @@
           "description": "System Control Number",
           "subfield": [
             "a"
+          ]
+        }
+      ]
+    },
+    {
+      "entityPerRepeatedSubfield": true,
+      "entity": [
+        {
+          "target": "identifiers.identifierTypeId",
+          "description": "Type for Cancelled system control number",
+          "subfield": [
+            "z"
+          ],
+          "rules": [
+            {
+              "conditions": [
+                {
+                  "type": "set_identifier_type_id_by_name",
+                  "parameter": {
+                    "name": "Cancelled system control number"
+                  }
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "target": "identifiers.value",
+          "description": "Cancelled system control number",
+          "subfield": [
+            "z"
+          ],
+          "rules": [
+            {
+              "conditions": [
+                {
+                  "type": "trim"
+                }
+              ]
+            }
           ]
         }
       ]
@@ -6601,8 +6683,8 @@
       "subfield": [
         "6"
       ],
-      "fieldReplacementBy3Digits" : true,
-      "fieldReplacementRule" : [
+      "fieldReplacementBy3Digits": true,
+      "fieldReplacementRule": [
         {
           "sourceDigits": "100",
           "targetField": "700"


### PR DESCRIPTION
## Purpose
In scope of adding Cancelled system control number as resource identifier type:
-	Added mapping rules for 019$a and 035$z subfields;

## Learning
https://issues.folio.org/browse/MODSOURMAN-563