### PR TITLE
MODDATAIMP-544 - Fixed endpoint definition for mapping metadata retrieving

### DIFF
--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -373,7 +373,7 @@
           "methods": [
             "GET"
           ],
-          "pathPattern": "/mapping-metadata",
+          "pathPattern": "/mapping-metadata/{jobExecutionId}",
           "permissionsRequired": [
             "mapping-metadata.get"
           ]


### PR DESCRIPTION
## Purpose
to fix definition for "GET /mapping-metadata/{jobExecutionId}" endpoint,
currently, we get 404 in response with the following message: 
> No suitable module found for path /mapping-metadata/8d679c03-4a86-42ca-a7eb-0e4593400d37 for tenant diku
