### PR TITLE
Adjust mapping metadata snapshots creation

### DIFF
--- a/mod-source-record-manager-server/src/main/java/org/folio/dao/MappingParamsSnapshotDaoImpl.java
+++ b/mod-source-record-manager-server/src/main/java/org/folio/dao/MappingParamsSnapshotDaoImpl.java
@@ -30,7 +30,7 @@ public class MappingParamsSnapshotDaoImpl implements MappingParamsSnapshotDao {
 
   private static final String TABLE_NAME = "mapping_params_snapshots";
   private static final String SELECT_QUERY = "SELECT params FROM %s.%s WHERE job_execution_id = $1";
-  private static final String INSERT_SQL = "INSERT INTO %s.%s (job_execution_id, params, saved_timestamp) VALUES ($1, $2, $3)";
+  private static final String INSERT_SQL = "INSERT INTO %s.%s (job_execution_id, params, saved_timestamp) VALUES ($1, $2, $3) ON CONFLICT DO NOTHING";
   private static final String DELETE_BY_JOB_EXECUTION_ID_QUERY = "DELETE FROM %s.%s WHERE job_execution_id = $1";
   private static final String PARAMS_FIELD = "params";
 

--- a/mod-source-record-manager-server/src/main/java/org/folio/dao/MappingRulesSnapshotDaoImpl.java
+++ b/mod-source-record-manager-server/src/main/java/org/folio/dao/MappingRulesSnapshotDaoImpl.java
@@ -29,7 +29,7 @@ public class MappingRulesSnapshotDaoImpl implements MappingRulesSnapshotDao {
 
   private static final String TABLE_NAME = "mapping_rules_snapshots";
   private static final String SELECT_QUERY = "SELECT rules FROM %s.%s WHERE job_execution_id = $1";
-  private static final String INSERT_SQL = "INSERT INTO %s.%s (job_execution_id, rules, saved_timestamp) VALUES ($1, $2, $3)";
+  private static final String INSERT_SQL = "INSERT INTO %s.%s (job_execution_id, rules, saved_timestamp) VALUES ($1, $2, $3) ON CONFLICT DO NOTHING";
   private static final String DELETE_BY_JOB_EXECUTION_ID_QUERY = "DELETE FROM %s.%s WHERE job_execution_id = $1";
   private static final String RULES_FIELD = "rules";
 

--- a/mod-source-record-manager-server/src/test/java/org/folio/dao/MappingParamsSnapshotDaoImplTest.java
+++ b/mod-source-record-manager-server/src/test/java/org/folio/dao/MappingParamsSnapshotDaoImplTest.java
@@ -1,0 +1,66 @@
+package org.folio.dao;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.vertx.core.Future;
+import io.vertx.core.Vertx;
+import io.vertx.ext.unit.Async;
+import io.vertx.ext.unit.TestContext;
+import io.vertx.ext.unit.junit.VertxUnitRunner;
+import org.folio.dao.util.PostgresClientFactory;
+import org.folio.processing.mapping.defaultmapper.processor.parameters.MappingParameters;
+import org.folio.rest.impl.AbstractRestTest;
+import org.folio.rest.jaxrs.model.InitJobExecutionsRsDto;
+import org.folio.rest.jaxrs.model.JobExecution;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.InjectMocks;
+import org.mockito.MockitoAnnotations;
+import org.mockito.Spy;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.List;
+
+import static org.hamcrest.Matchers.is;
+
+@RunWith(VertxUnitRunner.class)
+public class MappingParamsSnapshotDaoImplTest extends AbstractRestTest {
+
+  private static final String MARC_PARAMS_PATH = "src/test/resources/org/folio/services/marc_mapping_params.json";
+
+  @Spy
+  private PostgresClientFactory postgresClientFactory = new PostgresClientFactory(Vertx.vertx());
+
+  @InjectMocks
+  private MappingParamsSnapshotDao mappingParamsSnapshotDao = new MappingParamsSnapshotDaoImpl();
+
+  private MappingParameters mappingParameters;
+
+  @Before
+  public void setUp(TestContext context) throws IOException {
+    MockitoAnnotations.initMocks(this);
+    super.setUp(context);
+    mappingParameters = new ObjectMapper().readValue(new File(MARC_PARAMS_PATH), MappingParameters.class);
+  }
+
+  @Test
+  public void shouldReturnSucceededFutureWhenMappingParametersSnapshotWithSameJobIdExists(TestContext context) {
+    InitJobExecutionsRsDto response = constructAndPostInitJobExecutionRqDto(1);
+    List<JobExecution> createdJobExecutions = response.getJobExecutions();
+    Assert.assertThat(createdJobExecutions.size(), is(1));
+    JobExecution jobExecution = createdJobExecutions.get(0);
+
+    Async async = context.async();
+    Future<String> future = mappingParamsSnapshotDao.save(mappingParameters, jobExecution.getId(), TENANT_ID)
+      .compose(v -> mappingParamsSnapshotDao.save(mappingParameters, jobExecution.getId(), TENANT_ID));
+
+    future.onComplete(ar -> {
+      context.assertTrue(ar.succeeded());
+      context.assertEquals(jobExecution.getId(), ar.result());
+      async.complete();
+    });
+  }
+
+}

--- a/mod-source-record-manager-server/src/test/java/org/folio/dao/MappingRulesSnapshotDaoImplTest.java
+++ b/mod-source-record-manager-server/src/test/java/org/folio/dao/MappingRulesSnapshotDaoImplTest.java
@@ -1,0 +1,65 @@
+package org.folio.dao;
+
+import io.vertx.core.Future;
+import io.vertx.core.Vertx;
+import io.vertx.core.json.JsonObject;
+import io.vertx.ext.unit.Async;
+import io.vertx.ext.unit.TestContext;
+import io.vertx.ext.unit.junit.VertxUnitRunner;
+import org.folio.TestUtil;
+import org.folio.dao.util.PostgresClientFactory;
+import org.folio.rest.impl.AbstractRestTest;
+import org.folio.rest.jaxrs.model.InitJobExecutionsRsDto;
+import org.folio.rest.jaxrs.model.JobExecution;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.InjectMocks;
+import org.mockito.MockitoAnnotations;
+import org.mockito.Spy;
+
+import java.io.IOException;
+import java.util.List;
+
+import static org.hamcrest.Matchers.is;
+
+@RunWith(VertxUnitRunner.class)
+public class MappingRulesSnapshotDaoImplTest extends AbstractRestTest {
+
+  private static final String MARC_BIB_RULES_PATH = "src/test/resources/org/folio/services/marc_bib_rules.json";
+
+  @Spy
+  private PostgresClientFactory postgresClientFactory = new PostgresClientFactory(Vertx.vertx());
+
+  @InjectMocks
+  private MappingRulesSnapshotDao mappingRulesSnapshotDao = new MappingRulesSnapshotDaoImpl();
+
+  private JsonObject mappingRules;
+
+  @Before
+  public void setUp(TestContext context) throws IOException {
+    MockitoAnnotations.initMocks(this);
+    super.setUp(context);
+    mappingRules = new JsonObject(TestUtil.readFileFromPath(MARC_BIB_RULES_PATH));
+  }
+
+  @Test
+  public void shouldReturnSucceededFutureWhenRuleSnapshotWithSameJobIdExists(TestContext context) {
+    InitJobExecutionsRsDto response = constructAndPostInitJobExecutionRqDto(1);
+    List<JobExecution> createdJobExecutions = response.getJobExecutions();
+    Assert.assertThat(createdJobExecutions.size(), is(1));
+    JobExecution jobExecution = createdJobExecutions.get(0);
+
+    Async async = context.async();
+    Future<String> future = mappingRulesSnapshotDao.save(mappingRules, jobExecution.getId(), TENANT_ID)
+      .compose(v -> mappingRulesSnapshotDao.save(mappingRules, jobExecution.getId(), TENANT_ID));
+
+    future.onComplete(ar -> {
+      context.assertTrue(ar.succeeded());
+      context.assertEquals(jobExecution.getId(), ar.result());
+      async.complete();
+    });
+  }
+
+}


### PR DESCRIPTION
## Purpose
occasionally transactions for mapping rules snapshot creation and mapping params snapshot creation, which are triggered on receiving first chunk of records, are not completed before transactions for snapshots existence check, which are triggered on subsequent chunks receiving. Because of this, an attempt to recreate snapshots one more time appears.

> 12:12:01.486 [vert.x-worker-thread-1] ERROR MappingRulesSnapshotDaoImpl [227270eqId] Failed to save MappingRulesSnapshot entity
io.vertx.pgclient.PgException: { "message": "duplicate key value violates unique constraint \"mapping_rules_snapshots_pkey\"", "severity": "ERROR", "code": "23505", "detail": "Key (job_execution_id)=(6f6c03a1-2945-44f2-952a-c9b3ce53b67a) already exists.", "file": "nbtinsert.c", "line": "563", "routine": "_bt_check_unique", "schema": "diku_mod_source_record_manager", "table": "mapping_rules_snapshots", "constraint": "mapping_rules_snapshots_pkey" }


## Approach
* ignore primary key constraint on the attempt to create one more mapping rules snapshot or mapping parameters snapshot with the same  job id if there is one