### PR TITLE
MODSOURMAN-577 - Optimistic locking: mod-source-record-manager modifications

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,6 @@
+## 2021-xx-xx v3.3.0-SNAPSHOT
+* [MODSOURMAN-577](https://issues.folio.org/browse/MODSOURMAN-577) Optimistic locking: mod-source-record-manager modifications
+
 ## 2021-10-06 v3.2.1-SNAPSHOT
 * [MODSOURMAN-586](https://issues.folio.org/browse/MODSOURMAN-586) Kiwi bugfest cannot import a large file; adjust mapping metadata snapshots creation
 

--- a/mod-source-record-manager-server/src/test/java/org/folio/rest/impl/changeManager/ChangeManagerParsedRecordsAPITest.java
+++ b/mod-source-record-manager-server/src/test/java/org/folio/rest/impl/changeManager/ChangeManagerParsedRecordsAPITest.java
@@ -160,6 +160,7 @@ public class ChangeManagerParsedRecordsAPITest extends AbstractRestTest {
       .withParsedRecord(new ParsedRecord().withId(UUID.randomUUID().toString())
         .withContent("{\"leader\":\"01240cas a2200397   4500\",\"fields\":[]}"))
       .withRecordType(ParsedRecordDto.RecordType.MARC_HOLDING)
+      .withQmRecordVersion("1")
       .withExternalIdsHolder(new ExternalIdsHolder().withInstanceId(UUID.randomUUID().toString()));
 
     RestAssured.given()

--- a/mod-source-record-manager-server/src/test/java/org/folio/rest/impl/changeManager/ChangeManagerParsedRecordsAPITest.java
+++ b/mod-source-record-manager-server/src/test/java/org/folio/rest/impl/changeManager/ChangeManagerParsedRecordsAPITest.java
@@ -160,7 +160,7 @@ public class ChangeManagerParsedRecordsAPITest extends AbstractRestTest {
       .withParsedRecord(new ParsedRecord().withId(UUID.randomUUID().toString())
         .withContent("{\"leader\":\"01240cas a2200397   4500\",\"fields\":[]}"))
       .withRecordType(ParsedRecordDto.RecordType.MARC_HOLDING)
-      .withQmRecordVersion("1")
+      .withRelatedRecordVersion("1")
       .withExternalIdsHolder(new ExternalIdsHolder().withInstanceId(UUID.randomUUID().toString()));
 
     RestAssured.given()


### PR DESCRIPTION
## Purpose
In the scope of the Optimistic locking feature, mod-source-record-manager needs to pass along 'relatedRecordVersion' through the event chain. This story intended to add this field and update test(s).

## Approach
updated raml storage to have the latest updates from the master branch
updated test with new property 'relatedRecordVersion'