### PR TITLE
MODSOURMAN-581 - Populate title for MARC Holdings

### DIFF
--- a/mod-source-record-manager-server/src/main/resources/templates/db_scripts/create_get_job_log_entries_function.sql
+++ b/mod-source-record-manager-server/src/main/resources/templates/db_scripts/create_get_job_log_entries_function.sql
@@ -23,7 +23,10 @@ DROP FUNCTION IF EXISTS get_job_log_entries(uuid,text,text,bigint,bigint);
 
 -- Script to create function to get data import job log entries (jobLogEntry).
 CREATE OR REPLACE FUNCTION get_job_log_entries(jobExecutionId uuid, sortingField text, sortingDir text, limitVal bigint, offsetVal bigint)
-    RETURNS TABLE(job_execution_id uuid, source_id uuid, source_record_order integer, invoiceline_number text, title text, source_record_action_status text, instance_action_status text, holdings_action_status text, item_action_status text, order_action_status text, invoice_action_status text, error text, total_count bigint, invoice_line_journal_record_id uuid)
+    RETURNS TABLE(job_execution_id uuid, source_id uuid, source_record_order integer, invoiceline_number text, title text,
+                  source_record_action_status text, instance_action_status text, holdings_action_status text,
+                  item_action_status text, order_action_status text, invoice_action_status text, error text,
+                  total_count bigint, invoice_line_journal_record_id uuid, source_record_entity_type text, holdings_entity_hrid text[])
 AS $$
 BEGIN
     RETURN QUERY EXECUTE format('
@@ -39,7 +42,9 @@ SELECT records_actions.job_execution_id, records_actions.source_id, records_acti
        get_entity_status(item_actions, item_errors_number) AS item_action_status,
        get_entity_status(order_actions, order_errors_number) AS order_action_status,
        null AS invoice_action_status, rec_errors.error, records_actions.total_count,
-       null AS invoiceLineJournalRecordId
+       null AS invoiceLineJournalRecordId,
+       records_actions.source_record_entity_type,
+       records_actions.holdings_entity_hrid
 FROM (
          SELECT journal_records.source_id, journal_records.source_record_order, journal_records.job_execution_id,
                 array_agg(action_type ORDER BY action_date ASC) FILTER (WHERE entity_type IN (''MARC_BIBLIOGRAPHIC'', ''MARC_HOLDINGS'', ''MARC_AUTHORITY'')) AS marc_actions,
@@ -52,7 +57,9 @@ FROM (
                 count(journal_records.source_id) FILTER (WHERE entity_type = ''ITEM'' AND journal_records.error != '''') AS item_errors_number,
                 array_agg(action_type) FILTER (WHERE entity_type = ''ORDER'') AS order_actions,
                 count(journal_records.source_id) FILTER (WHERE entity_type = ''ORDER'' AND journal_records.error != '''') AS order_errors_number,
-                count(journal_records.source_id) OVER () AS total_count
+                count(journal_records.source_id) OVER () AS total_count,
+                (array_agg(journal_records.entity_type) FILTER (WHERE entity_type IN (''MARC_BIBLIOGRAPHIC'', ''MARC_HOLDINGS'', ''MARC_AUTHORITY'')))[1] AS source_record_entity_type,
+ 				array_agg(journal_records.entity_hrid) FILTER (WHERE entity_hrid !='''' and  entity_type = ''HOLDINGS'') as holdings_entity_hrid
          FROM journal_records
          WHERE journal_records.job_execution_id = ''%s'' and
                entity_type in (''MARC_BIBLIOGRAPHIC'', ''MARC_HOLDINGS'', ''MARC_AUTHORITY'', ''INSTANCE'', ''HOLDINGS'', ''ITEM'', ''ORDER'')
@@ -80,7 +87,11 @@ SELECT records_actions.job_execution_id, records_actions.source_id, source_recor
        null AS item_action_status,
        null AS order_action_status,
        get_entity_status(invoice_actions, invoice_errors_number) AS invoice_action_status,
-       error, records_actions.total_count, invoiceLineJournalRecordId
+       error,
+       records_actions.total_count,
+       invoiceLineJournalRecordId,
+       records_actions.source_record_entity_type,
+       records_actions.holdings_entity_hrid
 FROM (
          SELECT journal_records.source_id, journal_records.job_execution_id, source_record_order, entity_hrid, title, error,
                 array[]::varchar[] AS marc_actions,
@@ -88,7 +99,9 @@ FROM (
                 array_agg(action_type) FILTER (WHERE entity_type = ''INVOICE'') AS invoice_actions,
                 count(journal_records.source_id) FILTER (WHERE entity_type = ''INVOICE'' AND journal_records.error != '''') AS invoice_errors_number,
                 count(journal_records.source_id) OVER () AS total_count,
-                id AS invoiceLineJournalRecordId
+                id AS invoiceLineJournalRecordId,
+                (array_agg(entity_type) FILTER (WHERE entity_type IN (''EDIFACT'')))[1] AS source_record_entity_type,
+                array[]::varchar[] as holdings_entity_hrid
          FROM journal_records
          WHERE journal_records.job_execution_id = ''%s'' and entity_type = ''INVOICE'' and title != ''INVOICE''
          GROUP BY journal_records.source_id, journal_records.source_record_order, journal_records.job_execution_id,
@@ -96,6 +109,6 @@ FROM (
      ) AS records_actions
 ORDER BY %I %s
 LIMIT %s OFFSET %s;',
-        jobExecutionId, jobExecutionId, jobExecutionId, jobExecutionId, sortingField, sortingDir, limitVal, offsetVal);
+                                jobExecutionId, jobExecutionId, jobExecutionId, jobExecutionId, sortingField, sortingDir, limitVal, offsetVal);
 END;
 $$ LANGUAGE plpgsql;

--- a/mod-source-record-manager-server/src/main/resources/templates/db_scripts/schema.json
+++ b/mod-source-record-manager-server/src/main/resources/templates/db_scripts/schema.json
@@ -141,7 +141,7 @@
     {
       "run": "after",
       "snippetPath": "create_get_job_log_entries_function.sql",
-      "fromModuleVersion": "mod-source-record-manager-3.2.0"
+      "fromModuleVersion": "mod-source-record-manager-3.3.0"
     },
     {
       "run": "after",

--- a/mod-source-record-manager-server/src/test/java/org/folio/rest/impl/metadataProvider/MetaDataProviderJobLogEntriesAPITest.java
+++ b/mod-source-record-manager-server/src/test/java/org/folio/rest/impl/metadataProvider/MetaDataProviderJobLogEntriesAPITest.java
@@ -355,7 +355,7 @@ public class MetaDataProviderJobLogEntriesAPITest extends AbstractRestTest {
         .body("entries[0].sourceRecordId", is(sourceRecordId1))
         .body("entries[0].sourceRecordTitle", is(recordTitle1))
         .body("entries[0].sourceRecordOrder", is("1"))
-        .body("entries[0].holdingsRecordHridList.size", is(empty()))
+        .body("entries[0].holdingsRecordHridList", is(empty()))
         .body("entries[0].sourceRecordType", is(MARC_BIBLIOGRAPHIC.value()));
 
       async.complete();

--- a/mod-source-record-manager-server/src/test/java/org/folio/rest/impl/metadataProvider/MetaDataProviderJobLogEntriesAPITest.java
+++ b/mod-source-record-manager-server/src/test/java/org/folio/rest/impl/metadataProvider/MetaDataProviderJobLogEntriesAPITest.java
@@ -1,35 +1,5 @@
 package org.folio.rest.impl.metadataProvider;
 
-import io.restassured.RestAssured;
-import io.vertx.core.CompositeFuture;
-import io.vertx.core.Future;
-import io.vertx.core.Promise;
-import io.vertx.core.Vertx;
-import io.vertx.ext.unit.Async;
-import io.vertx.ext.unit.TestContext;
-import io.vertx.ext.unit.junit.VertxUnitRunner;
-import org.apache.http.HttpStatus;
-import org.folio.dao.JournalRecordDaoImpl;
-import org.folio.dao.util.PostgresClientFactory;
-import org.folio.okapi.common.GenericCompositeFuture;
-import org.folio.rest.impl.AbstractRestTest;
-import org.folio.rest.jaxrs.model.ActionStatus;
-import org.folio.rest.jaxrs.model.JobExecution;
-import org.folio.rest.jaxrs.model.JobLogEntryDto;
-import org.folio.rest.jaxrs.model.JobLogEntryDtoCollection;
-import org.folio.rest.jaxrs.model.JournalRecord;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.mockito.InjectMocks;
-import org.mockito.MockitoAnnotations;
-import org.mockito.Spy;
-
-import java.util.Date;
-import java.util.List;
-import java.util.UUID;
-
 import static org.folio.rest.jaxrs.model.JournalRecord.ActionStatus.COMPLETED;
 import static org.folio.rest.jaxrs.model.JournalRecord.ActionStatus.ERROR;
 import static org.folio.rest.jaxrs.model.JournalRecord.ActionType.CREATE;
@@ -50,6 +20,40 @@ import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.not;
 import static org.hamcrest.Matchers.nullValue;
+
+import java.util.Date;
+import java.util.List;
+import java.util.UUID;
+
+import io.restassured.response.ValidatableResponse;
+import org.apache.http.HttpStatus;
+import org.folio.dao.JournalRecordDaoImpl;
+import org.folio.dao.util.PostgresClientFactory;
+import org.folio.okapi.common.GenericCompositeFuture;
+import org.folio.rest.impl.AbstractRestTest;
+import org.folio.rest.jaxrs.model.ActionStatus;
+import org.folio.rest.jaxrs.model.JobExecution;
+import org.folio.rest.jaxrs.model.JobLogEntryDto;
+import org.folio.rest.jaxrs.model.JobLogEntryDtoCollection;
+import org.folio.rest.jaxrs.model.JournalRecord;
+import org.folio.rest.jaxrs.model.RecordProcessingLogDto;
+import org.folio.rest.jaxrs.model.RelatedInvoiceLineInfo;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.InjectMocks;
+import org.mockito.MockitoAnnotations;
+import org.mockito.Spy;
+
+import io.restassured.RestAssured;
+import io.vertx.core.CompositeFuture;
+import io.vertx.core.Future;
+import io.vertx.core.Promise;
+import io.vertx.core.Vertx;
+import io.vertx.ext.unit.Async;
+import io.vertx.ext.unit.TestContext;
+import io.vertx.ext.unit.junit.VertxUnitRunner;
 
 @RunWith(VertxUnitRunner.class)
 public class MetaDataProviderJobLogEntriesAPITest extends AbstractRestTest {
@@ -83,6 +87,7 @@ public class MetaDataProviderJobLogEntriesAPITest extends AbstractRestTest {
 
   @Test
   public void shouldReturnMarcBibUpdatedWhenMarcBibWasUpdated(TestContext context) {
+    //test 
     Async async = context.async();
     JobExecution createdJobExecution = constructAndPostInitJobExecutionRqDto(1).getJobExecutions().get(0);
     String sourceRecordId = UUID.randomUUID().toString();
@@ -90,7 +95,7 @@ public class MetaDataProviderJobLogEntriesAPITest extends AbstractRestTest {
 
     Future<JournalRecord> future = Future.succeededFuture()
       .compose(v -> createJournalRecord(createdJobExecution.getId(), sourceRecordId, null, null, recordTitle, 0, CREATE, MARC_BIBLIOGRAPHIC, COMPLETED, null))
-      .compose(v -> createJournalRecord(createdJobExecution.getId(), sourceRecordId, null, null, null, 0, UPDATE, MARC_BIBLIOGRAPHIC, COMPLETED, null))
+      .compose(v -> createJournalRecord(createdJobExecution.getId(), sourceRecordId, null, "in00000000001", null, 0, UPDATE, MARC_BIBLIOGRAPHIC, COMPLETED, null))
       .onFailure(context::fail);
 
     future.onComplete(ar -> context.verify(v -> {
@@ -151,7 +156,7 @@ public class MetaDataProviderJobLogEntriesAPITest extends AbstractRestTest {
 
     Future<JournalRecord> future = Future.succeededFuture()
       .compose(v -> createJournalRecord(createdJobExecution.getId(), sourceRecordId, null, null, recordTitle,  0, CREATE, MARC_BIBLIOGRAPHIC, COMPLETED, null))
-      .compose(v -> createJournalRecord(createdJobExecution.getId(), sourceRecordId, null, null, null,  0, NON_MATCH, INSTANCE, COMPLETED, null))
+      .compose(v -> createJournalRecord(createdJobExecution.getId(), sourceRecordId, null, "in00000000001", null,  0, NON_MATCH, INSTANCE, COMPLETED, null))
       .onSuccess(v -> async.complete())
       .onFailure(context::fail);
 
@@ -177,6 +182,7 @@ public class MetaDataProviderJobLogEntriesAPITest extends AbstractRestTest {
 
   @Test
   public void shouldReturnInstanceDiscardedWhenInstanceCreationFailed(TestContext context) {
+    //test
     Async async = context.async();
     JobExecution createdJobExecution = constructAndPostInitJobExecutionRqDto(1).getJobExecutions().get(0);
     String sourceRecordId = UUID.randomUUID().toString();
@@ -246,11 +252,11 @@ public class MetaDataProviderJobLogEntriesAPITest extends AbstractRestTest {
 
     Future<JournalRecord> future = Future.succeededFuture()
       .compose(v -> createJournalRecord(createdJobExecution.getId(), sourceRecordId1, null, null, null, 1, CREATE, MARC_BIBLIOGRAPHIC, COMPLETED, null))
-      .compose(v -> createJournalRecord(createdJobExecution.getId(), sourceRecordId1, null, null, null, 1, CREATE, INSTANCE, COMPLETED, null))
+      .compose(v -> createJournalRecord(createdJobExecution.getId(), sourceRecordId1, null, "in00000000002", null, 1, CREATE, INSTANCE, COMPLETED, null))
       .compose(v -> createJournalRecord(createdJobExecution.getId(), sourceRecordId2, null, null, null, 0, CREATE, MARC_BIBLIOGRAPHIC, COMPLETED, null))
-      .compose(v -> createJournalRecord(createdJobExecution.getId(), sourceRecordId2, null, null, null, 0, CREATE, INSTANCE, COMPLETED, null))
+      .compose(v -> createJournalRecord(createdJobExecution.getId(), sourceRecordId2, null, "in00000000001", null, 0, CREATE, INSTANCE, COMPLETED, null))
       .compose(v -> createJournalRecord(createdJobExecution.getId(), sourceRecordId3, null, null, null, 3, CREATE, MARC_BIBLIOGRAPHIC, COMPLETED, null))
-      .compose(v -> createJournalRecord(createdJobExecution.getId(), sourceRecordId3, null, null, null, 3, CREATE, INSTANCE, COMPLETED, null))
+      .compose(v -> createJournalRecord(createdJobExecution.getId(), sourceRecordId3, null, "in00000000003", null, 3, CREATE, INSTANCE, COMPLETED, null))
       .onFailure(context::fail);
 
     future.onComplete(ar -> context.verify(v -> {
@@ -295,7 +301,7 @@ public class MetaDataProviderJobLogEntriesAPITest extends AbstractRestTest {
 
     Future<JournalRecord> future = Future.succeededFuture()
       .compose(v -> createJournalRecord(createdJobExecution.getId(), sourceRecordId1, null, null, recordTitle1, 1, CREATE, MARC_BIBLIOGRAPHIC, COMPLETED, null))
-      .compose(v -> createJournalRecord(createdJobExecution.getId(), sourceRecordId1, null, null, null, 1, CREATE, INSTANCE, COMPLETED, null))
+      .compose(v -> createJournalRecord(createdJobExecution.getId(), sourceRecordId1, null, "in00000000001", null, 1, CREATE, INSTANCE, COMPLETED, null))
       .compose(v -> createJournalRecord(createdJobExecution.getId(), sourceRecordId2, null, null, "title0", 0, CREATE, MARC_BIBLIOGRAPHIC, COMPLETED, null))
       .compose(v -> createJournalRecord(createdJobExecution.getId(), sourceRecordId2, null, null, null, 0, CREATE, INSTANCE, COMPLETED, null))
       .compose(v -> createJournalRecord(createdJobExecution.getId(), sourceRecordId3, null, null, "title3", 3, CREATE, MARC_BIBLIOGRAPHIC, COMPLETED, null))
@@ -318,7 +324,9 @@ public class MetaDataProviderJobLogEntriesAPITest extends AbstractRestTest {
         .body("entries[0].jobExecutionId", is(createdJobExecution.getId()))
         .body("entries[0].sourceRecordId", is(sourceRecordId1))
         .body("entries[0].sourceRecordTitle", is(recordTitle1))
-        .body("entries[0].sourceRecordOrder", is("1"));
+        .body("entries[0].sourceRecordOrder", is("1"))
+        .body("entries[0].holdingsRecordHridList[0]", is("in00000000001"))
+        .body("entries[0].sourceRecordType", is(MARC_BIBLIOGRAPHIC.value()));
 
       async.complete();
     }));


### PR DESCRIPTION
## Purpose
in the scope of https://issues.folio.org/browse/MODSOURMAN-581 needs to return two additional columns to form title for HOLDINGS records

## Approach
* updated script to return two additional columns - source_record_entity_type and holdings_entity_hrid
* updated schemas from the master version
* updated the logic to return holdings title


