### PR TITLE
MODSOURMAN-474. Implement ProcessRecordErrorHandler for Kafka Consumers

### DIFF
--- a/mod-source-record-manager-server/pom.xml
+++ b/mod-source-record-manager-server/pom.xml
@@ -215,7 +215,7 @@
     <dependency>
       <groupId>org.folio</groupId>
       <artifactId>folio-kafka-wrapper</artifactId>
-      <version>2.4.0</version>
+      <version>2.5.0-SNAPSHOT</version>
     </dependency>
     <dependency>
       <groupId>org.folio</groupId>

--- a/mod-source-record-manager-server/src/main/java/org/folio/services/ChangeEngineServiceImpl.java
+++ b/mod-source-record-manager-server/src/main/java/org/folio/services/ChangeEngineServiceImpl.java
@@ -449,7 +449,7 @@ public class ChangeEngineServiceImpl implements ChangeEngineService {
     if (DataType.MARC.equals(jobExecution.getJobProfileInfo().getDataType())) {
       MarcRecordType marcRecordType = marcRecordAnalyzer.process(recordParsedResult.getParsedRecord());
       LOGGER.info("Marc record analyzer parsed record with id = {} and type = {}", recordId, marcRecordType);
-      return RecordType.valueOf(MARC_FORMAT + marcRecordType.name());
+      return MarcRecordType.NA == marcRecordType ? null : RecordType.valueOf(MARC_FORMAT + marcRecordType.name());
     }
 
     return RecordType.valueOf(jobExecution.getJobProfileInfo().getDataType().value());

--- a/mod-source-record-manager-server/src/main/java/org/folio/services/exceptions/RecordsProcessingException.java
+++ b/mod-source-record-manager-server/src/main/java/org/folio/services/exceptions/RecordsProcessingException.java
@@ -1,0 +1,22 @@
+package org.folio.services.exceptions;
+
+import org.folio.rest.jaxrs.model.Record;
+
+import java.util.List;
+
+/**
+ * Exception that accumulates records that processed with errors. This exception used in error handlers to
+ * send DI_ERROR for each failed record.
+ */
+public class RecordsProcessingException extends RuntimeException {
+  private List<Record> failedRecords;
+
+  public RecordsProcessingException(String message, List<Record> failedRecords) {
+    super(message);
+    this.failedRecords = failedRecords;
+  }
+
+  public List<Record> getFailedRecords() {
+    return failedRecords;
+  }
+}

--- a/mod-source-record-manager-server/src/main/java/org/folio/verticle/AbstractConsumersVerticle.java
+++ b/mod-source-record-manager-server/src/main/java/org/folio/verticle/AbstractConsumersVerticle.java
@@ -3,12 +3,7 @@ package org.folio.verticle;
 import io.vertx.core.AbstractVerticle;
 import io.vertx.core.Future;
 import io.vertx.core.Promise;
-import org.folio.kafka.AsyncRecordHandler;
-import org.folio.kafka.GlobalLoadSensor;
-import org.folio.kafka.KafkaConfig;
-import org.folio.kafka.KafkaConsumerWrapper;
-import org.folio.kafka.KafkaTopicNameHelper;
-import org.folio.kafka.SubscriptionDefinition;
+import org.folio.kafka.*;
 import org.folio.okapi.common.GenericCompositeFuture;
 import org.folio.spring.SpringContextUtil;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -55,6 +50,7 @@ public abstract class AbstractConsumersVerticle extends AbstractVerticle {
         .loadLimit(loadLimit)
         .globalLoadSensor(globalLoadSensor)
         .subscriptionDefinition(subscriptionDefinition)
+        .processRecordErrorHandler(getErrorHandler())
         .build());
     });
     List<Future<Void>> futures = new ArrayList<>();
@@ -83,5 +79,16 @@ public abstract class AbstractConsumersVerticle extends AbstractVerticle {
   public abstract List<String> getEvents();
 
   public abstract AsyncRecordHandler<String, String> getHandler();
+
+  /**
+   * By default error handler is null and so not invoked by folio-kafka-wrapper for failure cases.
+   * If you need to add error handling logic and send DI_ERROR events - override this method with own error handler
+   * implementation for  particular consumer instance.
+   *
+   * @return error handler
+   */
+  public ProcessRecordErrorHandler<String, String> getErrorHandler() {
+    return null;
+  };
 
 }

--- a/mod-source-record-manager-server/src/main/java/org/folio/verticle/RawMarcChunkConsumersVerticle.java
+++ b/mod-source-record-manager-server/src/main/java/org/folio/verticle/RawMarcChunkConsumersVerticle.java
@@ -1,6 +1,7 @@
 package org.folio.verticle;
 
 import org.folio.kafka.AsyncRecordHandler;
+import org.folio.kafka.ProcessRecordErrorHandler;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
 
@@ -15,6 +16,10 @@ public class RawMarcChunkConsumersVerticle extends AbstractConsumersVerticle {
   @Qualifier("RawMarcChunksKafkaHandler")
   private AsyncRecordHandler<String, String> rawMarcChunksKafkaHandler;
 
+  @Autowired
+  @Qualifier("RawMarcChunksErrorHandler")
+  private ProcessRecordErrorHandler<String, String> errorHandler;
+
   @Override
   public List<String> getEvents() {
     return Collections.singletonList(DI_RAW_RECORDS_CHUNK_READ.value());
@@ -23,6 +28,11 @@ public class RawMarcChunkConsumersVerticle extends AbstractConsumersVerticle {
   @Override
   public AsyncRecordHandler<String, String> getHandler() {
     return this.rawMarcChunksKafkaHandler;
+  }
+
+  @Override
+  public ProcessRecordErrorHandler<String, String> getErrorHandler() {
+    return this.errorHandler;
   }
 
 }

--- a/mod-source-record-manager-server/src/main/java/org/folio/verticle/StoredRecordChunkConsumersVerticle.java
+++ b/mod-source-record-manager-server/src/main/java/org/folio/verticle/StoredRecordChunkConsumersVerticle.java
@@ -1,6 +1,7 @@
 package org.folio.verticle;
 
 import org.folio.kafka.AsyncRecordHandler;
+import org.folio.kafka.ProcessRecordErrorHandler;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
 
@@ -15,6 +16,10 @@ public class StoredRecordChunkConsumersVerticle extends AbstractConsumersVerticl
   @Qualifier("StoredRecordChunksKafkaHandler")
   private AsyncRecordHandler<String, String> storedRecordChunksKafkaHandler;
 
+  @Autowired
+  @Qualifier("StoredRecordChunksErrorHandler")
+  private ProcessRecordErrorHandler<String, String> errorHandler;
+
   @Override
   public List<String> getEvents() {
     return Collections.singletonList(DI_PARSED_RECORDS_CHUNK_SAVED.value());
@@ -25,4 +30,8 @@ public class StoredRecordChunkConsumersVerticle extends AbstractConsumersVerticl
     return this.storedRecordChunksKafkaHandler;
   }
 
+  @Override
+  public ProcessRecordErrorHandler<String, String> getErrorHandler() {
+    return this.errorHandler;
+  }
 }

--- a/mod-source-record-manager-server/src/main/java/org/folio/verticle/consumers/errorhandlers/RawMarcChunksErrorHandler.java
+++ b/mod-source-record-manager-server/src/main/java/org/folio/verticle/consumers/errorhandlers/RawMarcChunksErrorHandler.java
@@ -1,0 +1,69 @@
+package org.folio.verticle.consumers.errorhandlers;
+
+import io.vertx.core.Vertx;
+import io.vertx.core.json.Json;
+import io.vertx.kafka.client.consumer.KafkaConsumerRecord;
+import io.vertx.kafka.client.producer.KafkaHeader;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.folio.dataimport.util.OkapiConnectionParams;
+import org.folio.kafka.KafkaConfig;
+import org.folio.kafka.KafkaHeaderUtils;
+import org.folio.kafka.ProcessRecordErrorHandler;
+import org.folio.rest.jaxrs.model.DataImportEventPayload;
+import org.folio.services.util.EventHandlingUtil;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.stereotype.Component;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.UUID;
+
+import static org.folio.rest.jaxrs.model.DataImportEventTypes.DI_ERROR;
+
+@Component
+@Qualifier("RawMarcChunksErrorHandler")
+public class RawMarcChunksErrorHandler implements ProcessRecordErrorHandler<String, String> {
+  private static final Logger LOGGER = LogManager.getLogger();
+
+  public static final String ERROR_KEY = "ERROR";
+  public static final String JOB_EXECUTION_ID_HEADER = "jobExecutionId";
+  public static final String RECORD_ID_HEADER = "recordId";
+
+  @Autowired
+  private Vertx vertx;
+  @Autowired
+  private KafkaConfig kafkaConfig;
+
+  @Override
+  public void handle(Throwable throwable, KafkaConsumerRecord<String, String> record) {
+    List<KafkaHeader> kafkaHeaders = record.headers();
+    OkapiConnectionParams okapiParams = new OkapiConnectionParams(KafkaHeaderUtils.kafkaHeadersToMap(kafkaHeaders), vertx);
+    String jobExecutionId = okapiParams.getHeaders().get(JOB_EXECUTION_ID_HEADER);
+    String tenantId = okapiParams.getTenantId();
+
+    DataImportEventPayload eventPayload = new DataImportEventPayload()
+      .withEventType(DI_ERROR.value())
+      .withJobExecutionId(jobExecutionId)
+      .withOkapiUrl(okapiParams.getOkapiUrl())
+      .withTenant(okapiParams.getTenantId())
+      .withToken(okapiParams.getToken())
+      .withContext(new HashMap<>(){{
+        put(ERROR_KEY, throwable.getMessage());
+      }});
+
+    sendDiErrorEvent(eventPayload, okapiParams, jobExecutionId, tenantId);
+  }
+
+  private void sendDiErrorEvent(DataImportEventPayload eventPayload, OkapiConnectionParams okapiParams, String jobExecutionId, String tenantId) {
+
+    // recordId is not yet created at this stage of parsing raw marc chunks, so setting random one to not fail calculation of progress bar
+    String recordId = UUID.randomUUID().toString();
+
+    okapiParams.getHeaders().set(RECORD_ID_HEADER, recordId);
+
+    EventHandlingUtil.sendEventToKafka(tenantId, Json.encode(eventPayload), DI_ERROR.value(), KafkaHeaderUtils.kafkaHeadersFromMultiMap(okapiParams.getHeaders()), kafkaConfig, null)
+     .onFailure(th -> LOGGER.error("Error publishing DI_ERROR event for jobExecutionId: {}", jobExecutionId, th));
+  }
+}

--- a/mod-source-record-manager-server/src/main/java/org/folio/verticle/consumers/errorhandlers/StoredRecordChunksErrorHandler.java
+++ b/mod-source-record-manager-server/src/main/java/org/folio/verticle/consumers/errorhandlers/StoredRecordChunksErrorHandler.java
@@ -1,0 +1,104 @@
+package org.folio.verticle.consumers.errorhandlers;
+
+import io.vertx.core.Vertx;
+import io.vertx.core.json.Json;
+import io.vertx.kafka.client.consumer.KafkaConsumerRecord;
+import io.vertx.kafka.client.producer.KafkaHeader;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.folio.dataimport.util.OkapiConnectionParams;
+import org.folio.kafka.KafkaConfig;
+import org.folio.kafka.KafkaHeaderUtils;
+import org.folio.kafka.ProcessRecordErrorHandler;
+import org.folio.rest.jaxrs.model.DataImportEventPayload;
+import org.folio.rest.jaxrs.model.Event;
+import org.folio.rest.jaxrs.model.Record;
+import org.folio.rest.jaxrs.model.RecordsBatchResponse;
+import org.folio.services.exceptions.RecordsProcessingException;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.stereotype.Component;
+
+import java.util.HashMap;
+import java.util.List;
+
+import static org.folio.rest.jaxrs.model.DataImportEventTypes.DI_ERROR;
+import static org.folio.rest.jaxrs.model.EntityType.*;
+import static org.folio.rest.jaxrs.model.Record.RecordType.MARC_AUTHORITY;
+import static org.folio.services.util.EventHandlingUtil.sendEventToKafka;
+
+@Component
+@Qualifier("StoredRecordChunksErrorHandler")
+public class StoredRecordChunksErrorHandler implements ProcessRecordErrorHandler<String, String> {
+  private static final Logger LOGGER = LogManager.getLogger();
+
+  public static final String ERROR_KEY = "ERROR";
+  public static final String JOB_EXECUTION_ID_HEADER = "jobExecutionId";
+  public static final String RECORD_ID_HEADER = "recordId";
+
+  @Autowired
+  private Vertx vertx;
+  @Autowired
+  private KafkaConfig kafkaConfig;
+
+  @Override
+  public void handle(Throwable throwable, KafkaConsumerRecord<String, String> kafkaConsumerRecord) {
+    List<KafkaHeader> kafkaHeaders = kafkaConsumerRecord.headers();
+    OkapiConnectionParams okapiParams = new OkapiConnectionParams(KafkaHeaderUtils.kafkaHeadersToMap(kafkaHeaders), vertx);
+    String jobExecutionId = okapiParams.getHeaders().get(JOB_EXECUTION_ID_HEADER);
+
+    // process for specific failure processed records from Exception body
+    if (throwable instanceof RecordsProcessingException) {
+      List<Record> failedRecords = ((RecordsProcessingException) throwable).getFailedRecords();
+      for (Record record: failedRecords) {
+        sendDiErrorForRecord(jobExecutionId, record, okapiParams, record.getErrorRecord().getDescription());
+      }
+
+    } else {
+      // process for all other cases that will include all records
+      Event event = Json.decodeValue(kafkaConsumerRecord.value(), Event.class);
+      RecordsBatchResponse recordCollection = Json.decodeValue(event.getEventPayload(), RecordsBatchResponse.class);
+      for (Record record: recordCollection.getRecords()) {
+        sendDiErrorForRecord(jobExecutionId, record, okapiParams, throwable.getMessage());
+      }
+    }
+  }
+
+  private void sendDiErrorForRecord(String jobExecutionId, Record record, OkapiConnectionParams okapiParams, String errorMsg) {
+    DataImportEventPayload errorPayload = getErrorPayload(jobExecutionId, okapiParams, new HashMap<>() {{
+      put(getSourceRecordKey(record), Json.encode(record));
+      put(ERROR_KEY, errorMsg);
+    }});
+
+    okapiParams.getHeaders().set(RECORD_ID_HEADER, record.getId());
+
+    sendEventToKafka(okapiParams.getTenantId(), Json.encode(errorPayload), DI_ERROR.value(), KafkaHeaderUtils.kafkaHeadersFromMultiMap(okapiParams.getHeaders()), kafkaConfig, null)
+      .onFailure(th -> LOGGER.error("Error publishing DI_ERROR event for jobExecutionId: {} , recordId: {}", errorPayload.getJobExecutionId(), record.getId(), th));
+  }
+
+  private DataImportEventPayload getErrorPayload(String jobExecutionId,
+                                                 OkapiConnectionParams params,
+                                                 HashMap<String, String> context) {
+    return new DataImportEventPayload()
+      .withEventType(DI_ERROR.value())
+      .withJobExecutionId(jobExecutionId)
+      .withOkapiUrl(params.getOkapiUrl())
+      .withTenant(params.getTenantId())
+      .withToken(params.getToken())
+      .withContext(context);
+  }
+
+  private String getSourceRecordKey(Record record) {
+    switch (record.getRecordType()) {
+      case MARC_BIB:
+        return MARC_BIBLIOGRAPHIC.value();
+      case MARC_AUTHORITY:
+        return MARC_AUTHORITY.value();
+      case MARC_HOLDING:
+        return MARC_HOLDINGS.value();
+      case EDIFACT:
+      default:
+        return EDIFACT_INVOICE.value();
+    }
+  }
+}

--- a/mod-source-record-manager-server/src/main/resources/log4j2.properties
+++ b/mod-source-record-manager-server/src/main/resources/log4j2.properties
@@ -21,3 +21,6 @@ rootLogger.appenderRef.stdout.ref = STDOUT
 
 logger.cql2pgjson.name = org.folio.rest.persist.cql
 logger.cql2pgjson.level = OFF
+
+logger.folio_rest.name = org.folio.rest
+logger.folio_rest.level = WARN

--- a/mod-source-record-manager-server/src/test/java/org/folio/verticle/consumers/StoredRecordChunkConsumersVerticleTest.java
+++ b/mod-source-record-manager-server/src/test/java/org/folio/verticle/consumers/StoredRecordChunkConsumersVerticleTest.java
@@ -4,6 +4,7 @@ import com.github.tomakehurst.wiremock.client.WireMock;
 import io.restassured.RestAssured;
 import io.vertx.core.json.Json;
 import io.vertx.ext.unit.junit.VertxUnitRunner;
+import static java.nio.charset.StandardCharsets.UTF_8;
 import net.mguenther.kafka.junit.KeyValue;
 import net.mguenther.kafka.junit.ObserveKeyValues;
 import net.mguenther.kafka.junit.ReadKeyValues;
@@ -13,7 +14,26 @@ import org.apache.commons.collections4.CollectionUtils;
 import org.apache.http.HttpStatus;
 import org.folio.DataImportEventPayload;
 import org.folio.rest.impl.AbstractRestTest;
-import org.folio.rest.jaxrs.model.*;
+import org.folio.rest.jaxrs.model.DataImportEventTypes;
+import static org.folio.rest.jaxrs.model.DataImportEventTypes.DI_ERROR;
+import static org.folio.rest.jaxrs.model.DataImportEventTypes.DI_PARSED_RECORDS_CHUNK_SAVED;
+import static org.folio.rest.jaxrs.model.DataImportEventTypes.DI_SRS_MARC_BIB_RECORD_CREATED;
+import org.folio.rest.jaxrs.model.EntityType;
+import org.folio.rest.jaxrs.model.Event;
+import org.folio.rest.jaxrs.model.InitJobExecutionsRsDto;
+import org.folio.rest.jaxrs.model.JobExecution;
+import org.folio.rest.jaxrs.model.JobProfile;
+import org.folio.rest.jaxrs.model.JobProfileInfo;
+import org.folio.rest.jaxrs.model.ParsedRecord;
+import org.folio.rest.jaxrs.model.Record;
+import static org.folio.rest.jaxrs.model.Record.RecordType.MARC_BIB;
+import org.folio.rest.jaxrs.model.RecordsBatchResponse;
+import static org.folio.rest.util.OkapiConnectionParams.OKAPI_TENANT_HEADER;
+import static org.folio.rest.util.OkapiConnectionParams.OKAPI_TOKEN_HEADER;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -23,16 +43,6 @@ import java.util.Collections;
 import java.util.List;
 import java.util.UUID;
 import java.util.concurrent.TimeUnit;
-
-import static java.nio.charset.StandardCharsets.UTF_8;
-import static org.folio.rest.jaxrs.model.DataImportEventTypes.*;
-import static org.folio.rest.jaxrs.model.Record.RecordType.MARC_BIB;
-import static org.folio.rest.util.OkapiConnectionParams.OKAPI_TENANT_HEADER;
-import static org.folio.rest.util.OkapiConnectionParams.OKAPI_TOKEN_HEADER;
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.is;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
 
 @RunWith(VertxUnitRunner.class)
 public class StoredRecordChunkConsumersVerticleTest extends AbstractRestTest {
@@ -180,7 +190,7 @@ public class StoredRecordChunkConsumersVerticleTest extends AbstractRestTest {
         .observeFor(30, TimeUnit.SECONDS)
         .build());
     }
-    for (String observedValue: observedValues) {
+    for (String observedValue : observedValues) {
       if (observedValue.contains(leader)) {
         result.add(observedValue);
       }

--- a/mod-source-record-manager-server/src/test/java/org/folio/verticle/consumers/StoredRecordChunkConsumersVerticleTest.java
+++ b/mod-source-record-manager-server/src/test/java/org/folio/verticle/consumers/StoredRecordChunkConsumersVerticleTest.java
@@ -6,33 +6,26 @@ import io.vertx.core.json.Json;
 import io.vertx.ext.unit.junit.VertxUnitRunner;
 import net.mguenther.kafka.junit.KeyValue;
 import net.mguenther.kafka.junit.ObserveKeyValues;
+import net.mguenther.kafka.junit.ReadKeyValues;
 import net.mguenther.kafka.junit.SendKeyValues;
+import org.apache.commons.collections.ListUtils;
+import org.apache.commons.collections4.CollectionUtils;
 import org.apache.http.HttpStatus;
 import org.folio.DataImportEventPayload;
 import org.folio.rest.impl.AbstractRestTest;
-import org.folio.rest.jaxrs.model.EntityType;
-import org.folio.rest.jaxrs.model.Event;
-import org.folio.rest.jaxrs.model.InitJobExecutionsRsDto;
-import org.folio.rest.jaxrs.model.JobExecution;
-import org.folio.rest.jaxrs.model.JobProfile;
-import org.folio.rest.jaxrs.model.JobProfileInfo;
-import org.folio.rest.jaxrs.model.ParsedRecord;
-import org.folio.rest.jaxrs.model.Record;
-import org.folio.rest.jaxrs.model.RecordsBatchResponse;
+import org.folio.rest.jaxrs.model.*;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
-import java.io.IOException;
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.UUID;
 import java.util.concurrent.TimeUnit;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
-import static org.folio.rest.jaxrs.model.DataImportEventTypes.DI_ERROR;
-import static org.folio.rest.jaxrs.model.DataImportEventTypes.DI_PARSED_RECORDS_CHUNK_SAVED;
-import static org.folio.rest.jaxrs.model.DataImportEventTypes.DI_SRS_MARC_BIB_RECORD_CREATED;
+import static org.folio.rest.jaxrs.model.DataImportEventTypes.*;
 import static org.folio.rest.jaxrs.model.Record.RecordType.MARC_BIB;
 import static org.folio.rest.util.OkapiConnectionParams.OKAPI_TENANT_HEADER;
 import static org.folio.rest.util.OkapiConnectionParams.OKAPI_TOKEN_HEADER;
@@ -73,85 +66,125 @@ public class StoredRecordChunkConsumersVerticleTest extends AbstractRestTest {
   }
 
   @Test
-  public void shouldPublishDiErrorWhenLeaderRecordTypeValueIsInvalid() throws InterruptedException, IOException {
+  public void shouldPublishDiErrorWhenLeaderRecordTypeValueIsInvalid() throws InterruptedException {
     // given
-    // parsed content with invalid value '7' as record type identifier at the LEADER/06
-    String parsedContentWithInvalidRecordTypeValue = "{\"leader\": \"13112c7m a2200553Ii 4500\"}";
+    String parsedContentWithInvalidRecordTypeValue = "{\"leader\": \"13112c7m a2200553Ii 3900\"}";
+    RecordsBatchResponse recordsBatch = getRecordsBatchResponse(parsedContentWithInvalidRecordTypeValue, 1);
 
-    RecordsBatchResponse recordsBatch = new RecordsBatchResponse()
-      .withTotalRecords(1)
-      .withRecords(List.of(new Record()
-        .withRecordType(MARC_BIB)
-        .withId(UUID.randomUUID().toString())
-        .withSnapshotId(jobExec.getId())
-        .withParsedRecord(new ParsedRecord().withContent(parsedContentWithInvalidRecordTypeValue))));
-
-    Event event = new Event().withId(UUID.randomUUID().toString()).withEventPayload(Json.encode(recordsBatch));
-    KeyValue<String, String> kafkaRecord = new KeyValue<>("42", Json.encode(event));
-    kafkaRecord.addHeader(OKAPI_TENANT_HEADER, TENANT_ID, UTF_8);
-    kafkaRecord.addHeader(OKAPI_TOKEN_HEADER, TOKEN, UTF_8);
-    kafkaRecord.addHeader(JOB_EXECUTION_ID_HEADER, jobExec.getId(), UTF_8);
-
-    String topic = formatToKafkaTopicName(DI_PARSED_RECORDS_CHUNK_SAVED.value());
-    SendKeyValues<String, String> request = SendKeyValues.to(topic, Collections.singletonList(kafkaRecord))
-      .useDefaults();
+    SendKeyValues<String, String> request = getRequest(jobExec.getId(), recordsBatch);
 
     // when
     kafkaCluster.send(request);
 
     // then
-    String topicToObserve = formatToKafkaTopicName(DI_ERROR.value());
-    List<String> observedValues = kafkaCluster.observeValues(ObserveKeyValues.on(topicToObserve, 1)
-      .observeFor(30, TimeUnit.SECONDS)
-      .build());
-
-    Event obtainedEvent = Json.decodeValue(observedValues.get(0), Event.class);
+    List<String> obtainedValues = observeValuesAndFilterByLeader("13112c7m a2200553Ii 3900", DI_ERROR, 1);
+    Event obtainedEvent = Json.decodeValue(obtainedValues.get(0), Event.class);
     DataImportEventPayload eventPayload = Json.decodeValue(obtainedEvent.getEventPayload(), DataImportEventPayload.class);
     assertEquals(DI_ERROR.value(), eventPayload.getEventType());
-    assertEquals(jobExec.getId(), eventPayload.getJobExecutionId());
     assertEquals(TENANT_ID, eventPayload.getTenant());
     assertNotNull(eventPayload.getContext().get(EntityType.MARC_BIBLIOGRAPHIC.value()));
     assertNotNull(eventPayload.getContext().get(ERROR_MSG_KEY));
   }
 
   @Test
-  public void shouldSendEventsWithRecords() throws InterruptedException {
-    // given
-    String parsedContent = "{\"leader\":\"00115nam  22000731a 4500\",\"fields\":[{\"003\":\"in001\"},{\"507\":{\"subfields\":[{\"a\":\"data\"}],\"ind1\":\" \",\"ind2\":\" \"}},{\"500\":{\"subfields\":[{\"a\":\"data\"}],\"ind1\":\" \",\"ind2\":\" \"}}]}";
+  public void shouldPublishCoupleDiErrorsWhenWrongPayload() throws InterruptedException {
+    String wrongPayload = "{\"leader\": \"13112c7m a2200553Ii 4300\"}";
+    RecordsBatchResponse recordsBatch = getRecordsBatchResponse(wrongPayload, 7);
 
-    RecordsBatchResponse recordsBatch = new RecordsBatchResponse()
-      .withTotalRecords(1)
-      .withRecords(List.of(new Record()
-        .withRecordType(MARC_BIB)
-        .withId(UUID.randomUUID().toString())
-        .withSnapshotId(jobExec.getId())
-        .withParsedRecord(new ParsedRecord().withContent(parsedContent))));
-
-    Event event = new Event().withId(UUID.randomUUID().toString()).withEventPayload(Json.encode(recordsBatch));
-    KeyValue<String, String> kafkaRecord = new KeyValue<>("42", Json.encode(event));
-    kafkaRecord.addHeader(OKAPI_TENANT_HEADER, TENANT_ID, UTF_8);
-    kafkaRecord.addHeader(OKAPI_TOKEN_HEADER, TOKEN, UTF_8);
-    kafkaRecord.addHeader(JOB_EXECUTION_ID_HEADER, jobExec.getId(), UTF_8);
-
-    String topic = formatToKafkaTopicName(DI_PARSED_RECORDS_CHUNK_SAVED.value());
-    SendKeyValues<String, String> request = SendKeyValues.to(topic, Collections.singletonList(kafkaRecord))
-      .useDefaults();
+    SendKeyValues<String, String> request = getRequest(jobExec.getId(), recordsBatch);
 
     // when
     kafkaCluster.send(request);
 
     // then
-    String topicToObserve = formatToKafkaTopicName(DI_SRS_MARC_BIB_RECORD_CREATED.value());
-    List<String> observedValues = kafkaCluster.observeValues(ObserveKeyValues.on(topicToObserve, 1)
-      .observeFor(30, TimeUnit.SECONDS)
-      .build());
+    List<String> diErrorValues = observeValuesAndFilterByLeader("13112c7m a2200553Ii 4300", DI_ERROR, 7);
+    assertEquals(7, diErrorValues.size());
+  }
 
+  @Test
+  public void shouldPublishCoupleOfSuccessEventsAndCoupleOfDiErrorEvents() throws InterruptedException {
+    String correctContent = "{\"leader\":\"00116nam  22000731a 4700\",\"fields\":[{\"003\":\"in001\"},{\"507\":{\"subfields\":[{\"a\":\"data\"}],\"ind1\":\" \",\"ind2\":\" \"}},{\"500\":{\"subfields\":[{\"a\":\"data\"}],\"ind1\":\" \",\"ind2\":\" \"}}]}";
+    String wrongContent = "{\"leader\": \"13113c7m a2200553Ii 4800\"}";
+
+    RecordsBatchResponse correctRecords = getRecordsBatchResponse(correctContent, 3);
+    RecordsBatchResponse wrongRecords = getRecordsBatchResponse(wrongContent, 7);
+
+    RecordsBatchResponse allRecords = new RecordsBatchResponse().withTotalRecords(10)
+      .withRecords(ListUtils.union(correctRecords.getRecords(), wrongRecords.getRecords()));
+
+    SendKeyValues<String, String> request = getRequest(jobExec.getId(), allRecords);
+
+    // when
+    kafkaCluster.send(request);
+
+    // then
+    List<String> successValues = observeValuesAndFilterByLeader("00116nam  22000731a 4700", DI_SRS_MARC_BIB_RECORD_CREATED, 3);
+    assertEquals(3, successValues.size());
+
+    List<String> diErrorValues = observeValuesAndFilterByLeader("13113c7m a2200553Ii 4800", DI_ERROR, 7);
+    assertEquals(7, diErrorValues.size());
+  }
+
+  @Test
+  public void shouldSendEventsWithRecords() throws InterruptedException {
+    // given
+    String parsedContent = "{\"leader\":\"00115nam  22000731a 4500\",\"fields\":[{\"003\":\"in001\"},{\"507\":{\"subfields\":[{\"a\":\"data\"}],\"ind1\":\" \",\"ind2\":\" \"}},{\"500\":{\"subfields\":[{\"a\":\"data\"}],\"ind1\":\" \",\"ind2\":\" \"}}]}";
+    RecordsBatchResponse recordsBatch = getRecordsBatchResponse(parsedContent, 1);
+
+    SendKeyValues<String, String> request = getRequest(jobExec.getId(), recordsBatch);
+
+    // when
+    kafkaCluster.send(request);
+
+    // then
+    List<String> observedValues = observeValuesAndFilterByLeader("00115nam  22000731a 4500", DI_SRS_MARC_BIB_RECORD_CREATED, 1);
     Event obtainedEvent = Json.decodeValue(observedValues.get(0), Event.class);
     DataImportEventPayload eventPayload = Json.decodeValue(obtainedEvent.getEventPayload(), DataImportEventPayload.class);
     assertEquals(DI_SRS_MARC_BIB_RECORD_CREATED.value(), eventPayload.getEventType());
-    assertEquals(jobExec.getId(), eventPayload.getJobExecutionId());
     assertEquals(TENANT_ID, eventPayload.getTenant());
     assertNotNull(eventPayload.getContext().get(EntityType.MARC_BIBLIOGRAPHIC.value()));
     assertNotNull(eventPayload.getContext().get(JOB_PROFILE_SNAPSHOT_ID));
+  }
+
+  private RecordsBatchResponse getRecordsBatchResponse(String parsedContent, Integer totalRecords) {
+    List<Record> records = new ArrayList<>();
+    for (int i = 0; i < totalRecords; i++) {
+      records.add(new Record()
+        .withRecordType(MARC_BIB)
+        .withId(UUID.randomUUID().toString())
+        .withSnapshotId(UUID.randomUUID().toString())
+        .withParsedRecord(new ParsedRecord().withContent(parsedContent)));
+    }
+    return new RecordsBatchResponse()
+      .withTotalRecords(totalRecords)
+      .withRecords(records);
+  }
+
+  private SendKeyValues<String, String> getRequest(String jobExecutionId, RecordsBatchResponse recordsBatch) {
+    Event event = new Event().withId(UUID.randomUUID().toString()).withEventPayload(Json.encode(recordsBatch));
+    KeyValue<String, String> kafkaRecord = new KeyValue<>("42", (Json.encode(event)));
+    kafkaRecord.addHeader(OKAPI_TENANT_HEADER, TENANT_ID, UTF_8);
+    kafkaRecord.addHeader(OKAPI_TOKEN_HEADER, TOKEN, UTF_8);
+    kafkaRecord.addHeader(JOB_EXECUTION_ID_HEADER, jobExecutionId, UTF_8);
+
+    String topic = formatToKafkaTopicName(DI_PARSED_RECORDS_CHUNK_SAVED.value());
+    return SendKeyValues.to(topic, Collections.singletonList(kafkaRecord)).useDefaults();
+  }
+
+  private List<String> observeValuesAndFilterByLeader(String leader, DataImportEventTypes eventType, Integer countToObserve) throws InterruptedException {
+    String topicToObserve = formatToKafkaTopicName(eventType.value());
+    List<String> result = new ArrayList<>();
+    List<String> observedValues = kafkaCluster.readValues(ReadKeyValues.from(topicToObserve).build());
+    if (CollectionUtils.isEmpty(observedValues)) {
+      observedValues = kafkaCluster.observeValues(ObserveKeyValues.on(topicToObserve, countToObserve)
+        .observeFor(30, TimeUnit.SECONDS)
+        .build());
+    }
+    for (String observedValue: observedValues) {
+      if (observedValue.contains(leader)) {
+        result.add(observedValue);
+      }
+    }
+    return result;
   }
 }


### PR DESCRIPTION
mod-source-record-manager should implement error's handler to send to Kafka DI_ERROR event if processing was with exception.

In handler's implementation need to make sure, that DI_ERROR thrown for particular record, not for all file taken to process.

This new error handler should be specified during creating of KafkaConsumerWrapper instance.

Adding error handler's for each processing service will help to resolve issue when progress-bar in UI got stuck, import should be 'Completed with errors' in case of failures.

Workflow for implemented error handlers:
![image](https://user-images.githubusercontent.com/25097693/140503588-d9bf1df7-a99f-4312-9ad5-a9bd87060790.png)
