### PR TITLE
MODSPURMAN-595: "View all" and "Load more" buttons do not load all logs in Data Import

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -3,6 +3,7 @@
 * [MODSOURMAN-573](https://issues.folio.org/browse/MODSOURMAN-573) Create mapping rules for AUTHORITY records
 * [MODDICORE-184](https://issues.folio.org/browse/MODDICORE-184) Update the MARC-Instance field mapping for InstanceType (336$a and $b)
 * [MODSOURMAN-590](https://issues.folio.org/browse/MODSOURMAN-590) Save AUTHORITY rules to database
+* [MODSOURMAN-595](https://issues.folio.org/browse/MODSOURMAN-595) "View all" and "Load more" buttons do not load all logs in Data Import
 
 ## 2021-10-xx v3.2.3-SNAPSHOT
 * [MODSOURMAN-522](https://issues.folio.org/browse/MODSOURMAN-522) Fix the effect of DI_ERROR messages when trying to duplicate records on the import job progress bar

--- a/mod-source-record-manager-server/src/main/java/org/folio/services/JobExecutionsCache.java
+++ b/mod-source-record-manager-server/src/main/java/org/folio/services/JobExecutionsCache.java
@@ -42,14 +42,15 @@ public class JobExecutionsCache {
 
   public Future<JobExecutionDtoCollection> get(String tenantId, String cqlQuery, int offset, int limit) {
     Promise<JobExecutionDtoCollection> promise = Promise.promise();
-    cache.get(Pair.of(tenantId, cqlQuery)).whenComplete((jobExecutionOptional, e) -> {
+    String resultingQuery  = cqlQuery + " LIMIT " + limit + " OFFSET " + offset;
+    cache.get(Pair.of(tenantId, resultingQuery)).whenComplete((jobExecutionOptional, e) -> {
       if (e == null) {
         if (jobExecutionOptional != null && jobExecutionOptional.isPresent()) {
           promise.complete(jobExecutionOptional.get());
         } else {
-          jobExecutionService.getJobExecutionsWithoutParentMultiple(cqlQuery, offset, limit, tenantId)
+          jobExecutionService.getJobExecutionsWithoutParentMultiple(resultingQuery, offset, limit, tenantId)
             .onSuccess(ar -> {
-              put(tenantId, cqlQuery, ar);
+              put(tenantId, resultingQuery, ar);
               promise.complete(ar);
             })
             .onFailure(cause -> {

--- a/mod-source-record-manager-server/src/main/java/org/folio/services/JobExecutionsCache.java
+++ b/mod-source-record-manager-server/src/main/java/org/folio/services/JobExecutionsCache.java
@@ -48,7 +48,7 @@ public class JobExecutionsCache {
         if (jobExecutionOptional != null && jobExecutionOptional.isPresent()) {
           promise.complete(jobExecutionOptional.get());
         } else {
-          jobExecutionService.getJobExecutionsWithoutParentMultiple(resultingQuery, offset, limit, tenantId)
+          jobExecutionService.getJobExecutionsWithoutParentMultiple(cqlQuery, offset, limit, tenantId)
             .onSuccess(ar -> {
               put(tenantId, resultingQuery, ar);
               promise.complete(ar);


### PR DESCRIPTION
## Purpose
"View all" and "Load more" buttons in Data Import should load all logs but are not.

## Approach
It seems like "limit" and "offset" params from the request are not concatenated to the query, which will be used in Cache. That's why queries with the difference limit and offset are the same as in the Cache. That's why in response there are the same results. 
This fix added "LIMIT and OFFSET" params to store them in the cache (create them unique).

## Learning
JIRA: https://issues.folio.org/browse/MODSOURMAN-595
