### PR TITLE
MODSOURMAN-594 Cannot build journal record when entity is empty

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -5,6 +5,7 @@
 * [MODSOURMAN-590](https://issues.folio.org/browse/MODSOURMAN-590) Save AUTHORITY rules to database
 * [MODSOURMAN-595](https://issues.folio.org/browse/MODSOURMAN-595) "View all" and "Load more" buttons do not load all logs in Data Import
 * [MODSOURMAN-570](https://issues.folio.org/browse/MODSOURMAN-570) Edit MARC Authorities via quickMARC | Handle events properly to Authorities
+* [MODSOURMAN-594](https://issues.folio.org/browse/MODSOURMAN-594) Cannot build journal record when entity is empty
 
 ## 2021-10-xx v3.2.3-SNAPSHOT
 * [MODSOURMAN-522](https://issues.folio.org/browse/MODSOURMAN-522) Fix the effect of DI_ERROR messages when trying to duplicate records on the import job progress bar

--- a/mod-source-record-manager-server/src/test/java/org/folio/services/JournalUtilTest.java
+++ b/mod-source-record-manager-server/src/test/java/org/folio/services/JournalUtilTest.java
@@ -121,4 +121,34 @@ public class JournalUtilTest {
     JournalUtil.buildJournalRecordByEvent(eventPayload,
       JournalRecord.ActionType.CREATE, JournalRecord.EntityType.INSTANCE, JournalRecord.ActionStatus.COMPLETED);
   }
+
+  @Test
+  public void shouldBuildJournalRecordWhenNoEntityPresent() throws JournalRecordMapperException {
+    String recordId = UUID.randomUUID().toString();
+    String snapshotId = UUID.randomUUID().toString();
+
+    JsonObject recordJson = new JsonObject()
+      .put("id", recordId)
+      .put("snapshotId", snapshotId)
+      .put("order", 1);
+
+    HashMap<String, String> context = new HashMap<>();
+    context.put(MARC_BIBLIOGRAPHIC.value(), recordJson.encode());
+
+    DataImportEventPayload eventPayload = new DataImportEventPayload()
+      .withEventType("DI_INVENTORY_HOLDING_NOT_MATCHED")
+      .withContext(context);
+
+    JournalRecord journalRecord = JournalUtil.buildJournalRecordByEvent(eventPayload,
+      JournalRecord.ActionType.NON_MATCH, JournalRecord.EntityType.HOLDINGS, JournalRecord.ActionStatus.COMPLETED);
+
+    Assert.assertNotNull(journalRecord);
+    Assert.assertEquals(snapshotId, journalRecord.getJobExecutionId());
+    Assert.assertEquals(recordId, journalRecord.getSourceId());
+    Assert.assertEquals(1, journalRecord.getSourceRecordOrder().intValue());
+    Assert.assertEquals(JournalRecord.EntityType.HOLDINGS, journalRecord.getEntityType());
+    Assert.assertEquals(JournalRecord.ActionType.NON_MATCH, journalRecord.getActionType());
+    Assert.assertEquals(JournalRecord.ActionStatus.COMPLETED, journalRecord.getActionStatus());
+    Assert.assertNotNull(journalRecord.getActionDate());
+  }
 }


### PR DESCRIPTION
## Purpose
Cannot build journal record when entity is empty

## Approach
Added additional entity validation for emptiness

## Learning
[MODSOURMAN-594](https://issues.folio.org/browse/MODSOURMAN-594)
