### PR TITLE
MODSOURMAN-598 Properly handle DB failures during events processing

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -7,7 +7,7 @@
 * [MODSOURMAN-570](https://issues.folio.org/browse/MODSOURMAN-570) Edit MARC Authorities via quickMARC | Handle events properly to Authorities
 * [MODSOURMAN-594](https://issues.folio.org/browse/MODSOURMAN-594) Cannot build journal record when entity is empty
 * [MODSOURMAN-228](https://issues.folio.org/browse/MODSOURMAN-228) Update the MARC-to-Instance mapping documentation
-
+* [MODSOURMAN-598](https://issues.folio.org/browse/MODSOURMAN-598) Properly handle DB failures during events processing
 
 ## 2021-10-xx v3.2.3-SNAPSHOT
 * [MODSOURMAN-522](https://issues.folio.org/browse/MODSOURMAN-522) Fix the effect of DI_ERROR messages when trying to duplicate records on the import job progress bar

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,4 +1,5 @@
 ## 2021-xx-xx v3.3.0-SNAPSHOT
+* [MODSOURMAN-614](https://issues.folio.org/browse/MODSOURMAN-614) Authority: Add mapping rule for note types
 * [MODSOURMAN-577](https://issues.folio.org/browse/MODSOURMAN-577) Optimistic locking: mod-source-record-manager modifications
 * [MODSOURMAN-573](https://issues.folio.org/browse/MODSOURMAN-573) Create mapping rules for AUTHORITY records
 * [MODDICORE-184](https://issues.folio.org/browse/MODDICORE-184) Update the MARC-Instance field mapping for InstanceType (336$a and $b)

--- a/mod-source-record-manager-server/src/main/java/org/folio/services/AbstractChunkProcessingService.java
+++ b/mod-source-record-manager-server/src/main/java/org/folio/services/AbstractChunkProcessingService.java
@@ -45,8 +45,7 @@ public abstract class AbstractChunkProcessingService implements ChunkProcessingS
 
           return jobExecutionSourceChunkDao.save(sourceChunk, params.getTenantId())
             .compose(ar -> processRawRecordsChunk(incomingChunk, sourceChunk, jobExecution.getId(), params))
-            .map(true)
-            .recover(th -> Future.succeededFuture(false));
+            .map(true);
         }).orElse(Future.failedFuture(new NotFoundException(String.format("Couldn't find JobExecution with id %s", jobExecutionId)))));
   }
 

--- a/mod-source-record-manager-server/src/main/java/org/folio/verticle/consumers/errorhandlers/RawMarcChunksErrorHandler.java
+++ b/mod-source-record-manager-server/src/main/java/org/folio/verticle/consumers/errorhandlers/RawMarcChunksErrorHandler.java
@@ -4,6 +4,7 @@ import io.vertx.core.Vertx;
 import io.vertx.core.json.Json;
 import io.vertx.kafka.client.consumer.KafkaConsumerRecord;
 import io.vertx.kafka.client.producer.KafkaHeader;
+import io.vertx.pgclient.PgException;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.folio.dataimport.util.OkapiConnectionParams;
@@ -11,6 +12,8 @@ import org.folio.kafka.KafkaConfig;
 import org.folio.kafka.KafkaHeaderUtils;
 import org.folio.kafka.ProcessRecordErrorHandler;
 import org.folio.rest.jaxrs.model.DataImportEventPayload;
+import org.folio.rest.jaxrs.model.Event;
+import org.folio.rest.jaxrs.model.RawRecordsDto;
 import org.folio.services.util.EventHandlingUtil;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
@@ -30,6 +33,8 @@ public class RawMarcChunksErrorHandler implements ProcessRecordErrorHandler<Stri
   public static final String ERROR_KEY = "ERROR";
   public static final String JOB_EXECUTION_ID_HEADER = "jobExecutionId";
   public static final String RECORD_ID_HEADER = "recordId";
+  public static final String CHUNK_ID_HEADER = "chunkId";
+  public static final String UNIQUE_CONSTRAINT_VIOLATION_CODE = "23505";
 
   @Autowired
   private Vertx vertx;
@@ -38,9 +43,12 @@ public class RawMarcChunksErrorHandler implements ProcessRecordErrorHandler<Stri
 
   @Override
   public void handle(Throwable throwable, KafkaConsumerRecord<String, String> record) {
+    Event event = Json.decodeValue(record.value(), Event.class);
+    RawRecordsDto rawRecordsDto = Json.decodeValue(event.getEventPayload(), RawRecordsDto.class);
     List<KafkaHeader> kafkaHeaders = record.headers();
     OkapiConnectionParams okapiParams = new OkapiConnectionParams(KafkaHeaderUtils.kafkaHeadersToMap(kafkaHeaders), vertx);
     String jobExecutionId = okapiParams.getHeaders().get(JOB_EXECUTION_ID_HEADER);
+    String chunkId = okapiParams.getHeaders().get(CHUNK_ID_HEADER);
     String tenantId = okapiParams.getTenantId();
 
     DataImportEventPayload eventPayload = new DataImportEventPayload()
@@ -53,7 +61,11 @@ public class RawMarcChunksErrorHandler implements ProcessRecordErrorHandler<Stri
         put(ERROR_KEY, throwable.getMessage());
       }});
 
-    sendDiErrorEvent(eventPayload, okapiParams, jobExecutionId, tenantId);
+    if(isUniqueConstraintViolationException(throwable)) {
+      LOGGER.warn("Duplicate event received, skipping parsing for jobExecutionId: {} , tenantId: {}, chunkId:{}, totalRecords: {}, cause: {}", jobExecutionId, tenantId, chunkId, rawRecordsDto.getInitialRecords().size(), throwable.getMessage());
+    } else {
+      sendDiErrorEvent(eventPayload, okapiParams, jobExecutionId, tenantId);
+    }
   }
 
   private void sendDiErrorEvent(DataImportEventPayload eventPayload, OkapiConnectionParams okapiParams, String jobExecutionId, String tenantId) {
@@ -65,5 +77,9 @@ public class RawMarcChunksErrorHandler implements ProcessRecordErrorHandler<Stri
 
     EventHandlingUtil.sendEventToKafka(tenantId, Json.encode(eventPayload), DI_ERROR.value(), KafkaHeaderUtils.kafkaHeadersFromMultiMap(okapiParams.getHeaders()), kafkaConfig, null)
      .onFailure(th -> LOGGER.error("Error publishing DI_ERROR event for jobExecutionId: {}", jobExecutionId, th));
+  }
+
+  private boolean isUniqueConstraintViolationException(Throwable throwable) {
+    return throwable instanceof PgException && ((PgException) throwable).getCode().equals(UNIQUE_CONSTRAINT_VIOLATION_CODE);
   }
 }

--- a/mod-source-record-manager-server/src/test/java/org/folio/rest/impl/changeManager/ChangeManagerAPITest.java
+++ b/mod-source-record-manager-server/src/test/java/org/folio/rest/impl/changeManager/ChangeManagerAPITest.java
@@ -1035,10 +1035,8 @@ public class ChangeManagerAPITest extends AbstractRestTest {
   }
 
   @Test
-  public void shouldProcess3ChunksAndRequestForMappingParameters1Time(TestContext testContext) {
+  public void shouldProcessChunksAndRequestForMappingParameters1Time(TestContext testContext) {
     // given
-    final int NUMBER_OF_CHUNKS = 3;
-
     InitJobExecutionsRsDto response = constructAndPostInitJobExecutionRqDto(1);
     List<JobExecution> createdJobExecutions = response.getJobExecutions();
     assertThat(createdJobExecutions.size(), is(1));
@@ -1059,17 +1057,25 @@ public class ChangeManagerAPITest extends AbstractRestTest {
     async.complete();
 
     // when
-    for (int i = 0; i < NUMBER_OF_CHUNKS; i++) {
-      async = testContext.async();
-      RestAssured.given()
-        .spec(spec)
-        .body(rawRecordsDto)
-        .when()
-        .post(JOB_EXECUTION_PATH + jobExec.getId() + RECORDS_PATH)
-        .then()
-        .statusCode(HttpStatus.SC_NO_CONTENT);
-      async.complete();
-    }
+    async = testContext.async();
+    RestAssured.given()
+      .spec(spec)
+      .body(rawRecordsDto)
+      .when()
+      .post(JOB_EXECUTION_PATH + jobExec.getId() + RECORDS_PATH)
+      .then()
+      .statusCode(HttpStatus.SC_NO_CONTENT);
+    async.complete();
+
+    async = testContext.async();
+    RestAssured.given()
+      .spec(spec)
+      .body(rawRecordsDto)
+      .when()
+      .post(JOB_EXECUTION_PATH + jobExec.getId() + RECORDS_PATH)
+      .then()
+      .statusCode(HttpStatus.SC_CONFLICT);
+    async.complete();
 
     // then
     async = testContext.async();


### PR DESCRIPTION
## Purpose
Prevent sending DI_ERROR event in srm when detected duplicate event

## Approach
- Removed throwable's catcher-mapper in AbstractChunkProccessingService
- Defining UNIQUE CONSTRAINT VIOLATION using Postgres error code and throwable instance

## Learning
https://issues.folio.org/browse/MODSOURMAN-598
