### PR TITLE
MODSOURMAN-614 Authority: Add mapping rule for note types

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,4 +1,5 @@
 ## 2021-xx-xx v3.3.0-SNAPSHOT
+* [MODSOURMAN-614](https://issues.folio.org/browse/MODSOURMAN-614) Authority: Add mapping rule for note types
 * [MODSOURMAN-577](https://issues.folio.org/browse/MODSOURMAN-577) Optimistic locking: mod-source-record-manager modifications
 * [MODSOURMAN-573](https://issues.folio.org/browse/MODSOURMAN-573) Create mapping rules for AUTHORITY records
 * [MODDICORE-184](https://issues.folio.org/browse/MODDICORE-184) Update the MARC-Instance field mapping for InstanceType (336$a and $b)

--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -69,6 +69,10 @@
     {
       "id": "source-storage-batch",
       "version": "1.1"
+    },
+    {
+      "id": "authority-note-types",
+      "version": "1.0"
     }
   ],
   "provides": [
@@ -209,6 +213,7 @@
             "inventory-storage.statistical-codes.collection.get",
             "inventory-storage.statistical-code-types.collection.get",
             "inventory-storage.item-note-types.collection.get",
+            "inventory-storage.authority-note-types.collection.get",
             "inventory-storage.items.collection.get",
             "inventory-storage.items.item.post",
             "inventory-storage.items.item.put",
@@ -297,6 +302,7 @@
             "inventory-storage.statistical-codes.collection.get",
             "inventory-storage.statistical-code-types.collection.get",
             "inventory-storage.item-note-types.collection.get",
+            "inventory-storage.authority-note-types.collection.get",
             "inventory-storage.material-types.item.get",
             "inventory-storage.material-types.collection.get",
             "inventory-storage.loan-types.item.get",

--- a/mod-source-record-manager-server/src/main/java/org/folio/services/mappers/processor/MappingParametersProvider.java
+++ b/mod-source-record-manager-server/src/main/java/org/folio/services/mappers/processor/MappingParametersProvider.java
@@ -4,6 +4,9 @@ import com.github.benmanes.caffeine.cache.AsyncLoadingCache;
 import com.github.benmanes.caffeine.cache.Caffeine;
 
 import org.apache.commons.lang.StringUtils;
+
+import org.folio.AuthorityNoteType;
+import org.folio.Authoritynotetypes;
 import org.folio.okapi.common.GenericCompositeFuture;
 
 import io.vertx.core.Future;
@@ -113,6 +116,7 @@ public class MappingParametersProvider {
   private static final String LOAN_TYPES_RESPONSE_PARAM = "loantypes";
   private static final String ITEM_NOTE_TYPES_RESPONSE_PARAM = "itemNoteTypes";
   private static final String FIELD_PROTECTION_SETTINGS_RESPONSE_PARAM = "marcFieldProtectionSettings";
+  private static final String AUTHORITY_NOTE_TYPES_RESPONSE_PARAM = "authorityNoteTypes";
 
   private static final String CONFIGS_VALUE_RESPONSE = "configs";
   private static final String VALUE_RESPONSE = "value";
@@ -167,6 +171,7 @@ public class MappingParametersProvider {
     Future<List<ItemDamageStatus>> itemDamagedStatusesFuture = getItemDamagedStatuses(okapiParams);
     Future<List<Loantype>> loanTypesFuture = getLoanTypes(okapiParams);
     Future<List<ItemNoteType>> itemNoteTypesFuture = getItemNoteTypes(okapiParams);
+    Future<List<AuthorityNoteType>> authorityNoteTypesFuture = getAuthorityNoteTypes(okapiParams);
     Future<List<MarcFieldProtectionSetting>> marcFieldProtectionSettingsFuture = getMarcFieldProtectionSettings(okapiParams);
     Future<String> tenantConfigurationFuture = getTenantConfiguration(okapiParams);
 
@@ -175,7 +180,7 @@ public class MappingParametersProvider {
         contributorTypesFuture, contributorNameTypesFuture, electronicAccessRelationshipsFuture, instanceNoteTypesFuture, alternativeTitleTypesFuture,
         issuanceModesFuture, instanceStatusesFuture, natureOfContentTermsFuture, instanceRelationshipTypesFuture, holdingsTypesFuture, holdingsNoteTypesFuture,
         illPoliciesFuture, callNumberTypesFuture, statisticalCodesFuture, statisticalCodeTypesFuture, locationsFuture, materialTypesFuture, itemDamagedStatusesFuture,
-        loanTypesFuture, itemNoteTypesFuture, marcFieldProtectionSettingsFuture, tenantConfigurationFuture))
+        loanTypesFuture, itemNoteTypesFuture, authorityNoteTypesFuture, marcFieldProtectionSettingsFuture, tenantConfigurationFuture))
       .map(ar ->
         mappingParams
           .withInitializedState(true)
@@ -204,6 +209,7 @@ public class MappingParametersProvider {
           .withItemDamagedStatuses(itemDamagedStatusesFuture.result())
           .withLoanTypes(loanTypesFuture.result())
           .withItemNoteTypes(itemNoteTypesFuture.result())
+          .withAuthorityNoteTypes(authorityNoteTypesFuture.result())
           .withMarcFieldProtectionSettings(marcFieldProtectionSettingsFuture.result())
           .withTenantConfiguration(tenantConfigurationFuture.result())
       );
@@ -661,6 +667,26 @@ public class MappingParametersProvider {
         } else {
           promise.complete(Collections.emptyList());
         }
+      }
+    });
+    return promise.future();
+  }
+
+  private Future<List<AuthorityNoteType>> getAuthorityNoteTypes(OkapiConnectionParams params) {
+    var promise = Promise.<List<AuthorityNoteType>>promise();
+    var authorityNoteTypesUrl = "/authority-note-types?limit=" + settingsLimit;
+
+    RestUtil.doRequest(params, authorityNoteTypesUrl, HttpMethod.GET, null).onComplete(ar -> {
+      if (!RestUtil.validateAsyncResult(ar, promise)) {
+        return;
+      }
+
+      var response = ar.result().getJson();
+      if (response != null && response.containsKey(AUTHORITY_NOTE_TYPES_RESPONSE_PARAM)) {
+        var authorityNoteTypes = response.mapTo(Authoritynotetypes.class).getAuthorityNoteTypes();
+        promise.complete(authorityNoteTypes);
+      } else {
+        promise.complete(Collections.emptyList());
       }
     });
     return promise.future();

--- a/mod-source-record-manager-server/src/main/resources/rules/marc_authority_rules.json
+++ b/mod-source-record-manager-server/src/main/resources/rules/marc_authority_rules.json
@@ -721,6 +721,47 @@
       "rules": []
     }
   ],
+  "667": [
+    {
+      "entity": [
+        {
+          "target": "notes.noteTypeId",
+          "description": "Authority note type id",
+          "subfield": [
+            "a"
+          ],
+          "rules": [
+            {
+              "conditions": [
+                {
+                  "type": "set_authority_note_type_id",
+                  "parameter": {
+                    "name": "Nonpublic general note"
+                  }
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "target": "notes.note",
+          "description": "Authority note",
+          "subfield": [
+            "a"
+          ],
+          "rules": [
+            {
+              "conditions": [
+                {
+                  "type": "trim"
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    }
+  ],
   "999": [
     {
       "target": "id",

--- a/mod-source-record-manager-server/src/test/java/org/folio/rest/impl/AbstractRestTest.java
+++ b/mod-source-record-manager-server/src/test/java/org/folio/rest/impl/AbstractRestTest.java
@@ -121,6 +121,7 @@ public abstract class AbstractRestTest {
   protected static final String ITEM_DAMAGED_STATUSES_URL = "/item-damaged-statuses?limit=1000";
   protected static final String LOAN_TYPES_URL = "/loan-types?limit=1000";
   protected static final String ITEM_NOTE_TYPES_URL = "/item-note-types?limit=1000";
+  protected static final String AUTHORITY_NOTE_TYPES_URL = "/authority-note-types?limit=1000";
   protected static final String FIELD_PROTECTION_SETTINGS_URL = "/field-protection-settings/marc?limit=1000";
   protected static final String TENANT_CONFIGURATIONS_SETTINGS_URL = "/configurations/entries?query=" + URLEncoder.encode("(module==ORG and configName==localeSettings)", StandardCharsets.UTF_8);;
 
@@ -338,6 +339,7 @@ public abstract class AbstractRestTest {
     WireMock.stubFor(get(ITEM_DAMAGED_STATUSES_URL).willReturn(okJson(new JsonObject().put("itemDamageStatuses", new JsonArray()).toString())));
     WireMock.stubFor(get(LOAN_TYPES_URL).willReturn(okJson(new JsonObject().put("loantypes", new JsonArray()).toString())));
     WireMock.stubFor(get(ITEM_NOTE_TYPES_URL).willReturn(okJson(new JsonObject().put("itemNoteTypes", new JsonArray()).toString())));
+    WireMock.stubFor(get(AUTHORITY_NOTE_TYPES_URL).willReturn(okJson(new JsonObject().put("authorityNoteTypes", new JsonArray()).toString())));
     WireMock.stubFor(get(FIELD_PROTECTION_SETTINGS_URL).willReturn(okJson(new JsonObject().put("marcFieldProtectionSettings", new JsonArray()).toString())));
     WireMock.stubFor(get(TENANT_CONFIGURATIONS_SETTINGS_URL).willReturn(okJson(new JsonObject().put("configs", new JsonArray()).toString())));
 

--- a/mod-source-record-manager-server/src/test/java/org/folio/rest/impl/changeManager/ChangeManagerAPITest.java
+++ b/mod-source-record-manager-server/src/test/java/org/folio/rest/impl/changeManager/ChangeManagerAPITest.java
@@ -1108,6 +1108,7 @@ public class ChangeManagerAPITest extends AbstractRestTest {
     verify(1, getRequestedFor(urlEqualTo(ITEM_DAMAGED_STATUSES_URL)));
     verify(1, getRequestedFor(urlEqualTo(LOAN_TYPES_URL)));
     verify(1, getRequestedFor(urlEqualTo(ITEM_NOTE_TYPES_URL)));
+    verify(1, getRequestedFor(urlEqualTo(AUTHORITY_NOTE_TYPES_URL)));
     verify(1, getRequestedFor(urlEqualTo(FIELD_PROTECTION_SETTINGS_URL)));
     verify(1, getRequestedFor(urlEqualTo(TENANT_CONFIGURATIONS_SETTINGS_URL)));
     async.complete();
@@ -1147,6 +1148,7 @@ public class ChangeManagerAPITest extends AbstractRestTest {
     WireMock.stubFor(get(ITEM_DAMAGED_STATUSES_URL).willReturn(serverError()));
     WireMock.stubFor(get(LOAN_TYPES_URL).willReturn(serverError()));
     WireMock.stubFor(get(ITEM_NOTE_TYPES_URL).willReturn(serverError()));
+    WireMock.stubFor(get(AUTHORITY_NOTE_TYPES_URL).willReturn(serverError()));
     WireMock.stubFor(get(FIELD_PROTECTION_SETTINGS_URL).willReturn(serverError()));
     WireMock.stubFor(get(TENANT_CONFIGURATIONS_SETTINGS_URL).willReturn(serverError()));
 


### PR DESCRIPTION
https://issues.folio.org/browse/MODSOURMAN-614

## Purpose
The purpose is to have an ability to map the note types from incoming marc record

## Approach
- Update MappingParametersProvider
- Update ModuleDescriptor to add new permissions
- Update marc_authority_rules.json
- Update tests
