### PR TITLE
MODSOURMAN-628: RMB 33.2.0, Vert.x 4.1.2

### DIFF
--- a/mod-source-record-manager-server/pom.xml
+++ b/mod-source-record-manager-server/pom.xml
@@ -14,8 +14,11 @@
     <sonar.exclusions>org.folio.services.mappers.processor.**</sonar.exclusions>
     <sonar.exclusions>**/org/folio/rest/impl/ModTenantAPI.java</sonar.exclusions>
     <sonar.coverage.exclusions>**/services/JournalRecordService.java</sonar.coverage.exclusions>
-    <jackson.version>2.10.5.1</jackson.version>
-    <jackson.jaxb.version>2.9.9</jackson.jaxb.version>
+    <!-- Scala module 2.10.5 requires Jackson Databind version >= 2.10.0 and < 2.11.0.
+         kafka-junit uses Scala.
+    -->
+    <jackson.version>2.10.5</jackson.version>
+    <jackson-databind.version>2.10.5.1</jackson-databind.version>
     <lombok.version>1.18.20</lombok.version>
     <testcontainers.version>1.15.3</testcontainers.version>
   </properties>
@@ -81,7 +84,7 @@
     <dependency>
       <groupId>org.folio</groupId>
       <artifactId>mod-source-record-storage-client</artifactId>
-      <version>5.2.0</version>
+      <version>5.2.5</version>
       <type>jar</type>
     </dependency>
     <dependency>
@@ -109,7 +112,7 @@
     <dependency>
       <groupId>net.mguenther.kafka</groupId>
       <artifactId>kafka-junit</artifactId>
-      <version>2.5.0</version>
+      <version>2.8.0</version>
       <scope>test</scope>
       <exclusions>
         <exclusion>
@@ -161,18 +164,28 @@
     </dependency>
     <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
+      <artifactId>jackson-core</artifactId>
+      <version>${jackson.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-databind</artifactId>
+      <version>${jackson-databind.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>com.fasterxml.jackson.core</groupId>
+      <artifactId>jackson-annotations</artifactId>
       <version>${jackson.version}</version>
     </dependency>
     <dependency>
       <groupId>com.fasterxml.jackson.module</groupId>
       <artifactId>jackson-module-jaxb-annotations</artifactId>
-      <version>${jackson.jaxb.version}</version>
+      <version>${jackson.version}</version>
     </dependency>
     <dependency>
       <groupId>org.folio</groupId>
       <artifactId>folio-di-support</artifactId>
-      <version>1.1.0</version>
+      <version>1.4.1</version>
       <type>jar</type>
     </dependency>
     <dependency>

--- a/mod-source-record-manager-server/src/test/java/org/folio/rest/impl/AbstractRestTest.java
+++ b/mod-source-record-manager-server/src/test/java/org/folio/rest/impl/AbstractRestTest.java
@@ -48,7 +48,6 @@ import org.folio.rest.tools.utils.NetworkUtils;
 import org.junit.AfterClass;
 import org.junit.Before;
 import org.junit.BeforeClass;
-import org.junit.ClassRule;
 import org.junit.Rule;
 import org.springframework.context.annotation.AnnotationConfigApplicationContext;
 import org.testcontainers.containers.PostgreSQLContainer;
@@ -66,7 +65,7 @@ import static com.github.tomakehurst.wiremock.client.WireMock.get;
 import static com.github.tomakehurst.wiremock.client.WireMock.okJson;
 import static com.github.tomakehurst.wiremock.client.WireMock.post;
 import static net.mguenther.kafka.junit.EmbeddedKafkaCluster.provisionWith;
-import static net.mguenther.kafka.junit.EmbeddedKafkaClusterConfig.useDefaults;
+import static net.mguenther.kafka.junit.EmbeddedKafkaClusterConfig.defaultClusterConfig;
 import static org.folio.dataimport.util.RestUtil.OKAPI_TENANT_HEADER;
 import static org.folio.dataimport.util.RestUtil.OKAPI_URL_HEADER;
 import static org.folio.kafka.KafkaTopicNameHelper.getDefaultNameSpace;
@@ -180,12 +179,13 @@ public abstract class AbstractRestTest {
       .extensions(new RequestToResponseTransformer())
   );
 
-  @ClassRule
-  public static EmbeddedKafkaCluster kafkaCluster = provisionWith(useDefaults());
+  public static EmbeddedKafkaCluster kafkaCluster;
 
   @BeforeClass
   public static void setUpClass(final TestContext context) throws Exception {
     vertx = Vertx.vertx();
+    kafkaCluster = provisionWith(defaultClusterConfig());
+    kafkaCluster.start();
     String[] hostAndPort = kafkaCluster.getBrokerList().split(":");
 
     System.setProperty(KAFKA_HOST, hostAndPort[0]);
@@ -204,6 +204,7 @@ public abstract class AbstractRestTest {
       if (useExternalDatabase.equals("embedded")) {
         PostgresClient.stopPostgresTester();
       }
+      kafkaCluster.stop();
       async.complete();
     }));
   }

--- a/pom.xml
+++ b/pom.xml
@@ -19,8 +19,8 @@
   </modules>
 
   <properties>
-    <raml-module-builder.version>33.0.2</raml-module-builder.version>
-    <vertx.version>4.1.0</vertx.version>
+    <raml-module-builder.version>33.2.0</raml-module-builder.version>
+    <vertx.version>4.2.1</vertx.version>
     <junit.version>4.13</junit.version>
     <rest-assured.version>4.3.1</rest-assured.version>
     <wiremock.version>2.27.2</wiremock.version>


### PR DESCRIPTION
Update dependencies:

* RMB from 33.0.2 to 33.2.0
* Vert.x from 4.1.0 to 4.2.1
* Jackson from 2.9.9 to 2.10.5
* folio-di-support from 1.1.0 to 1.4.1
* mod-source-record-storage-client from 5.2.0 to 5.2.5
* kafka-junit from 2.5.0 to 2.8.0