### PR TITLE
MODSOURMAN-651: cql2pgjson, Vertx 4.2.2, JUnit 4.13.2

### DIFF
--- a/mod-source-record-manager-server/pom.xml
+++ b/mod-source-record-manager-server/pom.xml
@@ -212,11 +212,6 @@
       <version>2.8.5</version>
     </dependency>
     <dependency>
-      <groupId>org.z3950.zing</groupId>
-      <artifactId>cql2pgjson</artifactId>
-      <version>4.0.0</version>
-    </dependency>
-    <dependency>
       <groupId>io.vertx</groupId>
       <artifactId>vertx-service-proxy</artifactId>
     </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -20,8 +20,8 @@
 
   <properties>
     <raml-module-builder.version>33.2.2</raml-module-builder.version>
-    <vertx.version>4.2.1</vertx.version>
-    <junit.version>4.13</junit.version>
+    <vertx.version>4.2.2</vertx.version>
+    <junit.version>4.13.2</junit.version>
     <rest-assured.version>4.3.1</rest-assured.version>
     <wiremock.version>2.27.2</wiremock.version>
     <main.basedir>${project.basedir}</main.basedir>


### PR DESCRIPTION
Remove unused cql2pgjson:4.0.0.

Update Vert.x from 4.2.1 to 4.2.2.

Update JUnit from 4.13 to 4.13.2.

This fixes these vulnerabilities:

cql2pgjson: "MITM attack http maven repository" https://issues.folio.org/browse/RMB-823 https://maven.apache.org/docs/3.8.1/release-notes.html#cve-2021-26291

Vert.x/Netty: "HTTP request smuggling" https://nvd.nist.gov/vuln/detail/CVE-2021-43797

JUnit: "TemporaryFolder local information disclosure" https://nvd.nist.gov/vuln/detail/CVE-2020-15250