### PR TITLE
MODSOURMAN-653 Authority update: Make Journal to log authorities

### DIFF
--- a/mod-source-record-manager-server/src/main/java/org/folio/verticle/DataImportJournalConsumersVerticle.java
+++ b/mod-source-record-manager-server/src/main/java/org/folio/verticle/DataImportJournalConsumersVerticle.java
@@ -3,7 +3,7 @@ package org.folio.verticle;
 import static org.folio.rest.jaxrs.model.DataImportEventTypes.DI_COMPLETED;
 import static org.folio.rest.jaxrs.model.DataImportEventTypes.DI_ERROR;
 import static org.folio.rest.jaxrs.model.DataImportEventTypes.DI_INVENTORY_AUTHORITY_NOT_MATCHED;
-import static org.folio.rest.jaxrs.model.DataImportEventTypes.DI_INVENTORY_AUTHORITY_MATCHED;
+import static org.folio.rest.jaxrs.model.DataImportEventTypes.DI_INVENTORY_AUTHORITY_UPDATED;
 import static org.folio.rest.jaxrs.model.DataImportEventTypes.DI_INVENTORY_HOLDING_CREATED;
 import static org.folio.rest.jaxrs.model.DataImportEventTypes.DI_INVENTORY_HOLDING_NOT_MATCHED;
 import static org.folio.rest.jaxrs.model.DataImportEventTypes.DI_INVENTORY_HOLDING_UPDATED;
@@ -50,7 +50,7 @@ public class DataImportJournalConsumersVerticle extends AbstractConsumersVerticl
       DI_INVENTORY_ITEM_CREATED.value(),
       DI_INVENTORY_ITEM_UPDATED.value(),
       DI_INVENTORY_ITEM_NOT_MATCHED.value(),
-      DI_INVENTORY_AUTHORITY_MATCHED.value(),
+      DI_INVENTORY_AUTHORITY_UPDATED.value(),
       DI_INVENTORY_AUTHORITY_NOT_MATCHED.value(),
       DI_INVOICE_CREATED.value(),
       DI_LOG_SRS_MARC_BIB_RECORD_CREATED.value(),

--- a/mod-source-record-manager-server/src/main/java/org/folio/verticle/DataImportJournalConsumersVerticle.java
+++ b/mod-source-record-manager-server/src/main/java/org/folio/verticle/DataImportJournalConsumersVerticle.java
@@ -2,6 +2,8 @@ package org.folio.verticle;
 
 import static org.folio.rest.jaxrs.model.DataImportEventTypes.DI_COMPLETED;
 import static org.folio.rest.jaxrs.model.DataImportEventTypes.DI_ERROR;
+import static org.folio.rest.jaxrs.model.DataImportEventTypes.DI_INVENTORY_AUTHORITY_NOT_MATCHED;
+import static org.folio.rest.jaxrs.model.DataImportEventTypes.DI_INVENTORY_AUTHORITY_MATCHED;
 import static org.folio.rest.jaxrs.model.DataImportEventTypes.DI_INVENTORY_HOLDING_CREATED;
 import static org.folio.rest.jaxrs.model.DataImportEventTypes.DI_INVENTORY_HOLDING_NOT_MATCHED;
 import static org.folio.rest.jaxrs.model.DataImportEventTypes.DI_INVENTORY_HOLDING_UPDATED;
@@ -48,6 +50,8 @@ public class DataImportJournalConsumersVerticle extends AbstractConsumersVerticl
       DI_INVENTORY_ITEM_CREATED.value(),
       DI_INVENTORY_ITEM_UPDATED.value(),
       DI_INVENTORY_ITEM_NOT_MATCHED.value(),
+      DI_INVENTORY_AUTHORITY_MATCHED.value(),
+      DI_INVENTORY_AUTHORITY_NOT_MATCHED.value(),
       DI_INVOICE_CREATED.value(),
       DI_LOG_SRS_MARC_BIB_RECORD_CREATED.value(),
       DI_LOG_SRS_MARC_BIB_RECORD_UPDATED.value(),

--- a/mod-source-record-manager-server/src/main/java/org/folio/verticle/consumers/util/JournalParams.java
+++ b/mod-source-record-manager-server/src/main/java/org/folio/verticle/consumers/util/JournalParams.java
@@ -132,6 +132,22 @@ public class JournalParams {
           JournalRecord.ActionStatus.COMPLETED));
       }
     },
+    DI_INVENTORY_AUTHORITY_MATCHED {
+      @Override
+      public Optional<JournalParams> getJournalParams(DataImportEventPayload eventPayload) {
+        return Optional.of(new JournalParams(JournalRecord.ActionType.MATCH,
+          JournalRecord.EntityType.AUTHORITY,
+          JournalRecord.ActionStatus.COMPLETED));
+      }
+    },
+    DI_INVENTORY_AUTHORITY_NOT_MATCHED {
+      @Override
+      public Optional<JournalParams> getJournalParams(DataImportEventPayload eventPayload) {
+        return Optional.of(new JournalParams(JournalRecord.ActionType.NON_MATCH,
+          JournalRecord.EntityType.AUTHORITY,
+          JournalRecord.ActionStatus.COMPLETED));
+      }
+    },
     DI_INVENTORY_ITEM_CREATED {
       @Override
       public Optional<JournalParams> getJournalParams(DataImportEventPayload eventPayload) {

--- a/mod-source-record-manager-server/src/main/java/org/folio/verticle/consumers/util/JournalParams.java
+++ b/mod-source-record-manager-server/src/main/java/org/folio/verticle/consumers/util/JournalParams.java
@@ -132,10 +132,10 @@ public class JournalParams {
           JournalRecord.ActionStatus.COMPLETED));
       }
     },
-    DI_INVENTORY_AUTHORITY_MATCHED {
+    DI_INVENTORY_AUTHORITY_UPDATED {
       @Override
       public Optional<JournalParams> getJournalParams(DataImportEventPayload eventPayload) {
-        return Optional.of(new JournalParams(JournalRecord.ActionType.MATCH,
+        return Optional.of(new JournalParams(JournalRecord.ActionType.UPDATE,
           JournalRecord.EntityType.AUTHORITY,
           JournalRecord.ActionStatus.COMPLETED));
       }

--- a/mod-source-record-manager-server/src/test/java/org/folio/verticle/consumers/util/JournalParamsTest.java
+++ b/mod-source-record-manager-server/src/test/java/org/folio/verticle/consumers/util/JournalParamsTest.java
@@ -215,8 +215,8 @@ public class JournalParamsTest {
   }
 
   @Test
-  public void shouldPopulateEntityTypeAuthorityWhenEventTypeIsDiInventoryAuthorityMatched() {
-    populateEntityTypeAndActionTypeByEventType(DI_INVENTORY_AUTHORITY_MATCHED, JournalRecord.EntityType.AUTHORITY, JournalRecord.ActionType.MATCH);
+  public void shouldPopulateEntityTypeAuthorityWhenEventTypeIsDiInventoryAuthorityUpdated() {
+    populateEntityTypeAndActionTypeByEventType(DI_INVENTORY_AUTHORITY_MATCHED, JournalRecord.EntityType.AUTHORITY, JournalRecord.ActionType.UPDATE);
   }
 
   @Test

--- a/mod-source-record-manager-server/src/test/java/org/folio/verticle/consumers/util/JournalParamsTest.java
+++ b/mod-source-record-manager-server/src/test/java/org/folio/verticle/consumers/util/JournalParamsTest.java
@@ -2,8 +2,8 @@ package org.folio.verticle.consumers.util;
 
 import static org.folio.DataImportEventTypes.DI_COMPLETED;
 import static org.folio.DataImportEventTypes.DI_ERROR;
-import static org.folio.rest.jaxrs.model.DataImportEventTypes.DI_INVENTORY_AUTHORITY_MATCHED;
 import static org.folio.rest.jaxrs.model.DataImportEventTypes.DI_INVENTORY_AUTHORITY_NOT_MATCHED;
+import static org.folio.rest.jaxrs.model.DataImportEventTypes.DI_INVENTORY_AUTHORITY_UPDATED;
 import static org.folio.rest.jaxrs.model.DataImportEventTypes.DI_INVENTORY_HOLDING_CREATED;
 import static org.folio.rest.jaxrs.model.DataImportEventTypes.DI_INVENTORY_HOLDING_NOT_MATCHED;
 import static org.folio.rest.jaxrs.model.DataImportEventTypes.DI_INVENTORY_HOLDING_UPDATED;
@@ -216,7 +216,7 @@ public class JournalParamsTest {
 
   @Test
   public void shouldPopulateEntityTypeAuthorityWhenEventTypeIsDiInventoryAuthorityUpdated() {
-    populateEntityTypeAndActionTypeByEventType(DI_INVENTORY_AUTHORITY_MATCHED, JournalRecord.EntityType.AUTHORITY, JournalRecord.ActionType.UPDATE);
+    populateEntityTypeAndActionTypeByEventType(DI_INVENTORY_AUTHORITY_UPDATED, JournalRecord.EntityType.AUTHORITY, JournalRecord.ActionType.UPDATE);
   }
 
   @Test

--- a/mod-source-record-manager-server/src/test/java/org/folio/verticle/consumers/util/JournalParamsTest.java
+++ b/mod-source-record-manager-server/src/test/java/org/folio/verticle/consumers/util/JournalParamsTest.java
@@ -2,6 +2,8 @@ package org.folio.verticle.consumers.util;
 
 import static org.folio.DataImportEventTypes.DI_COMPLETED;
 import static org.folio.DataImportEventTypes.DI_ERROR;
+import static org.folio.rest.jaxrs.model.DataImportEventTypes.DI_INVENTORY_AUTHORITY_MATCHED;
+import static org.folio.rest.jaxrs.model.DataImportEventTypes.DI_INVENTORY_AUTHORITY_NOT_MATCHED;
 import static org.folio.rest.jaxrs.model.DataImportEventTypes.DI_INVENTORY_HOLDING_CREATED;
 import static org.folio.rest.jaxrs.model.DataImportEventTypes.DI_INVENTORY_HOLDING_NOT_MATCHED;
 import static org.folio.rest.jaxrs.model.DataImportEventTypes.DI_INVENTORY_HOLDING_UPDATED;
@@ -212,6 +214,15 @@ public class JournalParamsTest {
     populateEntityTypeAndActionTypeByEventType(DI_INVENTORY_AUTHORITY_CREATED, JournalRecord.EntityType.AUTHORITY, JournalRecord.ActionType.CREATE);
   }
 
+  @Test
+  public void shouldPopulateEntityTypeAuthorityWhenEventTypeIsDiInventoryAuthorityMatched() {
+    populateEntityTypeAndActionTypeByEventType(DI_INVENTORY_AUTHORITY_MATCHED, JournalRecord.EntityType.AUTHORITY, JournalRecord.ActionType.MATCH);
+  }
+
+  @Test
+  public void shouldPopulateEntityTypeAuthorityWhenEventTypeIsDiInventoryAuthorityNonMatched() {
+    populateEntityTypeAndActionTypeByEventType(DI_INVENTORY_AUTHORITY_NOT_MATCHED, JournalRecord.EntityType.AUTHORITY, JournalRecord.ActionType.NON_MATCH);
+  }
   @Test
   public void shouldPopulateEntityTypeInstanceWhenEventTypeIsDiInventoryInstanceNonMatched() {
     populateEntityTypeAndActionTypeByEventType(DI_INVENTORY_INSTANCE_NOT_MATCHED, JournalRecord.EntityType.INSTANCE, JournalRecord.ActionType.NON_MATCH);


### PR DESCRIPTION
### Overview

 To have an ability to Log Authority records that were updated/matched or not matched

### Approach

  Update JournalParams, and DataImportJournalConsumersVerticle

### Acceptance criteria

The matched and non-matched records are getting logged into Journal
The new code is covered by unit tests (JournalParamsTest)

### Learn
https://issues.folio.org/browse/MODSOURMAN-653