### PR TITLE
MODSOURMAN-654 Import MARC authority records > Trim leading and trailing whitespaces on MARC 010

### DIFF
--- a/mod-source-record-manager-server/src/main/resources/rules/marc_authority_rules.json
+++ b/mod-source-record-manager-server/src/main/resources/rules/marc_authority_rules.json
@@ -76,7 +76,15 @@
             "a",
             "z"
           ],
-          "rules": []
+          "rules": [
+            {
+              "conditions": [
+                {
+                  "type": "trim"
+                }
+              ]
+            }
+          ]
         }
       ]
     }


### PR DESCRIPTION
## Purpose
 MARC tag 010 $a and $z values may have leading and trailing whitespaces

## Approach
Added trim to condition for 010 field

## Learning
https://issues.folio.org/browse/MODSOURMAN-654
