### PR TITLE
MODSOURMAN-625 Invoice log detail sort by Record column in Data Import detail log not working properly

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -17,6 +17,7 @@
 * [MODDATAIMP-621](https://issues.folio.org/browse/MODDATAIMP-621) Fix saving of default mapping rules
 * [MODDATAIMP-641](https://issues.folio.org/browse/MODDATAIMP-641) Fix NPE exception and fix the main reason of NPE (recordId = null).
 * [MODSOURMAN-645](https://issues.folio.org/browse/MODSOURMAN-645) Update permissions related to Authority
+* [MODSOURMAN-625](https://issues.folio.org/browse/MODSOURMAN-625) Invoice log detail sort by Record column in Data Import detail log not working properly
 
 ## 2021-10-xx v3.2.3-SNAPSHOT
 * [MODSOURMAN-522](https://issues.folio.org/browse/MODSOURMAN-522) Fix the effect of DI_ERROR messages when trying to duplicate records on the import job progress bar

--- a/mod-source-record-manager-server/src/main/java/org/folio/dao/JournalRecordDaoImpl.java
+++ b/mod-source-record-manager-server/src/main/java/org/folio/dao/JournalRecordDaoImpl.java
@@ -28,13 +28,14 @@ import javax.ws.rs.NotFoundException;
 import java.sql.Timestamp;
 import java.time.LocalDateTime;
 import java.time.ZoneOffset;
-import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Collections;
+import java.util.ArrayList;
+import java.util.Objects;
+import java.util.Arrays;
+import java.util.UUID;
 import java.util.Date;
 import java.util.List;
 import java.util.Set;
-import java.util.UUID;
 
 import static java.lang.String.format;
 import static org.apache.commons.lang3.StringUtils.EMPTY;
@@ -273,8 +274,8 @@ public class JournalRecordDaoImpl implements JournalRecordDao {
         .withAuthorityActionStatus(mapNameToEntityActionStatus(row.getString(AUTHORITY_ACTION_STATUS)))
         .withOrderActionStatus(mapNameToEntityActionStatus(row.getString(ORDER_ACTION_STATUS)))
         .withInvoiceActionStatus(mapNameToEntityActionStatus(row.getString(INVOICE_ACTION_STATUS)))
-        .withInvoiceLineJournalRecordId(row.getValue(INVOICE_LINE_JOURNAL_RECORD_ID) != null
-            ? row.getValue(INVOICE_LINE_JOURNAL_RECORD_ID).toString() : null)
+        .withInvoiceLineJournalRecordId(Objects.isNull(row.getValue(INVOICE_LINE_JOURNAL_RECORD_ID))
+            ? null : row.getValue(INVOICE_LINE_JOURNAL_RECORD_ID).toString())
         .withError(row.getString(ERROR));
   }
 

--- a/mod-source-record-manager-server/src/main/resources/templates/db_scripts/create_get_job_log_entries_function.sql
+++ b/mod-source-record-manager-server/src/main/resources/templates/db_scripts/create_get_job_log_entries_function.sql
@@ -31,7 +31,7 @@ AS $$
 DECLARE
     v_sortingfield text := sortingfield;
 BEGIN
-    v_sortingfield := sortingfield;
+-- Using the source_record_order column in the array type provides support for sorting invoices and marc records.
     IF sortingfield = 'source_record_order' THEN
       v_sortingfield := 'source_record_order_array';
     END IF;


### PR DESCRIPTION
## Purpose
Fix sorting of edifact invoices in logs

## Approach
- Added additionaly logic when we sort using source_record_order, now we replace this to other field - source_record_order_array
- Added new column(source_record_order_array) to function get_job_log_entries
- When we sort invoice, function use entity_hrid as int array. In other cases source_record_order as array with single element

## Learning
https://issues.folio.org/browse/MODSOURMAN-625
