### PR TITLE
MODSOURMAN-636 update kafka-junit and jackson dependencies

### DIFF
--- a/mod-source-record-manager-server/pom.xml
+++ b/mod-source-record-manager-server/pom.xml
@@ -14,11 +14,8 @@
     <sonar.exclusions>org.folio.services.mappers.processor.**</sonar.exclusions>
     <sonar.exclusions>**/org/folio/rest/impl/ModTenantAPI.java</sonar.exclusions>
     <sonar.coverage.exclusions>**/services/JournalRecordService.java</sonar.coverage.exclusions>
-    <!-- Scala module 2.10.5 requires Jackson Databind version >= 2.10.0 and < 2.11.0.
-         kafka-junit uses Scala.
-    -->
-    <jackson.version>2.10.5</jackson.version>
-    <jackson-databind.version>2.10.5.1</jackson-databind.version>
+    <jackson.version>2.12.6</jackson.version>
+    <jackson-databind.version>2.12.6</jackson-databind.version>
     <lombok.version>1.18.20</lombok.version>
     <testcontainers.version>1.15.3</testcontainers.version>
   </properties>
@@ -28,7 +25,7 @@
       <dependency>
         <groupId>org.apache.logging.log4j</groupId>
         <artifactId>log4j-bom</artifactId>
-        <version>2.16.0</version>
+        <version>2.17.0</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>
@@ -112,7 +109,7 @@
     <dependency>
       <groupId>net.mguenther.kafka</groupId>
       <artifactId>kafka-junit</artifactId>
-      <version>2.8.0</version>
+      <version>3.0.0</version>
       <scope>test</scope>
       <exclusions>
         <exclusion>


### PR DESCRIPTION
## Purpose
jackson-databind 2.10 has been closed since 2021-09-30, doesn't get any updates and therefore can no longer been used in critical production code: https://github.com/FasterXML/jackson/wiki/Jackson-Releases

## Approach
Bumping the kafka-junit version from 2.8.0 to 3.0.0 bumps the jackson-databind version from 2.10.5.1 to 2.12.6. The version 2.12.* is still maintained and receives security patches.