### PR TITLE
MODSOURMAN-664 Remove Kafka cache from QuickMarc handlers

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -21,7 +21,8 @@
 * [MODSOURMAN-432](https://issues.folio.org/browse/MODSOURMAN-432) Create job execution requires user with "personal" information
 * [MODSOURMAN-656](https://issues.folio.org/browse/MODSOURMAN-656) Support Update MARC Authority Action
 * [MODSOURMAN-638](https://issues.folio.org/browse/MODSOURMAN-638) Remove Kafka cache for StoreRecordsChunksKafkaHandler
-
+* [MODSOURMAN-664](https://issues.folio.org/browse/MODSOURMAN-664) Remove Kafka cache for QuickMarcUpdateKafkaHandler
+* 
 ## 2021-10-xx v3.2.3-SNAPSHOT
 * [MODSOURMAN-522](https://issues.folio.org/browse/MODSOURMAN-522) Fix the effect of DI_ERROR messages when trying to duplicate records on the import job progress bar
 


### PR DESCRIPTION
## Purpose
Kafka Cache is used in QuickMarcUpdateKafkaHandler in SRM. Just remove Kafka cache (consumer receiving QM_COMPLETED supports deduplication).

## Learning
[MODSOURMAN-664](https://issues.folio.org/browse/MODSOURMAN-664)