### PR TITLE
MODSOURMAN-640. Remove Kafka cache by handling Constraint Violation Exceptions for DataImportJournalKafkaHandler

### DIFF
--- a/mod-source-record-manager-server/src/test/java/org/folio/verticle/consumers/DataImportJournalConsumerVerticleTest.java
+++ b/mod-source-record-manager-server/src/test/java/org/folio/verticle/consumers/DataImportJournalConsumerVerticleTest.java
@@ -15,13 +15,14 @@ import org.folio.DataImportEventPayload;
 import org.folio.dao.JobExecutionDaoImpl;
 import org.folio.dao.JournalRecordDao;
 import org.folio.kafka.KafkaTopicNameHelper;
-import org.folio.kafka.cache.KafkaInternalCache;
 import org.folio.rest.impl.AbstractRestTest;
 import org.folio.rest.jaxrs.model.Event;
 import org.folio.rest.jaxrs.model.JobExecution;
 import org.folio.rest.jaxrs.model.JobExecutionLogDto;
 import org.folio.rest.jaxrs.model.JobProfileInfo;
 import org.folio.rest.jaxrs.model.ProfileSnapshotWrapper;
+import org.folio.services.EventProcessedService;
+import org.folio.services.EventProcessedServiceImpl;
 import org.folio.services.journal.JournalService;
 import org.folio.verticle.consumers.util.EventTypeHandlerSelector;
 import org.junit.Assert;
@@ -50,7 +51,7 @@ import static org.folio.rest.util.OkapiConnectionParams.OKAPI_TOKEN_HEADER;
 @RunWith(VertxUnitRunner.class)
 public class DataImportJournalConsumerVerticleTest extends AbstractRestTest {
 
-  private KafkaInternalCache kafkaInternalCache;
+  private EventProcessedService eventProcessedService;
   private JournalService journalService;
   private JobExecutionDaoImpl jobExecutionDao;
   private JournalRecordDao journalRecordDao;
@@ -91,13 +92,13 @@ public class DataImportJournalConsumerVerticleTest extends AbstractRestTest {
     journalService = getBeanFromSpringContext(vertx, org.folio.services.journal.JournalServiceImpl.class);
     Assert.assertNotNull(journalService);
 
-    kafkaInternalCache = getBeanFromSpringContext(vertx, KafkaInternalCache.class);
-    Assert.assertNotNull(kafkaInternalCache);
+    eventProcessedService = getBeanFromSpringContext(vertx, EventProcessedServiceImpl.class);
+    Assert.assertNotNull(eventProcessedService);
 
     EventTypeHandlerSelector eventTypeHandlerSelector = getBeanFromSpringContext(vertx, EventTypeHandlerSelector.class);
     Assert.assertNotNull(eventTypeHandlerSelector);
 
-    dataImportJournalKafkaHandler = new DataImportJournalKafkaHandler(vertx, kafkaInternalCache, eventTypeHandlerSelector, journalService);
+    dataImportJournalKafkaHandler = new DataImportJournalKafkaHandler(vertx, eventProcessedService, eventTypeHandlerSelector, journalService);
   }
 
   @Test

--- a/mod-source-record-manager-server/src/test/java/org/folio/verticle/consumers/ImportInvoiceJournalConsumerVerticleTest.java
+++ b/mod-source-record-manager-server/src/test/java/org/folio/verticle/consumers/ImportInvoiceJournalConsumerVerticleTest.java
@@ -17,13 +17,14 @@ import org.folio.Record;
 import org.folio.dao.JobExecutionDaoImpl;
 import org.folio.dao.JournalRecordDao;
 import org.folio.kafka.KafkaTopicNameHelper;
-import org.folio.kafka.cache.KafkaInternalCache;
 import org.folio.rest.impl.AbstractRestTest;
 import org.folio.rest.jaxrs.model.Event;
 import org.folio.rest.jaxrs.model.JobExecution;
 import org.folio.rest.jaxrs.model.JobExecutionLogDto;
 import org.folio.rest.jaxrs.model.JobProfileInfo;
 import org.folio.rest.jaxrs.model.ProfileSnapshotWrapper;
+import org.folio.services.EventProcessedService;
+import org.folio.services.EventProcessedServiceImpl;
 import org.folio.services.journal.JournalService;
 import org.folio.verticle.consumers.util.EventTypeHandlerSelector;
 import org.junit.Assert;
@@ -61,7 +62,7 @@ import static org.folio.verticle.consumers.ImportInvoiceJournalConsumerVerticleM
 @RunWith(VertxUnitRunner.class)
 public class ImportInvoiceJournalConsumerVerticleTest extends AbstractRestTest {
 
-  private KafkaInternalCache kafkaInternalCache;
+  private EventProcessedService eventProcessedService;
   private JournalService journalService;
   private JobExecutionDaoImpl jobExecutionDao;
   private JournalRecordDao journalRecordDao;
@@ -97,13 +98,13 @@ public class ImportInvoiceJournalConsumerVerticleTest extends AbstractRestTest {
     journalService = getBeanFromSpringContext(vertx, org.folio.services.journal.JournalServiceImpl.class);
     Assert.assertNotNull(journalService);
 
-    kafkaInternalCache = getBeanFromSpringContext(vertx, KafkaInternalCache.class);
-    Assert.assertNotNull(kafkaInternalCache);
+    eventProcessedService = getBeanFromSpringContext(vertx, EventProcessedServiceImpl.class);
+    Assert.assertNotNull(eventProcessedService);
 
     EventTypeHandlerSelector eventTypeHandlerSelector = getBeanFromSpringContext(vertx, EventTypeHandlerSelector.class);
     Assert.assertNotNull(eventTypeHandlerSelector);
 
-    dataImportJournalKafkaHandler = new DataImportJournalKafkaHandler(vertx, kafkaInternalCache, eventTypeHandlerSelector, journalService);
+    dataImportJournalKafkaHandler = new DataImportJournalKafkaHandler(vertx, eventProcessedService, eventTypeHandlerSelector, journalService);
   }
 
   String INVOICE_ID = UUID.randomUUID().toString();


### PR DESCRIPTION
## Purpose
Remove Kafka cache and at the same time need to support deduplication

## Approach
Replace Kafka cache with another deduplication implementation based on DB events_processed table


## Learning
https://issues.folio.org/browse/MODSOURMAN-640