### PR TITLE
Improve logging for handling duplicate events to not write in logs full stack trace

### DIFF
--- a/mod-source-record-manager-server/src/main/java/org/folio/services/AbstractChunkProcessingService.java
+++ b/mod-source-record-manager-server/src/main/java/org/folio/services/AbstractChunkProcessingService.java
@@ -6,7 +6,7 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.folio.dao.JobExecutionSourceChunkDao;
 import org.folio.dataimport.util.OkapiConnectionParams;
-import org.folio.dataimport.util.exception.ConflictException;
+import org.folio.kafka.exception.DuplicateEventException;
 import org.folio.rest.jaxrs.model.InitialRecord;
 import org.folio.rest.jaxrs.model.JobExecution;
 import org.folio.rest.jaxrs.model.JobExecutionSourceChunk;
@@ -50,7 +50,7 @@ public abstract class AbstractChunkProcessingService implements ChunkProcessingS
             .compose(ar -> processRawRecordsChunk(incomingChunk, sourceChunk, jobExecution.getId(), params))
             .map(true)
             .recover(throwable -> throwable instanceof PgException && ((PgException) throwable).getCode().equals(UNIQUE_CONSTRAINT_VIOLATION_CODE) ?
-              Future.failedFuture(new ConflictException(String.format("Source chunk with %s id for %s jobExecution is already exists", incomingChunk.getId(), jobExecutionId))) :
+              Future.failedFuture(new DuplicateEventException(String.format("Source chunk with %s id for %s jobExecution is already exists", incomingChunk.getId(), jobExecutionId))) :
               Future.failedFuture(throwable));
         }).orElse(Future.failedFuture(new NotFoundException(String.format("Couldn't find JobExecution with id %s", jobExecutionId)))));
   }

--- a/mod-source-record-manager-server/src/main/java/org/folio/services/EventProcessedServiceImpl.java
+++ b/mod-source-record-manager-server/src/main/java/org/folio/services/EventProcessedServiceImpl.java
@@ -5,7 +5,7 @@ import io.vertx.pgclient.PgException;
 import io.vertx.sqlclient.Row;
 import io.vertx.sqlclient.RowSet;
 import org.folio.dao.EventProcessedDao;
-import org.folio.dataimport.util.exception.ConflictException;
+import org.folio.kafka.exception.DuplicateEventException;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 import static org.folio.services.AbstractChunkProcessingService.UNIQUE_CONSTRAINT_VIOLATION_CODE;
@@ -25,7 +25,7 @@ public class EventProcessedServiceImpl implements EventProcessedService {
     return eventProcessedDao.save(handlerId, eventId, tenantId)
       .recover(throwable ->
         (throwable instanceof PgException && ((PgException) throwable).getCode().equals(UNIQUE_CONSTRAINT_VIOLATION_CODE)) ?
-          Future.failedFuture(new ConflictException(String.format("Event with eventId=%s for handlerId=%s is already processed.", eventId, handlerId))) :
+          Future.failedFuture(new DuplicateEventException(String.format("Event with eventId=%s for handlerId=%s is already processed.", eventId, handlerId))) :
           Future.failedFuture(throwable));
   }
 }

--- a/mod-source-record-manager-server/src/main/java/org/folio/verticle/consumers/DataImportJournalKafkaHandler.java
+++ b/mod-source-record-manager-server/src/main/java/org/folio/verticle/consumers/DataImportJournalKafkaHandler.java
@@ -11,7 +11,7 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.folio.DataImportEventPayload;
 import org.folio.dataimport.util.OkapiConnectionParams;
-import org.folio.dataimport.util.exception.ConflictException;
+import org.folio.kafka.exception.DuplicateEventException;
 import org.folio.kafka.AsyncRecordHandler;
 import org.folio.kafka.KafkaHeaderUtils;
 import org.folio.rest.jaxrs.model.Event;
@@ -75,7 +75,7 @@ public class DataImportJournalKafkaHandler implements AsyncRecordHandler<String,
   }
 
   private void processDeduplicationFailure(Promise<String> result, KafkaConsumerRecord<String, String> record, Event event, Throwable e) {
-    if (e instanceof ConflictException) { // duplicate coming, ignore it
+    if (e instanceof DuplicateEventException) { // duplicate coming, ignore it
       LOGGER.info(e.getMessage());
       result.complete(record.key());
     } else {

--- a/mod-source-record-manager-server/src/main/java/org/folio/verticle/consumers/DataImportKafkaHandler.java
+++ b/mod-source-record-manager-server/src/main/java/org/folio/verticle/consumers/DataImportKafkaHandler.java
@@ -11,7 +11,7 @@ import org.apache.commons.lang3.StringUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.folio.dataimport.util.OkapiConnectionParams;
-import org.folio.dataimport.util.exception.ConflictException;
+import org.folio.kafka.exception.DuplicateEventException;
 import org.folio.kafka.AsyncRecordHandler;
 import org.folio.kafka.KafkaHeaderUtils;
 import org.folio.rest.jaxrs.model.Event;
@@ -61,7 +61,7 @@ public class DataImportKafkaHandler implements AsyncRecordHandler<String, String
       eventProcessedService.collectData(DATA_IMPORT_KAFKA_HANDLER_UUID, event.getId(), okapiConnectionParams.getTenantId())
         .onSuccess(res -> handleLocalEvent(result, okapiConnectionParams, event))
         .onFailure(e -> {
-          if (e instanceof ConflictException) {
+          if (e instanceof DuplicateEventException) {
             LOGGER.info(e.getMessage());
             result.complete();
           } else {

--- a/mod-source-record-manager-server/src/main/java/org/folio/verticle/consumers/errorhandlers/RawMarcChunksErrorHandler.java
+++ b/mod-source-record-manager-server/src/main/java/org/folio/verticle/consumers/errorhandlers/RawMarcChunksErrorHandler.java
@@ -7,7 +7,7 @@ import io.vertx.kafka.client.producer.KafkaHeader;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.folio.dataimport.util.OkapiConnectionParams;
-import org.folio.dataimport.util.exception.ConflictException;
+import org.folio.kafka.exception.DuplicateEventException;
 import org.folio.kafka.KafkaConfig;
 import org.folio.kafka.KafkaHeaderUtils;
 import org.folio.kafka.ProcessRecordErrorHandler;
@@ -59,7 +59,7 @@ public class RawMarcChunksErrorHandler implements ProcessRecordErrorHandler<Stri
         put(ERROR_KEY, throwable.getMessage());
       }});
 
-    if(throwable instanceof ConflictException) {
+    if(throwable instanceof DuplicateEventException) {
       RawRecordsDto rawRecordsDto = Json.decodeValue(event.getEventPayload(), RawRecordsDto.class);
       LOGGER.info("Duplicate event received, skipping parsing for jobExecutionId: {} , tenantId: {}, chunkId:{}, totalRecords: {}, cause: {}", jobExecutionId, tenantId, chunkId, rawRecordsDto.getInitialRecords().size(), throwable.getMessage());
     } else {

--- a/mod-source-record-manager-server/src/main/java/org/folio/verticle/consumers/errorhandlers/StoredRecordChunksErrorHandler.java
+++ b/mod-source-record-manager-server/src/main/java/org/folio/verticle/consumers/errorhandlers/StoredRecordChunksErrorHandler.java
@@ -7,7 +7,7 @@ import io.vertx.kafka.client.producer.KafkaHeader;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.folio.dataimport.util.OkapiConnectionParams;
-import org.folio.dataimport.util.exception.ConflictException;
+import org.folio.kafka.exception.DuplicateEventException;
 import org.folio.kafka.KafkaConfig;
 import org.folio.kafka.KafkaHeaderUtils;
 import org.folio.kafka.ProcessRecordErrorHandler;
@@ -61,7 +61,7 @@ public class StoredRecordChunksErrorHandler implements ProcessRecordErrorHandler
         sendDiErrorForRecord(jobExecutionId, failedRecord, okapiParams, failedRecord.getErrorRecord().getDescription());
       }
 
-    } else if (throwable instanceof ConflictException) {
+    } else if (throwable instanceof DuplicateEventException) {
         LOGGER.info(throwable.getMessage());
 
     } else {

--- a/mod-source-record-manager-server/src/test/java/org/folio/rest/impl/changeManager/ChangeManagerAPITest.java
+++ b/mod-source-record-manager-server/src/test/java/org/folio/rest/impl/changeManager/ChangeManagerAPITest.java
@@ -1091,7 +1091,7 @@ public class ChangeManagerAPITest extends AbstractRestTest {
       .when()
       .post(JOB_EXECUTION_PATH + jobExec.getId() + RECORDS_PATH)
       .then()
-      .statusCode(HttpStatus.SC_CONFLICT);
+      .statusCode(HttpStatus.SC_INTERNAL_SERVER_ERROR);
     async.complete();
 
     // then

--- a/mod-source-record-manager-server/src/test/java/org/folio/services/EventProcessedServiceTest.java
+++ b/mod-source-record-manager-server/src/test/java/org/folio/services/EventProcessedServiceTest.java
@@ -6,7 +6,7 @@ import io.vertx.pgclient.PgException;
 import io.vertx.sqlclient.Row;
 import io.vertx.sqlclient.RowSet;
 import org.folio.dao.EventProcessedDao;
-import org.folio.dataimport.util.exception.ConflictException;
+import org.folio.kafka.exception.DuplicateEventException;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -50,7 +50,7 @@ public class EventProcessedServiceTest {
   }
 
   @Test
-  public void shouldReturnFailedFutureWithConflictExceptionWhenConstraintViolation() {
+  public void shouldReturnFailedFutureWithDuplicateExceptionWhenConstraintViolation() {
     when(eventProcessedDao.save(HANDLER_ID, EVENT_ID, TENANT_ID))
       .thenReturn(Future.failedFuture(new PgException("DB error", "ERROR", UNIQUE_CONSTRAINT_VIOLATION_CODE, "ConstrainViolation")));
 
@@ -58,7 +58,7 @@ public class EventProcessedServiceTest {
 
     verify(eventProcessedDao).save(HANDLER_ID, EVENT_ID, TENANT_ID);
     assertTrue(future.failed());
-    assertTrue(future.cause() instanceof ConflictException);
+    assertTrue(future.cause() instanceof DuplicateEventException);
   }
 
   @Test

--- a/mod-source-record-manager-server/src/test/java/org/folio/verticle/consumers/DataImportJournalConsumerVerticleMockTest.java
+++ b/mod-source-record-manager-server/src/test/java/org/folio/verticle/consumers/DataImportJournalConsumerVerticleMockTest.java
@@ -16,7 +16,7 @@ import org.folio.DataImportEventPayload;
 import org.folio.TestUtil;
 import org.folio.dao.JournalRecordDaoImpl;
 import org.folio.dao.util.PostgresClientFactory;
-import org.folio.dataimport.util.exception.ConflictException;
+import org.folio.kafka.exception.DuplicateEventException;
 import org.folio.kafka.KafkaTopicNameHelper;
 import org.folio.rest.impl.AbstractRestTest;
 import org.folio.rest.jaxrs.model.Event;
@@ -317,7 +317,7 @@ public class DataImportJournalConsumerVerticleMockTest extends AbstractRestTest 
   public void shouldNotProcessEventWhenItAlreadyProcessed() {
     // given
     when(eventProcessedService.collectData(eq(DATA_IMPORT_JOURNAL_KAFKA_HANDLER_UUID), anyString(), eq(TENANT_ID)))
-      .thenReturn(Future.failedFuture(new ConflictException("ConstraintViolation occurs")));
+      .thenReturn(Future.failedFuture(new DuplicateEventException("ConstraintViolation occurs")));
     Mockito.doNothing().when(journalService).save(ArgumentMatchers.any(JsonObject.class), ArgumentMatchers.any(String.class));
 
     DataImportEventPayload dataImportEventPayload = new DataImportEventPayload()

--- a/mod-source-record-manager-server/src/test/java/org/folio/verticle/consumers/DataImportKafkaHandlerMockTest.java
+++ b/mod-source-record-manager-server/src/test/java/org/folio/verticle/consumers/DataImportKafkaHandlerMockTest.java
@@ -9,7 +9,7 @@ import org.apache.kafka.clients.consumer.ConsumerRecord;
 import org.apache.kafka.common.header.internals.RecordHeader;
 import org.folio.DataImportEventPayload;
 import org.folio.dataimport.util.OkapiConnectionParams;
-import org.folio.dataimport.util.exception.ConflictException;
+import org.folio.kafka.exception.DuplicateEventException;
 import org.folio.kafka.KafkaTopicNameHelper;
 import org.folio.rest.jaxrs.model.Event;
 import org.folio.services.EventHandlingService;
@@ -62,7 +62,7 @@ public class DataImportKafkaHandlerMockTest {
   public void shouldSkipEventHandlingWhenDBContainsHandlerAndEventId() {
     // given
     Mockito.when(eventProcessedService.collectData(eq(DI_KAFKA_HANDLER_ID), eq("c9d09a5e-73ba-11ec-90d6-0242ac120003"), eq(TENANT_ID)))
-      .thenReturn(Future.failedFuture(new ConflictException("Constraint Violation Occurs")));
+      .thenReturn(Future.failedFuture(new DuplicateEventException("Constraint Violation Occurs")));
 
     DataImportEventPayload dataImportEventPayload = new DataImportEventPayload()
       .withEventType(DI_ERROR.value())

--- a/mod-source-record-manager-server/src/test/java/org/folio/verticle/consumers/StoredRecordChunksKafkaHandlerTest.java
+++ b/mod-source-record-manager-server/src/test/java/org/folio/verticle/consumers/StoredRecordChunksKafkaHandlerTest.java
@@ -9,7 +9,7 @@ import io.vertx.kafka.client.consumer.KafkaConsumerRecord;
 import io.vertx.kafka.client.producer.KafkaHeader;
 import org.folio.TestUtil;
 import org.folio.dataimport.util.OkapiConnectionParams;
-import org.folio.dataimport.util.exception.ConflictException;
+import org.folio.kafka.exception.DuplicateEventException;
 import org.folio.kafka.AsyncRecordHandler;
 import org.folio.rest.jaxrs.model.Event;
 import org.folio.rest.jaxrs.model.JournalRecord;
@@ -100,7 +100,7 @@ public class StoredRecordChunksKafkaHandlerTest {
     when(kafkaRecord.value()).thenReturn(Json.encode(event));
     when(kafkaRecord.headers()).thenReturn(List.of(KafkaHeader.header(OKAPI_HEADER_TENANT, TENANT_ID)));
     when(eventProcessedService.collectData(STORED_RECORD_CHUNKS_KAFKA_HANDLER_UUID, event.getId(), TENANT_ID))
-      .thenReturn(Future.failedFuture(new ConflictException("Constraint Violation Occurs")));
+      .thenReturn(Future.failedFuture(new DuplicateEventException("Constraint Violation Occurs")));
 
     // when
     Future<String> future = storedRecordChunksKafkaHandler.handle(kafkaRecord);
@@ -108,7 +108,7 @@ public class StoredRecordChunksKafkaHandlerTest {
     // then
     verify(recordsPublishingService, never()).sendEventsWithRecords(anyList(), anyString(), any(OkapiConnectionParams.class), anyString());
     assertTrue(future.failed());
-    assertTrue(future.cause() instanceof ConflictException);
+    assertTrue(future.cause() instanceof DuplicateEventException);
   }
 
   @Test


### PR DESCRIPTION
## Purpose
Prevent logging of full stack traces for duplicate event to not confuse that someting was wrong

**Example of such stack trace:**
10:01:36.749 [vert.x-worker-thread-0] ERROR KafkaConsumerWrapper [138548eqId] Error while processing a record - id: 81 subscriptionPattern: SubscriptionDefinition(eventType=DI_PARSED_RECORDS_CHUNK_SAVED, subscriptionPattern=FOLIO.Default.\w{1,}.DI_PARSED_RECORDS_CHUNK_SAVED) offset: 2 org.folio.dataimport.util.exception.ConflictException: Event with eventId=4013eb1c-83ce-4782-b6d7-bbda4a4323e3 for handlerId=4d39ced7-9b67-4bdc-b232-343dbb5b8cef is already processed. at org.folio.services.EventProcessedServiceImpl.lambda$collectData$0(EventProcessedServiceImpl.java:28) ~[mod-source-record-manager-server-fat.jar:?] at io.vertx.core.impl.future.Composition.onFailure(Composition.java:50) ~[mod-source-record-manager-server-fat.jar:?] at io.vertx.core.impl.future.FutureBase.emitFailure(FutureBase.java:75) ~[mod-source-record-manager-server-fat.jar:?] at io.vertx.core.impl.future.FutureImpl.tryFail(FutureImpl.java:230) ~[mod-source-record-manager-server-fat.jar:?] at io.vertx.core.impl.future.PromiseImpl.tryFail(PromiseImpl.java:23) ~[mod-source-record-manager-server-fat.jar:?] at io.vertx.core.impl.future.PromiseImpl.onFailure(PromiseImpl.java:54) ~[mod-source-record-manager-server-fat.jar:?] at io.vertx.core.impl.future.FutureBase.emitFailure(FutureBase.java:75) ~[mod-source-record-manager-server-fat.jar:?] at io.vertx.core.impl.future.FutureImpl.tryFail(FutureImpl.java:230) ~[mod-source-record-manager-server-fat.jar:?] at io.vertx.core.impl.future.Composition$1.onFailure(Composition.java:66) ~[mod-source-record-manager-server-fat.jar:?] at io.vertx.core.impl.future.FutureImpl$ListenerArray.onFailure(FutureImpl.java:268) ~[mod-source-record-manager-server-fat.jar:?] at io.vertx.core.impl.future.FutureBase.emitFailure(FutureBase.java:75) ~[mod-source-record-manager-server-fat.jar:?] at io.vertx.core.impl.future.FutureImpl.tryFail(FutureImpl.java:230) ~[mod-source-record-manager-server-fat.jar:?] at io.vertx.core.impl.future.PromiseImpl.tryFail(PromiseImpl.java:23) ~[mod-source-record-manager-server-fat.jar:?] at io.vertx.sqlclient.impl.QueryResultBuilder.tryFail(QueryResultBuilder.java:118) ~[mod-source-record-manager-server-fat.jar:?] at io.vertx.core.Promise.fail(Promise.java:89) ~[mod-source-record-manager-server-fat.jar:?] at io.vertx.core.Promise.handle(Promise.java:53) ~[mod-source-record-manager-server-fat.jar:?] at io.vertx.core.Promise.handle(Promise.java:29) ~[mod-source-record-manager-server-fat.jar:?] at io.vertx.core.impl.future.FutureImpl$3.onFailure(FutureImpl.java:153) ~[mod-source-record-manager-server-fat.jar:?] at io.vertx.core.impl.future.FutureBase.lambda$emitFailure$1(FutureBase.java:69) ~[mod-source-record-manager-server-fat.jar:?] at io.vertx.core.impl.WorkerContext.lambda$execute$2(WorkerContext.java:104) ~[mod-source-record-manager-server-fat.jar:?] at io.vertx.core.impl.TaskQueue.run(TaskQueue.java:76) ~[mod-source-record-manager-server-fat.jar:?] at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1128) [?:?] at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:628) [?:?] at io.netty.util.concurrent.FastThreadLocalRunnable.run(FastThreadLocalRunnable.java:30) [mod-source-record-manager-server-fat.jar:?] at java.lang.Thread.run(Thread.java:829) [?:?

## Approach
To use the same exception DuplicateEventException that used also in other modules , because for this exception folio-kafka-wrapper not writes full stack trace, only error message
