### PR TITLE
Update Kafka clients version to fix unit tests on Windows

### DIFF
--- a/mod-source-record-manager-server/pom.xml
+++ b/mod-source-record-manager-server/pom.xml
@@ -18,7 +18,7 @@
     <jackson-databind.version>2.12.6</jackson-databind.version>
     <lombok.version>1.18.20</lombok.version>
     <testcontainers.version>1.15.3</testcontainers.version>
-    <kafkaclients.version>3.0.0</kafkaclients.version>
+    <kafkaclients.version>3.1.0</kafkaclients.version>
   </properties>
 
   <dependencyManagement>


### PR DESCRIPTION
## Purpose
Kafka clients 3.0.0 version contained an issue with running tests on Windows machine.
https://issues.apache.org/jira/browse/KAFKA-13391
 Since 3.0.1 it was fixed so applying this new version in SRM

## Approach
Increase version of kafka-clients