### PR TITLE
MODSOURMAN-675 Data Import handles repeated 020 $a:s in an unexpected manner when creating Instance Identifiers

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -27,6 +27,7 @@
 * [MODSOURMAN-641](https://issues.folio.org/browse/MODSOURMAN-641) Remove Kafka cache by handling Constraint Violation Exceptions
 * [MODDATAIMP-623](https://issues.folio.org/browse/MODDATAIMP-623) Remove Kafka cache initialization and Maven dependency
 * [MODSOURMAN-668](https://issues.folio.org/browse/MODSOURMAN-668) Restructure job_execution_progress table for DataImportKafkaHandler
+* [MODSOURMAN-675](https://issues.folio.org/browse/MODSOURMAN-675) Data Import handles repeated 020 $a:s in an unexpected manner when creating Instance Identifiers
 
 ## 2021-10-xx v3.2.3-SNAPSHOT
 * [MODSOURMAN-522](https://issues.folio.org/browse/MODSOURMAN-522) Fix the effect of DI_ERROR messages when trying to duplicate records on the import job progress bar

--- a/mod-source-record-manager-server/src/main/resources/rules/marc_bib_rules.json
+++ b/mod-source-record-manager-server/src/main/resources/rules/marc_bib_rules.json
@@ -157,6 +157,7 @@
   ],
   "020": [
     {
+      "entityPerRepeatedSubfield": true,
       "entity": [
         {
           "target": "identifiers.identifierTypeId",
@@ -180,20 +181,19 @@
         {
           "target": "identifiers.value",
           "description": "Valid ISBN",
-          "applyRulesOnConcatenatedData": true,
           "subfield": [
-            "a",
-            "c",
-            "q"
-          ],
-          "requiredSubfield": [
             "a"
           ],
           "rules": [
             {
               "conditions": [
                 {
-                  "type": "remove_ending_punc, trim"
+                  "type": "concat_subfields_by_name, remove_ending_punc,trim",
+                  "parameter": {
+                    "subfieldsToConcat": [
+                      "c", "q"
+                    ]
+                  }
                 }
               ]
             }
@@ -202,6 +202,7 @@
       ]
     },
     {
+      "entityPerRepeatedSubfield": true,
       "entity": [
         {
           "target": "identifiers.identifierTypeId",
@@ -225,20 +226,19 @@
         {
           "target": "identifiers.value",
           "description": "Invalid ISBN",
-          "applyRulesOnConcatenatedData": true,
           "subfield": [
-            "z",
-            "q",
-            "c"
-          ],
-          "requiredSubfield": [
             "z"
           ],
           "rules": [
             {
               "conditions": [
                 {
-                  "type": "remove_ending_punc, trim"
+                  "type": "concat_subfields_by_name, remove_ending_punc,trim",
+                  "parameter": {
+                    "subfieldsToConcat": [
+                      "q", "c"
+                    ]
+                  }
                 }
               ]
             }

--- a/mod-source-record-manager-server/src/test/resources/org/folio/services/marc_bib_rules.json
+++ b/mod-source-record-manager-server/src/test/resources/org/folio/services/marc_bib_rules.json
@@ -157,6 +157,7 @@
   ],
   "020": [
     {
+      "entityPerRepeatedSubfield": true,
       "entity": [
         {
           "target": "identifiers.identifierTypeId",
@@ -180,20 +181,19 @@
         {
           "target": "identifiers.value",
           "description": "Valid ISBN",
-          "applyRulesOnConcatenatedData": true,
           "subfield": [
-            "a",
-            "c",
-            "q"
-          ],
-          "requiredSubfield": [
             "a"
           ],
           "rules": [
             {
               "conditions": [
                 {
-                  "type": "remove_ending_punc, trim"
+                  "type": "concat_subfields_by_name, remove_ending_punc,trim",
+                  "parameter": {
+                    "subfieldsToConcat": [
+                      "c", "q"
+                    ]
+                  }
                 }
               ]
             }
@@ -202,6 +202,7 @@
       ]
     },
     {
+      "entityPerRepeatedSubfield": true,
       "entity": [
         {
           "target": "identifiers.identifierTypeId",
@@ -225,20 +226,19 @@
         {
           "target": "identifiers.value",
           "description": "Invalid ISBN",
-          "applyRulesOnConcatenatedData": true,
           "subfield": [
-            "z",
-            "q",
-            "c"
-          ],
-          "requiredSubfield": [
             "z"
           ],
           "rules": [
             {
               "conditions": [
                 {
-                  "type": "remove_ending_punc, trim"
+                  "type": "concat_subfields_by_name, remove_ending_punc,trim",
+                  "parameter": {
+                    "subfieldsToConcat": [
+                      "q", "c"
+                    ]
+                  }
                 }
               ]
             }


### PR DESCRIPTION
## Purpose
Incorrect mapping "020" marc field when fields repeated:
**=020  \\$a9780471622673$q(acid-free paper)$a0471725331$q(electronic bk.)**
_Expected result:_
ISBN : 9780471622673 (acid-free paper)
ISBN : 0471725331 (electronic bk.)
_Actual result:_
ISBN :  (acid-free paper) 0471725331 (electronic bk.)
ISBN :  9780471622673

## Approach

- Added [entityPerRepeatedSubfield flag](https://github.com/folio-org/mod-source-record-manager/blob/master/RuleProcessorApi.md#new-object-per-repeated-sub-fields) to 020 field
- Replaced [applyRulesOnConcatedData flag](https://github.com/folio-org/mod-source-record-manager/blob/master/RuleProcessorApi.md#processing-rules-on-concatenated-data) to [subfieldsToConcat flag](https://github.com/folio-org/mod-source-record-manager/blob/master/RuleProcessorApi.md#required-sub-fields-concatenation)

## Learning
[MODSOURMAN-675](https://issues.folio.org/browse/MODSOURMAN-675)
