### PR TITLE
MODSOURMAN-676 Provide Instance UUID for populating Inventory hotlinks for holdings/items

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -28,6 +28,7 @@
 * [MODDATAIMP-623](https://issues.folio.org/browse/MODDATAIMP-623) Remove Kafka cache initialization and Maven dependency
 * [MODSOURMAN-668](https://issues.folio.org/browse/MODSOURMAN-668) Restructure job_execution_progress table for DataImportKafkaHandler
 * [MODSOURMAN-675](https://issues.folio.org/browse/MODSOURMAN-675) Data Import handles repeated 020 $a:s in an unexpected manner when creating Instance Identifiers
+* [MODSOURMAN-676](https://issues.folio.org/browse/MODSOURMAN-676) Provide Instance UUID for populating Inventory hotlinks for holdings/items
 
 ## 2021-10-xx v3.2.3-SNAPSHOT
 * [MODSOURMAN-522](https://issues.folio.org/browse/MODSOURMAN-522) Fix the effect of DI_ERROR messages when trying to duplicate records on the import job progress bar

--- a/mod-source-record-manager-server/src/main/java/org/folio/dao/util/JournalRecordsColumns.java
+++ b/mod-source-record-manager-server/src/main/java/org/folio/dao/util/JournalRecordsColumns.java
@@ -11,6 +11,8 @@ public final class JournalRecordsColumns {
   public static final String ENTITY_TYPE = "entity_type";
   public static final String ACTION_TYPE = "action_type";
   public static final String ENTITY_ID = "entity_id";
+  public static final String INSTANCE_ID = "instance_id";
+  public static final String HOLDINGS_ID = "holdings_id";
   public static final String ENTITY_HRID = "entity_hrid";
   public static final String ACTION_STATUS = "action_status";
   public static final String ACTION_DATE = "action_date";

--- a/mod-source-record-manager-server/src/main/java/org/folio/services/journal/JournalUtil.java
+++ b/mod-source-record-manager-server/src/main/java/org/folio/services/journal/JournalUtil.java
@@ -87,6 +87,9 @@ public class JournalUtil {
             if (eventPayloadContext.containsKey(INSTANCE.value())) {
               JsonObject instanceJson = new JsonObject(eventPayloadContext.get(INSTANCE.value()));
               journalRecord.setInstanceId(instanceJson.getString("id"));
+            } else if (eventPayloadContext.containsKey(HOLDINGS.value())) {
+              JsonObject holdingsJson = new JsonObject(eventPayloadContext.get(HOLDINGS.value()));
+              journalRecord.setInstanceId(holdingsJson.getString("instanceId"));
             }
             journalRecord.setHoldingsId(entityJson.getString("holdingsRecordId"));
           }

--- a/mod-source-record-manager-server/src/main/resources/templates/db_scripts/create_get_record_processing_log_function.sql
+++ b/mod-source-record-manager-server/src/main/resources/templates/db_scripts/create_get_record_processing_log_function.sql
@@ -7,161 +7,168 @@ AS $$
 BEGIN
     RETURN QUERY
         SELECT records_actions.job_execution_id,
-               records_actions.source_id,
-               records_actions.source_record_order,
-               rec_titles.title,
-               CASE WHEN marc_errors_number != 0 OR marc_actions[array_length(marc_actions, 1)] = 'NON_MATCH'
-                        THEN 'DISCARDED'
-                    WHEN marc_actions[array_length(marc_actions, 1)] = 'CREATE'
-                        THEN 'CREATED'
-                    WHEN marc_actions[array_length(marc_actions, 1)] IN ('UPDATE', 'MODIFY')
-                        THEN 'UPDATED'
-               END AS source_record_action_status,
-			   records_actions.source_entity_error[1],
-               get_entity_status(instance_actions, instance_errors_number) AS instance_action_status,
-			   records_actions.instance_entity_id,
-			   records_actions.instance_entity_hrid,
-			   records_actions.instance_entity_error[1],
-               get_entity_status(holdings_actions, holdings_errors_number) AS holdings_action_status,
-			   records_actions.holdings_entity_id,
-			   records_actions.holdings_entity_hrid,
-			   records_actions.holdings_entity_error[1],
-               get_entity_status(item_actions, item_errors_number)         AS item_action_status,
-			   records_actions.item_entity_id,
-			   records_actions.item_entity_hrid,
-			   records_actions.item_entity_error[1],
-			         get_entity_status(authority_actions, authority_errors_number)         AS authority_action_status,
-			   records_actions.authority_entity_id,
-			   records_actions.authority_entity_error[1],
-               get_entity_status(order_actions, order_errors_number)       AS order_action_status,
-			   records_actions.order_entity_id,
-			   records_actions.order_entity_hrid,
-			   records_actions.order_entity_error[1],
-               null AS invoice_action_status,
-			   null AS invoice_entity_id,
-			   null AS invoice_entity_hrid,
-			   null AS invoice_entity_error,
-               null AS invoice_line_action_status,
-               null AS invoice_line_entity_id,
-               null AS invoice_line_entity_hrid,
-               null AS invoice_line_entity_error
+            records_actions.source_id,
+            records_actions.source_record_order,
+            rec_titles.title,
+            CASE WHEN marc_errors_number != 0 OR marc_actions[array_length(marc_actions, 1)] = 'NON_MATCH'
+                THEN 'DISCARDED'
+              WHEN marc_actions[array_length(marc_actions, 1)] = 'CREATE'
+                THEN 'CREATED'
+              WHEN marc_actions[array_length(marc_actions, 1)] IN ('UPDATE', 'MODIFY')
+                THEN 'UPDATED'
+            END AS source_record_action_status,
+            records_actions.source_entity_error[1],
+
+            get_entity_status(instance_actions, instance_errors_number) AS instance_action_status,
+            COALESCE(records_actions.instance_entity_id, records_actions.instance_id_value) AS instance_entity_id,
+            records_actions.instance_entity_hrid,
+            records_actions.instance_entity_error[1],
+
+            get_entity_status(holdings_actions, holdings_errors_number) AS holdings_action_status,
+            COALESCE(records_actions.holdings_entity_id, records_actions.holdings_id_value) AS holdings_entity_id,
+            records_actions.holdings_entity_hrid,
+            records_actions.holdings_entity_error[1],
+
+            get_entity_status(item_actions, item_errors_number) AS item_action_status,
+            records_actions.item_entity_id,
+            records_actions.item_entity_hrid,
+            records_actions.item_entity_error[1],
+
+            get_entity_status(authority_actions, authority_errors_number) AS authority_action_status,
+            records_actions.authority_entity_id,
+            records_actions.authority_entity_error[1],
+
+            get_entity_status(order_actions, order_errors_number) AS order_action_status,
+            records_actions.order_entity_id,
+            records_actions.order_entity_hrid,
+            records_actions.order_entity_error[1],
+
+            null AS invoice_action_status,
+            null AS invoice_entity_id,
+            null AS invoice_entity_hrid,
+            null AS invoice_entity_error,
+            null AS invoice_line_action_status,
+            null AS invoice_line_entity_id,
+            null AS invoice_line_entity_hrid,
+            null AS invoice_line_entity_error
         FROM (
-               SELECT journal_records.source_id,
-                      journal_records.source_record_order,
-                      journal_records.job_execution_id,
-                      array_agg(action_type ORDER BY action_date ASC) FILTER (WHERE entity_type = 'MARC_BIBLIOGRAPHIC' OR entity_type = 'MARC_HOLDINGS' OR entity_type = 'MARC_AUTHORITY') AS marc_actions,
-                      count(journal_records.source_id) FILTER (WHERE (entity_type = 'MARC_BIBLIOGRAPHIC' OR entity_type = 'MARC_HOLDINGS' OR entity_type = 'MARC_AUTHORITY') AND journal_records.error != '') AS marc_errors_number,
+            SELECT journal_records.source_id,
+                journal_records.source_record_order,
+                journal_records.job_execution_id,
+                array_agg(action_type ORDER BY action_date ASC) FILTER (WHERE entity_type = 'MARC_BIBLIOGRAPHIC' OR entity_type = 'MARC_HOLDINGS' OR entity_type = 'MARC_AUTHORITY') AS marc_actions,
+                count(journal_records.source_id) FILTER (WHERE (entity_type = 'MARC_BIBLIOGRAPHIC' OR entity_type = 'MARC_HOLDINGS' OR entity_type = 'MARC_AUTHORITY') AND journal_records.error != '') AS marc_errors_number,
 
-			          array_agg(error) FILTER (WHERE entity_type = 'MARC_BIBLIOGRAPHIC' OR entity_type = 'MARC_HOLDINGS' OR entity_type = 'MARC_AUTHORITY') AS source_entity_error,
+                array_agg(error) FILTER (WHERE entity_type = 'MARC_BIBLIOGRAPHIC' OR entity_type = 'MARC_HOLDINGS' OR entity_type = 'MARC_AUTHORITY') AS source_entity_error,
 
-                      array_agg(action_type) FILTER (WHERE entity_type = 'INSTANCE') AS instance_actions,
-                      count(journal_records.source_id) FILTER (WHERE entity_type = 'INSTANCE' AND journal_records.error != '') AS instance_errors_number,
+                array_agg(action_type) FILTER (WHERE entity_type = 'INSTANCE') AS instance_actions,
+                count(journal_records.source_id) FILTER (WHERE entity_type = 'INSTANCE' AND journal_records.error != '') AS instance_errors_number,
 
-			          array_agg(entity_hrid) FILTER (WHERE entity_type = 'INSTANCE') AS instance_entity_hrid,
-			          array_agg(entity_id) FILTER (WHERE entity_type = 'INSTANCE') AS instance_entity_id,
-				      array_agg(error) FILTER (WHERE entity_type = 'INSTANCE') AS instance_entity_error,
+                array_agg(entity_hrid) FILTER (WHERE entity_type = 'INSTANCE') AS instance_entity_hrid,
+                array_agg(entity_id) FILTER (WHERE entity_type = 'INSTANCE') AS instance_entity_id,
+                array_agg(error) FILTER (WHERE entity_type = 'INSTANCE') AS instance_entity_error,
 
+                array_agg(action_type) FILTER (WHERE entity_type = 'HOLDINGS') AS holdings_actions,
+                count(journal_records.source_id) FILTER (WHERE entity_type = 'HOLDINGS' AND journal_records.error != '') AS holdings_errors_number,
 
-                      array_agg(action_type) FILTER (WHERE entity_type = 'HOLDINGS') AS holdings_actions,
-                      count(journal_records.source_id) FILTER (WHERE entity_type = 'HOLDINGS' AND journal_records.error != '') AS holdings_errors_number,
+                array_agg(entity_hrid) FILTER (WHERE entity_type = 'HOLDINGS') AS holdings_entity_hrid,
+                array_agg(entity_id) FILTER (WHERE entity_type = 'HOLDINGS') AS holdings_entity_id,
+                array_agg(error) FILTER (WHERE entity_type = 'HOLDINGS') AS holdings_entity_error,
 
-					  array_agg(entity_hrid) FILTER (WHERE entity_type = 'HOLDINGS') AS holdings_entity_hrid,
-			          array_agg(entity_id) FILTER (WHERE entity_type = 'HOLDINGS') AS holdings_entity_id,
-					  array_agg(error) FILTER (WHERE entity_type = 'HOLDINGS') AS holdings_entity_error,
+                array_agg(action_type) FILTER (WHERE entity_type = 'ITEM') AS item_actions,
+                count(journal_records.source_id) FILTER (WHERE entity_type = 'ITEM' AND journal_records.error != '') AS item_errors_number,
 
+                array_agg(entity_hrid) FILTER (WHERE entity_type = 'ITEM') AS item_entity_hrid,
+                array_agg(entity_id) FILTER (WHERE entity_type = 'ITEM') AS item_entity_id,
+                array_agg(error) FILTER (WHERE entity_type = 'ITEM') AS item_entity_error,
 
-                      array_agg(action_type) FILTER (WHERE entity_type = 'ITEM') AS item_actions,
-                      count(journal_records.source_id) FILTER (WHERE entity_type = 'ITEM' AND journal_records.error != '') AS item_errors_number,
+                array_agg(action_type) FILTER (WHERE entity_type = 'AUTHORITY') AS authority_actions,
+                count(journal_records.source_id) FILTER (WHERE entity_type = 'AUTHORITY' AND journal_records.error != '') AS authority_errors_number,
 
-					  array_agg(entity_hrid) FILTER (WHERE entity_type = 'ITEM') AS item_entity_hrid,
-			          array_agg(entity_id) FILTER (WHERE entity_type = 'ITEM') AS item_entity_id,
-					  array_agg(error) FILTER (WHERE entity_type = 'ITEM') AS item_entity_error,
+                array_agg(entity_id) FILTER (WHERE entity_type = 'AUTHORITY') AS authority_entity_id,
+                array_agg(error) FILTER (WHERE entity_type = 'AUTHORITY') AS authority_entity_error,
 
-					  array_agg(action_type) FILTER (WHERE entity_type = 'AUTHORITY') AS authority_actions,
-                      count(journal_records.source_id) FILTER (WHERE entity_type = 'AUTHORITY' AND journal_records.error != '') AS authority_errors_number,
+                array_agg(action_type) FILTER (WHERE entity_type = 'ORDER') AS order_actions,
+                count(journal_records.source_id) FILTER (WHERE entity_type = 'ORDER' AND journal_records.error != '') AS order_errors_number,
 
-			          array_agg(entity_id) FILTER (WHERE entity_type = 'AUTHORITY') AS authority_entity_id,
-					  array_agg(error) FILTER (WHERE entity_type = 'AUTHORITY') AS authority_entity_error,
+                array_agg(entity_hrid) FILTER (WHERE entity_type = 'ORDER') AS order_entity_hrid,
+                array_agg(entity_id) FILTER (WHERE entity_type = 'ORDER') AS order_entity_id,
+                array_agg(error) FILTER (WHERE entity_type = 'ORDER') AS order_entity_error,
 
-                      array_agg(action_type) FILTER (WHERE entity_type = 'ORDER') AS order_actions,
-                      count(journal_records.source_id) FILTER (WHERE entity_type = 'ORDER' AND journal_records.error != '') AS order_errors_number,
-
-					  array_agg(entity_hrid) FILTER (WHERE entity_type = 'ORDER') AS order_entity_hrid,
-			          array_agg(entity_id) FILTER (WHERE entity_type = 'ORDER') AS order_entity_id,
-					  array_agg(error) FILTER (WHERE entity_type = 'ORDER') AS order_entity_error
-               FROM journal_records
-               WHERE journal_records.job_execution_id = jobExecutionId AND journal_records.source_id = recordId AND journal_records.entity_type NOT IN ('EDIFACT', 'INVOICE')
-               GROUP BY journal_records.source_id, journal_records.source_record_order, journal_records.job_execution_id)
-			   AS records_actions
+                array_agg(DISTINCT instance_id) FILTER (WHERE instance_id IS NOT NULL AND (entity_type = 'HOLDINGS' OR entity_type = 'ITEM')) AS instance_id_value,
+                array_agg(holdings_id) FILTER (WHERE holdings_id IS NOT NULL AND entity_type = 'ITEM') AS holdings_id_value
+            FROM journal_records
+            WHERE journal_records.job_execution_id = jobExecutionId AND journal_records.source_id = recordId AND journal_records.entity_type NOT IN ('EDIFACT', 'INVOICE')
+            GROUP BY journal_records.source_id, journal_records.source_record_order, journal_records.job_execution_id)
+            AS records_actions
         LEFT JOIN (
-                    SELECT journal_records.source_id, journal_records.title FROM journal_records
-                    WHERE journal_records.job_execution_id = jobExecutionId AND journal_records.source_id = recordId
-                  ) AS rec_titles ON rec_titles.source_id = records_actions.source_id AND rec_titles.title IS NOT NULL
+            SELECT journal_records.source_id, journal_records.title FROM journal_records
+            WHERE journal_records.job_execution_id = jobExecutionId AND journal_records.source_id = recordId
+        ) AS rec_titles ON rec_titles.source_id = records_actions.source_id AND rec_titles.title IS NOT NULL
         UNION
             SELECT invoice_line_info.job_execution_id,
-                   invoice_line_info.source_id,
-                   records_actions.source_record_order,
-                   invoice_line_info.title,
-                   CASE WHEN edifact_errors_number != 0 THEN 'DISCARDED'
-                        WHEN edifact_actions[array_length(edifact_actions, 1)] = 'CREATE' THEN 'CREATED'
-                   END AS source_record_action_status,
-                   records_actions.source_record_error[1],
-                   null AS instance_action_status,
-                   null AS instance_entity_id,
-                   null AS instance_entity_hrid,
-                   null AS instance_entity_error,
-                   null AS holdings_action_status,
-                   null AS holdings_entity_id,
-                   null AS holdings_entity_hrid,
-                   null AS holdings_entity_error,
-                   null AS item_action_status,
-                   null AS item_entity_id,
-                   null AS item_entity_hrid,
-                   null AS item_entity_error,
-                   null AS authority_action_status,
-                   null AS authority_entity_id,
-                   null AS authority_entity_error,
-                   null AS order_action_status,
-                   null AS order_entity_id,
-                   null AS order_entity_hrid,
-                   null AS order_entity_error,
-                   get_entity_status(records_actions.invoice_actions, records_actions.invoice_errors_number) AS invoice_action_status,
-                   records_actions.invoice_entity_id,
-                   records_actions.invoice_entity_hrid,
-                   records_actions.invoice_entity_error[1],
-                   CASE WHEN action_status = 'ERROR' THEN 'DISCARDED'
-                        WHEN inv_line_actions = 'CREATE' THEN 'CREATED'
-                   END AS invoice_line_action_status,
-                   invoice_line_info.invoice_line_entity_id,
-                   invoice_line_info.invoice_line_entity_hrid,
-                   invoice_line_info.invoice_line_entity_error
+                invoice_line_info.source_id,
+                records_actions.source_record_order,
+                invoice_line_info.title,
+                CASE WHEN edifact_errors_number != 0 THEN 'DISCARDED'
+                  WHEN edifact_actions[array_length(edifact_actions, 1)] = 'CREATE' THEN 'CREATED'
+                END AS source_record_action_status,
+                records_actions.source_record_error[1],
+                null AS instance_action_status,
+                null AS instance_entity_id,
+                null AS instance_entity_hrid,
+                null AS instance_entity_error,
+                null AS holdings_action_status,
+                null AS holdings_entity_id,
+                null AS holdings_entity_hrid,
+                null AS holdings_entity_error,
+                null AS item_action_status,
+                null AS item_entity_id,
+                null AS item_entity_hrid,
+                null AS item_entity_error,
+                null AS authority_action_status,
+                null AS authority_entity_id,
+                null AS authority_entity_error,
+                null AS order_action_status,
+                null AS order_entity_id,
+                null AS order_entity_hrid,
+                null AS order_entity_error,
+                get_entity_status(records_actions.invoice_actions, records_actions.invoice_errors_number) AS invoice_action_status,
+                records_actions.invoice_entity_id,
+                records_actions.invoice_entity_hrid,
+                records_actions.invoice_entity_error[1],
+                CASE WHEN action_status = 'ERROR' THEN 'DISCARDED'
+                  WHEN inv_line_actions = 'CREATE' THEN 'CREATED'
+                END AS invoice_line_action_status,
+                invoice_line_info.invoice_line_entity_id,
+                invoice_line_info.invoice_line_entity_hrid,
+                invoice_line_info.invoice_line_entity_error
             FROM (
-                   SELECT journal_records.source_id,
-                          journal_records.job_execution_id,
-                          journal_records.title,
-                          journal_records.action_type AS inv_line_actions,
-                          action_status,
-                          entity_hrid AS invoice_line_entity_hrid,
-                          entity_id AS invoice_line_entity_id,
-                          error AS invoice_line_entity_error
-                   FROM journal_records
-                   WHERE journal_records.id = recordId AND journal_records.entity_type = 'INVOICE' AND journal_records.title != 'INVOICE'
+                SELECT journal_records.source_id,
+                    journal_records.job_execution_id,
+                    journal_records.title,
+                    journal_records.action_type AS inv_line_actions,
+                    action_status,
+                    entity_hrid AS invoice_line_entity_hrid,
+                    entity_id AS invoice_line_entity_id,
+                    error AS invoice_line_entity_error
+                FROM journal_records
+                WHERE journal_records.id = recordId AND journal_records.entity_type = 'INVOICE' AND journal_records.title != 'INVOICE'
             ) AS invoice_line_info
             LEFT JOIN (
-                   SELECT journal_records.source_id,
-                          journal_records.source_record_order,
-                          array_agg(action_type) FILTER (WHERE entity_type = 'EDIFACT') AS edifact_actions,
-                          count(journal_records.source_id) FILTER (WHERE entity_type = 'EDIFACT' AND journal_records.error != '') AS edifact_errors_number,
-                          array_agg(error) FILTER (WHERE entity_type = 'EDIFACT') AS source_record_error,
+                SELECT journal_records.source_id,
+                    journal_records.source_record_order,
+                    array_agg(action_type) FILTER (WHERE entity_type = 'EDIFACT') AS edifact_actions,
+                    count(journal_records.source_id) FILTER (WHERE entity_type = 'EDIFACT' AND journal_records.error != '') AS edifact_errors_number,
+                    array_agg(error) FILTER (WHERE entity_type = 'EDIFACT') AS source_record_error,
 
-                          array_agg(action_type) FILTER (WHERE entity_type = 'INVOICE' AND journal_records.title = 'INVOICE') AS invoice_actions,
-                          count(journal_records.source_id) FILTER (WHERE entity_type = 'INVOICE' AND journal_records.title = 'INVOICE' AND journal_records.error != '') AS invoice_errors_number,
-                          array_agg(entity_hrid) FILTER (WHERE entity_type = 'INVOICE' AND journal_records.title = 'INVOICE') AS invoice_entity_hrid,
-                          array_agg(entity_id) FILTER (WHERE entity_type = 'INVOICE' AND journal_records.title = 'INVOICE') AS invoice_entity_id,
-                          array_agg(error) FILTER (WHERE entity_type = 'INVOICE' AND journal_records.title = 'INVOICE') AS invoice_entity_error
-                   FROM journal_records
-                   WHERE journal_records.job_execution_id = jobExecutionId and entity_type = 'EDIFACT' OR journal_records.title = 'INVOICE'
-                   GROUP BY journal_records.source_id, journal_records.job_execution_id, journal_records.source_record_order
+                    array_agg(action_type) FILTER (WHERE entity_type = 'INVOICE' AND journal_records.title = 'INVOICE') AS invoice_actions,
+                    count(journal_records.source_id) FILTER (WHERE entity_type = 'INVOICE' AND journal_records.title = 'INVOICE' AND journal_records.error != '') AS invoice_errors_number,
+                    array_agg(entity_hrid) FILTER (WHERE entity_type = 'INVOICE' AND journal_records.title = 'INVOICE') AS invoice_entity_hrid,
+                    array_agg(entity_id) FILTER (WHERE entity_type = 'INVOICE' AND journal_records.title = 'INVOICE') AS invoice_entity_id,
+                    array_agg(error) FILTER (WHERE entity_type = 'INVOICE' AND journal_records.title = 'INVOICE') AS invoice_entity_error
+                FROM journal_records
+                WHERE journal_records.job_execution_id = jobExecutionId AND entity_type = 'EDIFACT' OR journal_records.title = 'INVOICE'
+                GROUP BY journal_records.source_id, journal_records.job_execution_id, journal_records.source_record_order
             ) AS records_actions ON records_actions.source_id = invoice_line_info.source_id;
 END;
 $$ LANGUAGE plpgsql;

--- a/mod-source-record-manager-server/src/main/resources/templates/db_scripts/schema.json
+++ b/mod-source-record-manager-server/src/main/resources/templates/db_scripts/schema.json
@@ -197,6 +197,11 @@
       "run": "after",
       "snippetPath": "replace_job_execution_progress_table.sql",
       "fromModuleVersion": "mod-source-record-manager-3.3.0"
+    },
+    {
+      "run": "after",
+      "snippet": "ALTER TABLE journal_records ADD COLUMN IF NOT EXISTS instance_id text; ALTER TABLE journal_records ADD COLUMN IF NOT EXISTS holdings_id text;",
+      "fromModuleVersion": "mod-source-record-manager-3.3.0"
     }
   ]
 }

--- a/mod-source-record-manager-server/src/test/java/org/folio/services/JournalUtilTest.java
+++ b/mod-source-record-manager-server/src/test/java/org/folio/services/JournalUtilTest.java
@@ -13,14 +13,16 @@ import org.junit.runner.RunWith;
 import java.util.HashMap;
 import java.util.UUID;
 
-import static org.folio.rest.jaxrs.model.JournalRecord.EntityType.INSTANCE;
-import static org.folio.rest.jaxrs.model.JournalRecord.EntityType.MARC_BIBLIOGRAPHIC;
+import static org.folio.rest.jaxrs.model.JournalRecord.ActionStatus.COMPLETED;
+import static org.folio.rest.jaxrs.model.JournalRecord.ActionType.CREATE;
+import static org.folio.rest.jaxrs.model.JournalRecord.ActionType.NON_MATCH;
+import static org.folio.rest.jaxrs.model.JournalRecord.EntityType.*;
 
 @RunWith(VertxUnitRunner.class)
 public class JournalUtilTest {
 
   @Test
-  public void shouldBuildJournalRecord() throws JournalRecordMapperException {
+  public void shouldBuildJournalRecordForInstance() throws JournalRecordMapperException {
     String instanceId = UUID.randomUUID().toString();
     String instanceHrid = UUID.randomUUID().toString();
 
@@ -45,17 +47,17 @@ public class JournalUtilTest {
       .withContext(context);
 
     JournalRecord journalRecord = JournalUtil.buildJournalRecordByEvent(eventPayload,
-      JournalRecord.ActionType.CREATE, JournalRecord.EntityType.INSTANCE, JournalRecord.ActionStatus.COMPLETED);
+      CREATE, INSTANCE, COMPLETED);
 
     Assert.assertNotNull(journalRecord);
     Assert.assertEquals(snapshotId, journalRecord.getJobExecutionId());
     Assert.assertEquals(recordId, journalRecord.getSourceId());
     Assert.assertEquals(1, journalRecord.getSourceRecordOrder().intValue());
-    Assert.assertEquals(JournalRecord.EntityType.INSTANCE, journalRecord.getEntityType());
+    Assert.assertEquals(INSTANCE, journalRecord.getEntityType());
     Assert.assertEquals(instanceId, journalRecord.getEntityId());
     Assert.assertEquals(instanceHrid, journalRecord.getEntityHrId());
-    Assert.assertEquals(JournalRecord.ActionType.CREATE, journalRecord.getActionType());
-    Assert.assertEquals(JournalRecord.ActionStatus.COMPLETED, journalRecord.getActionStatus());
+    Assert.assertEquals(CREATE, journalRecord.getActionType());
+    Assert.assertEquals(COMPLETED, journalRecord.getActionStatus());
     Assert.assertNotNull(journalRecord.getActionDate());
   }
 
@@ -77,7 +79,7 @@ public class JournalUtilTest {
       .withContext(context);
 
     JournalUtil.buildJournalRecordByEvent(eventPayload,
-      JournalRecord.ActionType.CREATE, JournalRecord.EntityType.INSTANCE, JournalRecord.ActionStatus.COMPLETED);
+      CREATE, INSTANCE, COMPLETED);
   }
 
   @Test(expected = JournalRecordMapperException.class)
@@ -97,7 +99,7 @@ public class JournalUtilTest {
       .withContext(context);
 
     JournalUtil.buildJournalRecordByEvent(eventPayload,
-      JournalRecord.ActionType.CREATE, JournalRecord.EntityType.INSTANCE, JournalRecord.ActionStatus.COMPLETED);
+      CREATE, INSTANCE, COMPLETED);
   }
 
   @Test(expected = JournalRecordMapperException.class)
@@ -119,7 +121,7 @@ public class JournalUtilTest {
       .withContext(context);
 
     JournalUtil.buildJournalRecordByEvent(eventPayload,
-      JournalRecord.ActionType.CREATE, JournalRecord.EntityType.INSTANCE, JournalRecord.ActionStatus.COMPLETED);
+      CREATE, INSTANCE, COMPLETED);
   }
 
   @Test
@@ -140,15 +142,161 @@ public class JournalUtilTest {
       .withContext(context);
 
     JournalRecord journalRecord = JournalUtil.buildJournalRecordByEvent(eventPayload,
-      JournalRecord.ActionType.NON_MATCH, JournalRecord.EntityType.HOLDINGS, JournalRecord.ActionStatus.COMPLETED);
+      NON_MATCH, HOLDINGS, COMPLETED);
 
     Assert.assertNotNull(journalRecord);
     Assert.assertEquals(snapshotId, journalRecord.getJobExecutionId());
     Assert.assertEquals(recordId, journalRecord.getSourceId());
     Assert.assertEquals(1, journalRecord.getSourceRecordOrder().intValue());
-    Assert.assertEquals(JournalRecord.EntityType.HOLDINGS, journalRecord.getEntityType());
-    Assert.assertEquals(JournalRecord.ActionType.NON_MATCH, journalRecord.getActionType());
-    Assert.assertEquals(JournalRecord.ActionStatus.COMPLETED, journalRecord.getActionStatus());
+    Assert.assertEquals(HOLDINGS, journalRecord.getEntityType());
+    Assert.assertEquals(NON_MATCH, journalRecord.getActionType());
+    Assert.assertEquals(COMPLETED, journalRecord.getActionStatus());
+    Assert.assertNotNull(journalRecord.getActionDate());
+  }
+
+  @Test
+  public void shouldBuildJournalRecordForHolding() throws JournalRecordMapperException {
+    String instanceId = UUID.randomUUID().toString();
+    String holdingsId = UUID.randomUUID().toString();
+    String holdingsHrid = UUID.randomUUID().toString();
+
+    JsonObject holdingsJson = new JsonObject()
+      .put("id", holdingsId)
+      .put("hrid", holdingsHrid)
+      .put("instanceId", instanceId);
+
+    String recordId = UUID.randomUUID().toString();
+    String snapshotId = UUID.randomUUID().toString();
+
+    JsonObject recordJson = new JsonObject()
+      .put("id", recordId)
+      .put("snapshotId", snapshotId)
+      .put("order", 1);
+
+    HashMap<String, String> context = new HashMap<>();
+    context.put(HOLDINGS.value(), holdingsJson.encode());
+    context.put(MARC_BIBLIOGRAPHIC.value(), recordJson.encode());
+
+    DataImportEventPayload eventPayload = new DataImportEventPayload()
+      .withEventType("DI_INVENTORY_HOLDING_CREATED")
+      .withContext(context);
+
+    JournalRecord journalRecord = JournalUtil.buildJournalRecordByEvent(eventPayload,
+      CREATE, HOLDINGS, COMPLETED);
+
+    Assert.assertNotNull(journalRecord);
+    Assert.assertEquals(snapshotId, journalRecord.getJobExecutionId());
+    Assert.assertEquals(recordId, journalRecord.getSourceId());
+    Assert.assertEquals(1, journalRecord.getSourceRecordOrder().intValue());
+    Assert.assertEquals(HOLDINGS, journalRecord.getEntityType());
+    Assert.assertEquals(holdingsId, journalRecord.getEntityId());
+    Assert.assertEquals(holdingsHrid, journalRecord.getEntityHrId());
+    Assert.assertEquals(instanceId, journalRecord.getInstanceId());
+    Assert.assertEquals(CREATE, journalRecord.getActionType());
+    Assert.assertEquals(COMPLETED, journalRecord.getActionStatus());
+    Assert.assertNotNull(journalRecord.getActionDate());
+  }
+
+  @Test
+  public void shouldBuildJournalRecordForItemWhenInstanceIsPopulated() throws JournalRecordMapperException {
+    String itemId = UUID.randomUUID().toString();
+    String itemHrid = UUID.randomUUID().toString();
+    String instanceId = UUID.randomUUID().toString();
+    String instanceHrid = UUID.randomUUID().toString();
+    String holdingsId = UUID.randomUUID().toString();
+
+    JsonObject itemJson = new JsonObject()
+      .put("id", itemId)
+      .put("hrid", itemHrid)
+      .put("holdingsRecordId", holdingsId);
+
+    JsonObject instanceJson = new JsonObject()
+      .put("id", instanceId)
+      .put("hrid", instanceHrid);
+
+    String recordId = UUID.randomUUID().toString();
+    String snapshotId = UUID.randomUUID().toString();
+
+    JsonObject recordJson = new JsonObject()
+      .put("id", recordId)
+      .put("snapshotId", snapshotId)
+      .put("order", 1);
+
+    HashMap<String, String> context = new HashMap<>();
+    context.put(ITEM.value(), itemJson.encode());
+    context.put(INSTANCE.value(), instanceJson.encode());
+    context.put(MARC_BIBLIOGRAPHIC.value(), recordJson.encode());
+
+    DataImportEventPayload eventPayload = new DataImportEventPayload()
+      .withEventType("DI_INVENTORY_ITEM_CREATED")
+      .withContext(context);
+
+    JournalRecord journalRecord = JournalUtil.buildJournalRecordByEvent(eventPayload,
+      CREATE, ITEM, COMPLETED);
+
+    Assert.assertNotNull(journalRecord);
+    Assert.assertEquals(snapshotId, journalRecord.getJobExecutionId());
+    Assert.assertEquals(recordId, journalRecord.getSourceId());
+    Assert.assertEquals(1, journalRecord.getSourceRecordOrder().intValue());
+    Assert.assertEquals(ITEM, journalRecord.getEntityType());
+    Assert.assertEquals(itemId, journalRecord.getEntityId());
+    Assert.assertEquals(itemHrid, journalRecord.getEntityHrId());
+    Assert.assertEquals(instanceId, journalRecord.getInstanceId());
+    Assert.assertEquals(holdingsId, journalRecord.getHoldingsId());
+    Assert.assertEquals(CREATE, journalRecord.getActionType());
+    Assert.assertEquals(COMPLETED, journalRecord.getActionStatus());
+    Assert.assertNotNull(journalRecord.getActionDate());
+  }
+
+  @Test
+  public void shouldBuildJournalRecordForItemWhenInstanceIsNotPopulated() throws JournalRecordMapperException {
+    String itemId = UUID.randomUUID().toString();
+    String itemHrid = UUID.randomUUID().toString();
+    String instanceId = UUID.randomUUID().toString();
+    String holdingsId = UUID.randomUUID().toString();
+    String holdingsHrid = UUID.randomUUID().toString();
+
+    JsonObject itemJson = new JsonObject()
+      .put("id", itemId)
+      .put("hrid", itemHrid)
+      .put("holdingsRecordId", holdingsId);
+
+    JsonObject holdingsJson = new JsonObject()
+      .put("id", holdingsId)
+      .put("hrid", holdingsHrid)
+      .put("instanceId", instanceId);
+
+    String recordId = UUID.randomUUID().toString();
+    String snapshotId = UUID.randomUUID().toString();
+
+    JsonObject recordJson = new JsonObject()
+      .put("id", recordId)
+      .put("snapshotId", snapshotId)
+      .put("order", 1);
+
+    HashMap<String, String> context = new HashMap<>();
+    context.put(ITEM.value(), itemJson.encode());
+    context.put(HOLDINGS.value(), holdingsJson.encode());
+    context.put(MARC_BIBLIOGRAPHIC.value(), recordJson.encode());
+
+    DataImportEventPayload eventPayload = new DataImportEventPayload()
+      .withEventType("DI_INVENTORY_ITEM_CREATED")
+      .withContext(context);
+
+    JournalRecord journalRecord = JournalUtil.buildJournalRecordByEvent(eventPayload,
+      CREATE, ITEM, COMPLETED);
+
+    Assert.assertNotNull(journalRecord);
+    Assert.assertEquals(snapshotId, journalRecord.getJobExecutionId());
+    Assert.assertEquals(recordId, journalRecord.getSourceId());
+    Assert.assertEquals(1, journalRecord.getSourceRecordOrder().intValue());
+    Assert.assertEquals(ITEM, journalRecord.getEntityType());
+    Assert.assertEquals(itemId, journalRecord.getEntityId());
+    Assert.assertEquals(itemHrid, journalRecord.getEntityHrId());
+    Assert.assertEquals(instanceId, journalRecord.getInstanceId());
+    Assert.assertEquals(holdingsId, journalRecord.getHoldingsId());
+    Assert.assertEquals(CREATE, journalRecord.getActionType());
+    Assert.assertEquals(COMPLETED, journalRecord.getActionStatus());
     Assert.assertNotNull(journalRecord.getActionDate());
   }
 }

--- a/mod-source-record-manager-server/src/test/java/org/folio/services/JournalUtilTest.java
+++ b/mod-source-record-manager-server/src/test/java/org/folio/services/JournalUtilTest.java
@@ -16,7 +16,10 @@ import java.util.UUID;
 import static org.folio.rest.jaxrs.model.JournalRecord.ActionStatus.COMPLETED;
 import static org.folio.rest.jaxrs.model.JournalRecord.ActionType.CREATE;
 import static org.folio.rest.jaxrs.model.JournalRecord.ActionType.NON_MATCH;
-import static org.folio.rest.jaxrs.model.JournalRecord.EntityType.*;
+import static org.folio.rest.jaxrs.model.JournalRecord.EntityType.INSTANCE;
+import static org.folio.rest.jaxrs.model.JournalRecord.EntityType.ITEM;
+import static org.folio.rest.jaxrs.model.JournalRecord.EntityType.HOLDINGS;
+import static org.folio.rest.jaxrs.model.JournalRecord.EntityType.MARC_BIBLIOGRAPHIC;
 
 @RunWith(VertxUnitRunner.class)
 public class JournalUtilTest {


### PR DESCRIPTION
## Purpose
Extend functionality for /metadata-provider/jobLogEntries endpoint to provide information about Instance even if no action was performed on Instance.

## Approach
Added two new columns for journal_records table (instance_id and holdings_id) and implemented functionality to work with them.

## Learning
[MODSOURMAN-676](https://issues.folio.org/browse/MODSOURMAN-676)

## Information 
There are also known issue:
For the case, when we are going to only update ITEM entity with matching on ITEM's field, we will not get hotlink due to no information about INSTANCE entity (instanceId and holdingId are required to build hotlink for the ITEM entity). 