### PR TITLE
MODSOURMAN-695. Upgrade RMB and Vertx versions that contain fixes for…

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,4 +1,5 @@
 ## 2021-xx-xx v3.3.0-SNAPSHOT
+* [MODSOURMAN-695](https://issues.folio.org/browse/MODSOURMAN-695) Upgrade RMB and Vertx versions that contain fixes for the connection pool
 * [MODSOURMAN-624](https://issues.folio.org/browse/MODSOURMAN-624) Failed to handle DI_ERROR when 004 is invalid in MARC Holdings
 * [MODSOURMAN-614](https://issues.folio.org/browse/MODSOURMAN-614) Authority: Add mapping rule for note types
 * [MODSOURMAN-577](https://issues.folio.org/browse/MODSOURMAN-577) Optimistic locking: mod-source-record-manager modifications

--- a/pom.xml
+++ b/pom.xml
@@ -19,8 +19,8 @@
   </modules>
 
   <properties>
-    <raml-module-builder.version>33.2.2</raml-module-builder.version>
-    <vertx.version>4.2.2</vertx.version>
+    <raml-module-builder.version>33.2.5</raml-module-builder.version>
+    <vertx.version>4.2.4</vertx.version>
     <junit.version>4.13.2</junit.version>
     <rest-assured.version>4.3.1</rest-assured.version>
     <wiremock.version>2.27.2</wiremock.version>


### PR DESCRIPTION
## Approach
New 2.4.2 version of Vertx recenly released.

https://github.com/vert-x3/wiki/wiki/4.2.4-Release-Notes#vertx

It contains fixes related to the connection pool that can help to resolve Connect timeout issues, that we observe in logs of the recent vagrant boxes when importing large files.

RMB 33.2.5 also contains Vertx version of 2.4.2.

So expected versions set in module pom:

RMB - 33.2.5
Vertx - 2.4.2

## Learning
https://issues.folio.org/browse/MODSOURMAN-695