### PR TITLE
MODSOURMAN-691 Delete Authority: Support delete action and produce event

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -33,6 +33,7 @@
 * [MODSOURMAN-675](https://issues.folio.org/browse/MODSOURMAN-675) Data Import handles repeated 020 $a:s in an unexpected manner when creating Instance Identifiers
 * [MODSOURMAN-676](https://issues.folio.org/browse/MODSOURMAN-676) Provide Instance UUID for populating Inventory hotlinks for holdings/items
 * [MODSOURMAN-682](https://issues.folio.org/browse/MODSOURMAN-682) Consume Authority log event
+* [MODSOURMAN-691](https://issues.folio.org/browse/MODSOURMAN-691) Support Delete MARC Authority Action
 
 ## 2021-10-xx v3.2.3-SNAPSHOT
 * [MODSOURMAN-522](https://issues.folio.org/browse/MODSOURMAN-522) Fix the effect of DI_ERROR messages when trying to duplicate records on the import job progress bar

--- a/mod-source-record-manager-server/src/main/java/org/folio/services/ChangeEngineServiceImpl.java
+++ b/mod-source-record-manager-server/src/main/java/org/folio/services/ChangeEngineServiceImpl.java
@@ -81,6 +81,7 @@ import static org.folio.services.afterprocessing.AdditionalFieldsUtil.getValue;
 import static org.folio.services.util.EventHandlingUtil.sendEventToKafka;
 import static org.folio.rest.jaxrs.model.DataImportEventTypes.DI_ERROR;
 import static org.folio.rest.jaxrs.model.DataImportEventTypes.DI_MARC_FOR_UPDATE_RECEIVED;
+import static org.folio.rest.jaxrs.model.DataImportEventTypes.DI_MARC_FOR_DELETE_RECEIVED;
 import static org.folio.rest.jaxrs.model.DataImportEventTypes.DI_RAW_RECORDS_CHUNK_PARSED;
 
 @Service
@@ -141,10 +142,23 @@ public class ChangeEngineServiceImpl implements ChangeEngineService {
         .map(parsedRecords))
       .onSuccess(parsedRecords -> {
         fillParsedRecordsWithAdditionalFields(parsedRecords);
-        boolean updateMarcActionExists = containsUpdateMarcActionProfile(jobExecution.getJobProfileSnapshotWrapper());
+
+        boolean updateMarcActionExists = containsMarcActionProfile(
+          jobExecution.getJobProfileSnapshotWrapper()
+          , List.of(FolioRecord.MARC_BIBLIOGRAPHIC, FolioRecord.MARC_AUTHORITY)
+          , Action.UPDATE);
+
+        boolean deleteMarcActionExists = containsMarcActionProfile(
+          jobExecution.getJobProfileSnapshotWrapper()
+          , List.of(FolioRecord.MARC_AUTHORITY)
+          , Action.DELETE);
 
         if (updateMarcActionExists) {
           updateRecords(parsedRecords, jobExecution, params)
+            .onSuccess(ar -> promise.complete(parsedRecords))
+            .onFailure(promise::fail);
+        } else if (deleteMarcActionExists) {
+          deleteRecords(parsedRecords, jobExecution, params)
             .onSuccess(ar -> promise.complete(parsedRecords))
             .onFailure(promise::fail);
         } else {
@@ -186,6 +200,12 @@ public class ChangeEngineServiceImpl implements ChangeEngineService {
       .sendEventsWithRecords(records, jobExecution.getId(), params, DI_MARC_FOR_UPDATE_RECEIVED.value());
   }
 
+  private Future<Boolean> deleteRecords(List<Record> records, JobExecution jobExecution, OkapiConnectionParams params) {
+    LOGGER.info("Records have not been saved in record-storage, because job contains action for Marc delete");
+    return recordsPublishingService
+      .sendEventsWithRecords(records, jobExecution.getId(), params, DI_MARC_FOR_DELETE_RECEIVED.value());
+  }
+
   private Future<Boolean> ensureMappingMetaDataSnapshot(String jobExecutionId, List<Record> recordsList,
                                                         OkapiConnectionParams okapiParams) {
     if (CollectionUtils.isEmpty(recordsList)) {
@@ -209,24 +229,24 @@ public class ChangeEngineServiceImpl implements ChangeEngineService {
     return promise.future();
   }
 
-  private boolean containsUpdateMarcActionProfile(ProfileSnapshotWrapper profileSnapshot) {
+  private boolean containsMarcActionProfile(ProfileSnapshotWrapper profileSnapshot,
+                                                  List<FolioRecord> records, Action action) {
     List<ProfileSnapshotWrapper> childWrappers = profileSnapshot.getChildSnapshotWrappers();
     for (ProfileSnapshotWrapper childWrapper : childWrappers) {
       if (childWrapper.getContentType() == ProfileSnapshotWrapper.ContentType.ACTION_PROFILE
-        && actionProfileMatches(childWrapper)) {
+        && actionProfileMatches(childWrapper, records, action)) {
         return true;
-      } else if (containsUpdateMarcActionProfile(childWrapper)) {
+      } else if (containsMarcActionProfile(childWrapper, records, action)) {
         return true;
       }
     }
     return false;
   }
 
-  private boolean actionProfileMatches(ProfileSnapshotWrapper actionProfileWrapper) {
+  private boolean actionProfileMatches(ProfileSnapshotWrapper actionProfileWrapper,
+                                       List<FolioRecord> records, Action action) {
     ActionProfile actionProfile = new JsonObject((Map) actionProfileWrapper.getContent()).mapTo(ActionProfile.class);
-    return (actionProfile.getFolioRecord() == FolioRecord.MARC_BIBLIOGRAPHIC
-      || actionProfile.getFolioRecord() == FolioRecord.MARC_AUTHORITY)
-      && actionProfile.getAction() == Action.UPDATE;
+    return (records.contains(actionProfile.getFolioRecord())) && actionProfile.getAction() == action;
   }
 
   /**

--- a/mod-source-record-manager-server/src/main/java/org/folio/services/ChangeEngineServiceImpl.java
+++ b/mod-source-record-manager-server/src/main/java/org/folio/services/ChangeEngineServiceImpl.java
@@ -143,21 +143,11 @@ public class ChangeEngineServiceImpl implements ChangeEngineService {
       .onSuccess(parsedRecords -> {
         fillParsedRecordsWithAdditionalFields(parsedRecords);
 
-        boolean updateMarcActionExists = containsMarcActionProfile(
-          jobExecution.getJobProfileSnapshotWrapper()
-          , List.of(FolioRecord.MARC_BIBLIOGRAPHIC, FolioRecord.MARC_AUTHORITY)
-          , Action.UPDATE);
-
-        boolean deleteMarcActionExists = containsMarcActionProfile(
-          jobExecution.getJobProfileSnapshotWrapper()
-          , List.of(FolioRecord.MARC_AUTHORITY)
-          , Action.DELETE);
-
-        if (updateMarcActionExists) {
+        if (updateMarcActionExists(jobExecution)) {
           updateRecords(parsedRecords, jobExecution, params)
             .onSuccess(ar -> promise.complete(parsedRecords))
             .onFailure(promise::fail);
-        } else if (deleteMarcActionExists) {
+        } else if (deleteMarcActionExists(jobExecution)) {
           deleteRecords(parsedRecords, jobExecution, params)
             .onSuccess(ar -> promise.complete(parsedRecords))
             .onFailure(promise::fail);
@@ -227,6 +217,20 @@ public class ChangeEngineServiceImpl implements ChangeEngineService {
         promise.fail(e);
       });
     return promise.future();
+  }
+
+  private boolean updateMarcActionExists(JobExecution jobExecution) {
+    return containsMarcActionProfile(
+      jobExecution.getJobProfileSnapshotWrapper()
+      , List.of(FolioRecord.MARC_BIBLIOGRAPHIC, FolioRecord.MARC_AUTHORITY)
+      , Action.UPDATE);
+  }
+
+  private boolean deleteMarcActionExists(JobExecution jobExecution) {
+    return containsMarcActionProfile(
+      jobExecution.getJobProfileSnapshotWrapper()
+      , List.of(FolioRecord.MARC_AUTHORITY)
+      , Action.DELETE);
   }
 
   private boolean containsMarcActionProfile(ProfileSnapshotWrapper profileSnapshot,

--- a/mod-source-record-manager-server/src/main/java/org/folio/services/ChangeEngineServiceImpl.java
+++ b/mod-source-record-manager-server/src/main/java/org/folio/services/ChangeEngineServiceImpl.java
@@ -221,16 +221,16 @@ public class ChangeEngineServiceImpl implements ChangeEngineService {
 
   private boolean updateMarcActionExists(JobExecution jobExecution) {
     return containsMarcActionProfile(
-      jobExecution.getJobProfileSnapshotWrapper()
-      , List.of(FolioRecord.MARC_BIBLIOGRAPHIC, FolioRecord.MARC_AUTHORITY)
-      , Action.UPDATE);
+      jobExecution.getJobProfileSnapshotWrapper(),
+      List.of(FolioRecord.MARC_BIBLIOGRAPHIC, FolioRecord.MARC_AUTHORITY),
+      Action.UPDATE);
   }
 
   private boolean deleteMarcActionExists(JobExecution jobExecution) {
     return containsMarcActionProfile(
-      jobExecution.getJobProfileSnapshotWrapper()
-      , List.of(FolioRecord.MARC_AUTHORITY)
-      , Action.DELETE);
+      jobExecution.getJobProfileSnapshotWrapper(),
+      List.of(FolioRecord.MARC_AUTHORITY),
+      Action.DELETE);
   }
 
   private boolean containsMarcActionProfile(ProfileSnapshotWrapper profileSnapshot,

--- a/mod-source-record-manager-server/src/test/java/org/folio/services/ChangeEngineServiceImplTest.java
+++ b/mod-source-record-manager-server/src/test/java/org/folio/services/ChangeEngineServiceImplTest.java
@@ -162,6 +162,34 @@ public class ChangeEngineServiceImplTest {
   }
 
   @Test
+  public void shouldReturnMarcAuthorityRecordWhenProfileHasDeleteAction() {
+    RawRecordsDto rawRecordsDto = getTestRawRecordsDto(MARC_AUTHORITY_REC_VALID);
+    JobExecution jobExecution = getTestJobExecution();
+    jobExecution.setJobProfileSnapshotWrapper(new ProfileSnapshotWrapper()
+      .withChildSnapshotWrappers(List.of(new ProfileSnapshotWrapper()
+        .withContentType(ProfileSnapshotWrapper.ContentType.ACTION_PROFILE)
+        .withContent(new JsonObject(Json.encode(new ActionProfile()
+          .withAction(ActionProfile.Action.DELETE)
+          .withFolioRecord(ActionProfile.FolioRecord.MARC_AUTHORITY))).getMap())
+      ))
+    );
+
+    when(marcRecordAnalyzer.process(any())).thenReturn(MarcRecordType.AUTHORITY);
+    when(jobExecutionSourceChunkDao.getById(any(), any()))
+      .thenReturn(Future.succeededFuture(Optional.of(new JobExecutionSourceChunk())));
+    when(jobExecutionSourceChunkDao.update(any(), any())).thenReturn(Future.succeededFuture(new JobExecutionSourceChunk()));
+    when(recordsPublishingService.sendEventsWithRecords(any(), any(), any(), any()))
+      .thenReturn(Future.succeededFuture(true));
+
+    Future<List<Record>> serviceFuture = executeWithKafkaMock(rawRecordsDto, jobExecution, Future.succeededFuture(true));
+
+    var actual = serviceFuture.result();
+    assertThat(actual, hasSize(1));
+    assertThat(actual.get(0).getRecordType(), equalTo(Record.RecordType.MARC_AUTHORITY));
+    assertThat(actual.get(0).getErrorRecord(), nullValue());
+  }
+
+  @Test
   public void shouldNotReturnMarcHoldingsRecordWhen004FieldIsMissing() {
     RawRecordsDto rawRecordsDto = getTestRawRecordsDto(MARC_HOLDINGS_REC_WITHOUT_004);
     JobExecution jobExecution = getTestJobExecution();


### PR DESCRIPTION
## Purpose
Support Delete MARC Authority Action

## Approach
Update handling of record processing: if JobProfile contains an action for MARC_AUTHORITY delete then send DI_MARC_FOR_DELETE_RECEIVED event. 


## Learning
[MODSOURMAN-691](https://issues.folio.org/browse/MODSOURMAN-691)
