### PR TITLE
MODSOURMAN-702 Change authority mapping for MARC 410

### DIFF
--- a/mod-source-record-manager-server/src/main/resources/rules/marc_authority_rules.json
+++ b/mod-source-record-manager-server/src/main/resources/rules/marc_authority_rules.json
@@ -413,8 +413,8 @@
       "rules": []
     },
     {
-      "target": "sftPersonalNameTitle",
-      "description": "See from tracing personal name title",
+      "target": "sftCorporateNameTitle",
+      "description": "See from tracing corporate name title",
       "subfield": [
         "a",
         "b",


### PR DESCRIPTION
## Purpose
MARC 410 is mapped to sftPersonalNameTitle but should be mapped to sftCorporateNameTitle
