### PR TITLE
MODSOURMAN-699. Can`t map 'RECORD' or/and 'MARC_BIBLIOGRAPHIC' statements from logs

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -33,6 +33,7 @@
 * [MODSOURMAN-675](https://issues.folio.org/browse/MODSOURMAN-675) Data Import handles repeated 020 $a:s in an unexpected manner when creating Instance Identifiers
 * [MODSOURMAN-676](https://issues.folio.org/browse/MODSOURMAN-676) Provide Instance UUID for populating Inventory hotlinks for holdings/items
 * [MODSOURMAN-682](https://issues.folio.org/browse/MODSOURMAN-682) Consume Authority log event
+* [MODSOURMAN-699](https://issues.folio.org/browse/MODSOURMAN-699) Fix Can`t map 'RECORD' or/and 'MARC_BIBLIOGRAPHIC' statements from logs
 
 ## 2021-10-xx v3.2.3-SNAPSHOT
 * [MODSOURMAN-522](https://issues.folio.org/browse/MODSOURMAN-522) Fix the effect of DI_ERROR messages when trying to duplicate records on the import job progress bar

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,4 +1,5 @@
 ## 2021-xx-xx v3.3.0-SNAPSHOT
+* [MODSOURMAN-694](https://issues.folio.org/browse/MODSOURMAN-694) Improve sql query for retrieving job execution sourcechunks
 * [MODSOURMAN-695](https://issues.folio.org/browse/MODSOURMAN-695) Upgrade RMB and Vertx versions that contain fixes for the connection pool
 * [MODINVOICE-356](https://issues.folio.org/browse/MODINVOICE-356) Fix progress bar stuck behaviour after the RecordTooLargeException
 * [MODSOURMAN-624](https://issues.folio.org/browse/MODSOURMAN-624) Failed to handle DI_ERROR when 004 is invalid in MARC Holdings

--- a/mod-source-record-manager-server/src/main/java/org/folio/dao/JobExecutionSourceChunkDaoImpl.java
+++ b/mod-source-record-manager-server/src/main/java/org/folio/dao/JobExecutionSourceChunkDaoImpl.java
@@ -39,7 +39,7 @@ public class JobExecutionSourceChunkDaoImpl implements JobExecutionSourceChunkDa
 
   public static final Logger LOGGER = LogManager.getLogger();
   private static final String TABLE_NAME = "job_execution_source_chunks";
-  private static final String ID_FIELD = "'id'";
+  private static final String ID_FIELD = "id";
   private static final String JOB_EXECUTION_ID_FIELD = "'jobExecutionId'";
   private static final String IS_PROCESSING_COMPLETED_QUERY = "SELECT is_processing_completed('%s');";
   private static final String ARE_THERE_ANY_ERRORS_DURING_PROCESSING_QUERY = "SELECT processing_contains_error_chunks('%s');";
@@ -82,7 +82,7 @@ public class JobExecutionSourceChunkDaoImpl implements JobExecutionSourceChunkDa
         LOGGER.warn("Can't retrieve JobExecutionSourceChunk by empty id.");
         return promise.future().map(Optional.empty());
       }
-      Criteria idCrit = constructCriteria(ID_FIELD, id);
+      Criteria idCrit = constructCriteria(ID_FIELD, id).setJSONB(false);
       pgClientFactory.createInstance(tenantId)
         .get(TABLE_NAME, JobExecutionSourceChunk.class, new Criterion(idCrit), true, false, promise);
     } catch (Exception e) {
@@ -98,7 +98,7 @@ public class JobExecutionSourceChunkDaoImpl implements JobExecutionSourceChunkDa
   public Future<JobExecutionSourceChunk> update(JobExecutionSourceChunk jobExecutionChunk, String tenantId) {
     Promise<JobExecutionSourceChunk> promise = Promise.promise();
     try {
-      Criteria idCrit = constructCriteria(ID_FIELD, jobExecutionChunk.getId());
+      Criteria idCrit = constructCriteria(ID_FIELD, jobExecutionChunk.getId()).setJSONB(false);
       pgClientFactory.createInstance(tenantId)
         .update(TABLE_NAME, jobExecutionChunk, new Criterion(idCrit), true, updateResult -> {
           if (updateResult.failed()) {

--- a/mod-source-record-manager-server/src/main/java/org/folio/services/exceptions/RawChunkRecordsParsingException.java
+++ b/mod-source-record-manager-server/src/main/java/org/folio/services/exceptions/RawChunkRecordsParsingException.java
@@ -7,7 +7,7 @@ import org.folio.rest.jaxrs.model.RawRecordsDto;
  * It used in error handlers to send DI_ERROR for each failed record from the chunk.
  */
 public class RawChunkRecordsParsingException extends RuntimeException {
-  private RawRecordsDto rawRecordsDto;
+  private final RawRecordsDto rawRecordsDto;
 
   public RawChunkRecordsParsingException(Throwable cause, RawRecordsDto rawRecordsDto) {
     super(cause);

--- a/mod-source-record-manager-server/src/main/java/org/folio/services/exceptions/RawChunkRecordsParsingException.java
+++ b/mod-source-record-manager-server/src/main/java/org/folio/services/exceptions/RawChunkRecordsParsingException.java
@@ -1,0 +1,20 @@
+package org.folio.services.exceptions;
+
+import org.folio.rest.jaxrs.model.RawRecordsDto;
+
+/**
+ * This exception can occur during parsing chunk of initial raw records.
+ * It used in error handlers to send DI_ERROR for each failed record from the chunk.
+ */
+public class RawChunkRecordsParsingException extends RuntimeException {
+  private RawRecordsDto rawRecordsDto;
+
+  public RawChunkRecordsParsingException(Throwable cause, RawRecordsDto rawRecordsDto) {
+    super(cause);
+    this.rawRecordsDto = rawRecordsDto;
+  }
+
+  public RawRecordsDto getRawRecordsDto() {
+    return rawRecordsDto;
+  }
+}

--- a/mod-source-record-manager-server/src/main/java/org/folio/services/exceptions/RawChunkRecordsParsingException.java
+++ b/mod-source-record-manager-server/src/main/java/org/folio/services/exceptions/RawChunkRecordsParsingException.java
@@ -7,7 +7,7 @@ import org.folio.rest.jaxrs.model.RawRecordsDto;
  * It used in error handlers to send DI_ERROR for each failed record from the chunk.
  */
 public class RawChunkRecordsParsingException extends RuntimeException {
-  private final RawRecordsDto rawRecordsDto;
+  private final RawRecordsDto rawRecordsDto; //NOSONAR
 
   public RawChunkRecordsParsingException(Throwable cause, RawRecordsDto rawRecordsDto) {
     super(cause);

--- a/mod-source-record-manager-server/src/main/java/org/folio/verticle/consumers/errorhandlers/ParsedRecordsDiErrorProvider.java
+++ b/mod-source-record-manager-server/src/main/java/org/folio/verticle/consumers/errorhandlers/ParsedRecordsDiErrorProvider.java
@@ -1,0 +1,49 @@
+package org.folio.verticle.consumers.errorhandlers;
+
+import com.google.common.collect.Lists;
+import io.vertx.core.Future;
+import org.folio.dataimport.util.OkapiConnectionParams;
+import org.folio.rest.jaxrs.model.RawRecordsDto;
+import org.folio.rest.jaxrs.model.Record;
+import org.folio.rest.jaxrs.model.RecordsMetadata;
+import org.folio.services.ChangeEngineServiceImpl;
+import org.folio.services.JobExecutionService;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+import java.util.UUID;
+
+@Component
+public class ParsedRecordsDiErrorProvider {
+
+  private JobExecutionService jobExecutionService;
+  private ChangeEngineServiceImpl changeEngineService;
+
+  @Autowired
+  public ParsedRecordsDiErrorProvider(JobExecutionService jobExecutionService, ChangeEngineServiceImpl changeEngineService) {
+    this.jobExecutionService = jobExecutionService;
+    this.changeEngineService = changeEngineService;
+  }
+
+  /**
+   * Get parsed records from initial records in the particular chunk.
+   *
+   * @param okapiParams the okapi params
+   * @param jobExecutionId the job execution id
+   * @param rawRecordsDto the raw records dto
+   * @return list of parsed records
+   */
+  public Future<List<Record>> getParsedRecordsFromInitialRecords(OkapiConnectionParams okapiParams,
+                                                         String jobExecutionId,
+                                                         RawRecordsDto rawRecordsDto) {
+    return jobExecutionService.getJobExecutionById(jobExecutionId, okapiParams.getTenantId())
+      .compose(jobExecutionOptional -> {
+        if (jobExecutionOptional.isPresent()) {
+          RecordsMetadata.ContentType contentType = rawRecordsDto.getRecordsMetadata().getContentType();
+          return Future.succeededFuture(changeEngineService.getParsedRecordsFromInitialRecords(rawRecordsDto.getInitialRecords(), contentType, jobExecutionOptional.get(), UUID.randomUUID().toString()));
+        }
+        return Future.succeededFuture(Lists.newArrayList());
+      });
+  }
+}

--- a/mod-source-record-manager-server/src/main/java/org/folio/verticle/consumers/errorhandlers/ParsedRecordsDiErrorProvider.java
+++ b/mod-source-record-manager-server/src/main/java/org/folio/verticle/consumers/errorhandlers/ParsedRecordsDiErrorProvider.java
@@ -12,10 +12,11 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
 import java.util.List;
-import java.util.UUID;
 
 @Component
 public class ParsedRecordsDiErrorProvider {
+
+  private static final String ERROR_SOURCE_CHUNK_ID = "a5fe4e07-d6b3-47c7-9b84-3e4074f7177f";
 
   private JobExecutionService jobExecutionService;
   private ChangeEngineServiceImpl changeEngineService;
@@ -41,7 +42,7 @@ public class ParsedRecordsDiErrorProvider {
       .compose(jobExecutionOptional -> {
         if (jobExecutionOptional.isPresent()) {
           RecordsMetadata.ContentType contentType = rawRecordsDto.getRecordsMetadata().getContentType();
-          return Future.succeededFuture(changeEngineService.getParsedRecordsFromInitialRecords(rawRecordsDto.getInitialRecords(), contentType, jobExecutionOptional.get(), UUID.randomUUID().toString()));
+          return Future.succeededFuture(changeEngineService.getParsedRecordsFromInitialRecords(rawRecordsDto.getInitialRecords(), contentType, jobExecutionOptional.get(), ERROR_SOURCE_CHUNK_ID));
         }
         return Future.succeededFuture(Lists.newArrayList());
       });

--- a/mod-source-record-manager-server/src/main/java/org/folio/verticle/consumers/errorhandlers/RawMarcChunksErrorHandler.java
+++ b/mod-source-record-manager-server/src/main/java/org/folio/verticle/consumers/errorhandlers/RawMarcChunksErrorHandler.java
@@ -4,6 +4,7 @@ import io.vertx.core.Vertx;
 import io.vertx.core.json.Json;
 import io.vertx.kafka.client.consumer.KafkaConsumerRecord;
 import io.vertx.kafka.client.producer.KafkaHeader;
+import org.apache.commons.collections4.CollectionUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.folio.DataImportEventPayload;
@@ -15,8 +16,10 @@ import org.folio.kafka.exception.DuplicateEventException;
 import org.folio.rest.jaxrs.model.Event;
 import org.folio.rest.jaxrs.model.RawRecordsDto;
 import org.folio.rest.jaxrs.model.Record;
+import org.folio.services.exceptions.RawChunkRecordsParsingException;
 import org.folio.services.exceptions.RecordsPublishingException;
 import org.folio.services.util.EventHandlingUtil;
+import org.folio.services.util.RecordConversionUtil;
 import org.folio.verticle.consumers.errorhandlers.payloadbuilders.DiErrorPayloadBuilder;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
@@ -43,6 +46,8 @@ public class RawMarcChunksErrorHandler implements ProcessRecordErrorHandler<Stri
   private KafkaConfig kafkaConfig;
   @Autowired
   private List<DiErrorPayloadBuilder> errorPayloadBuilders;
+  @Autowired
+  private ParsedRecordsDiErrorProvider parsedRecordsErrorProvider;
 
   @Override
   public void handle(Throwable throwable, KafkaConsumerRecord<String, String> record) {
@@ -61,7 +66,21 @@ public class RawMarcChunksErrorHandler implements ProcessRecordErrorHandler<Stri
     } else if (throwable instanceof DuplicateEventException) {
       RawRecordsDto rawRecordsDto = Json.decodeValue(event.getEventPayload(), RawRecordsDto.class);
       LOGGER.info("Duplicate event received, skipping parsing for jobExecutionId: {} , tenantId: {}, chunkId:{}, totalRecords: {}, cause: {}", jobExecutionId, tenantId, chunkId, rawRecordsDto.getInitialRecords().size(), throwable.getMessage());
-    } else {
+    } else if (throwable instanceof RawChunkRecordsParsingException) {
+      RawChunkRecordsParsingException exception = (RawChunkRecordsParsingException) throwable;
+      parsedRecordsErrorProvider.getParsedRecordsFromInitialRecords(okapiParams, jobExecutionId, exception.getRawRecordsDto())
+        .onComplete(ar -> {
+          List<Record> parsedRecords = ar.result();
+          if (CollectionUtils.isNotEmpty(parsedRecords)) {
+            for (Record rec : parsedRecords) {
+              sendDiError(throwable, jobExecutionId, okapiParams, rec);
+            }
+          } else {
+            sendDiError(throwable, jobExecutionId, okapiParams, null);
+          }
+        });
+    }
+    else {
       sendDiErrorEvent(throwable, okapiParams, jobExecutionId, tenantId, null);
     }
   }
@@ -69,7 +88,8 @@ public class RawMarcChunksErrorHandler implements ProcessRecordErrorHandler<Stri
   private void sendDiErrorEvent(Throwable throwable,
                                 OkapiConnectionParams okapiParams,
                                 String jobExecutionId,
-                                String tenantId, Record record) {
+                                String tenantId,
+                                Record record) {
     if (record != null) {
       okapiParams.getHeaders().set(RECORD_ID_HEADER, record.getId());
       for (DiErrorPayloadBuilder payloadBuilder: errorPayloadBuilders) {
@@ -82,23 +102,24 @@ public class RawMarcChunksErrorHandler implements ProcessRecordErrorHandler<Stri
         }
       }
       LOGGER.warn("Appropriate DI_ERROR payload builder not found, DI_ERROR without records info will be send");
-      sendDiError(throwable, jobExecutionId, okapiParams);
-
-    } else {
-      sendDiError(throwable, jobExecutionId, okapiParams);
     }
+    sendDiError(throwable, jobExecutionId, okapiParams, null);
   }
 
-  private void sendDiError(Throwable throwable, String jobExecutionId, OkapiConnectionParams okapiParams) {
+  private void sendDiError(Throwable throwable, String jobExecutionId, OkapiConnectionParams okapiParams, Record record) {
+    HashMap<String, String> context = new HashMap<>();
+    context.put(ERROR_KEY, throwable.getMessage());
+    if (record != null) {
+      context.put(RecordConversionUtil.getEntityType(record).value(), Json.encode(record));
+    }
+
     DataImportEventPayload payload = new DataImportEventPayload()
       .withEventType(DI_ERROR.value())
       .withJobExecutionId(jobExecutionId)
       .withOkapiUrl(okapiParams.getOkapiUrl())
       .withTenant(okapiParams.getTenantId())
       .withToken(okapiParams.getToken())
-      .withContext(new HashMap<>(){{
-        put(ERROR_KEY, throwable.getMessage());
-      }});
+      .withContext(context);
     EventHandlingUtil.sendEventToKafka(okapiParams.getTenantId(), Json.encode(payload), DI_ERROR.value(),
       KafkaHeaderUtils.kafkaHeadersFromMultiMap(okapiParams.getHeaders()), kafkaConfig, null);
   }

--- a/mod-source-record-manager-server/src/test/java/org/folio/verticle/consumers/errorhandlers/ParsedRecordsDiErrorProviderTest.java
+++ b/mod-source-record-manager-server/src/test/java/org/folio/verticle/consumers/errorhandlers/ParsedRecordsDiErrorProviderTest.java
@@ -1,0 +1,101 @@
+package org.folio.verticle.consumers.errorhandlers;
+
+import com.google.common.collect.Lists;
+import io.vertx.core.Future;
+import io.vertx.core.Vertx;
+import io.vertx.ext.unit.Async;
+import io.vertx.ext.unit.TestContext;
+import io.vertx.ext.unit.junit.VertxUnitRunner;
+import static junit.framework.TestCase.assertEquals;
+import static junit.framework.TestCase.assertTrue;
+import org.folio.dataimport.util.OkapiConnectionParams;
+import static org.folio.dataimport.util.RestUtil.OKAPI_URL_HEADER;
+import org.folio.rest.jaxrs.model.InitialRecord;
+import org.folio.rest.jaxrs.model.JobExecution;
+import org.folio.rest.jaxrs.model.ParsedRecord;
+import org.folio.rest.jaxrs.model.RawRecordsDto;
+import org.folio.rest.jaxrs.model.Record;
+import org.folio.rest.jaxrs.model.RecordsMetadata;
+import static org.folio.rest.util.OkapiConnectionParams.OKAPI_TENANT_HEADER;
+import static org.folio.rest.util.OkapiConnectionParams.OKAPI_TOKEN_HEADER;
+import org.folio.services.ChangeEngineServiceImpl;
+import org.folio.services.JobExecutionService;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+import org.mockito.MockitoAnnotations;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+@RunWith(VertxUnitRunner.class)
+public class ParsedRecordsDiErrorProviderTest {
+  private static final String JOB_EXECUTION_ID = UUID.randomUUID().toString();
+  private static final String TENANT_ID = "diku";
+  private static final String TOKEN = "token";
+
+  @Mock
+  private JobExecutionService jobExecutionService;
+  @Mock
+  private ChangeEngineServiceImpl changeEngineService;
+
+  @InjectMocks
+  private ParsedRecordsDiErrorProvider diErrorProvider = new ParsedRecordsDiErrorProvider(jobExecutionService, changeEngineService);
+
+  @Before
+  public void setUp() {
+    MockitoAnnotations.openMocks(this);
+  }
+
+  @Test
+  public void shouldParseInitialRecords(TestContext context) {
+    Async async = context.async();
+
+    JobExecution jobExecution = new JobExecution().withId(JOB_EXECUTION_ID);
+    when(jobExecutionService.getJobExecutionById(JOB_EXECUTION_ID, TENANT_ID))
+      .thenReturn(Future.succeededFuture(Optional.of(jobExecution)));
+    RawRecordsDto rawRecordsDto = new RawRecordsDto()
+      .withInitialRecords(Lists.newArrayList(new InitialRecord()))
+      .withRecordsMetadata(new RecordsMetadata().withContentType(RecordsMetadata.ContentType.MARC_JSON));
+    when(changeEngineService.getParsedRecordsFromInitialRecords(eq(rawRecordsDto.getInitialRecords()),
+      eq(rawRecordsDto.getRecordsMetadata().getContentType()), eq(jobExecution), anyString()))
+        .thenReturn(Lists.newArrayList(new Record().withParsedRecord(new ParsedRecord())));
+    Future<List<Record>> parserRecordsFuture = diErrorProvider.getParsedRecordsFromInitialRecords(getOkapiParams(), JOB_EXECUTION_ID, rawRecordsDto);
+    parserRecordsFuture.onComplete(ar -> {
+      List<Record> parsedRecords = ar.result();
+      assertEquals(1, parsedRecords.size());
+      async.complete();
+    });
+  }
+
+  @Test
+  public void shouldReturnEmptyListWhenJobExecutionNotFound(TestContext context) {
+    Async async = context.async();
+
+    when(jobExecutionService.getJobExecutionById(JOB_EXECUTION_ID, TENANT_ID))
+      .thenReturn(Future.succeededFuture(Optional.empty()));
+    Future<List<Record>> parserRecordsFuture = diErrorProvider.getParsedRecordsFromInitialRecords(getOkapiParams(), JOB_EXECUTION_ID, new RawRecordsDto());
+    parserRecordsFuture.onComplete(ar -> {
+      List<Record> parsedRecords = ar.result();
+      assertTrue(parsedRecords.isEmpty());
+      async.complete();
+    });
+  }
+
+  private OkapiConnectionParams getOkapiParams() {
+    HashMap<String, String> headers = new HashMap<>();
+    headers.put(OKAPI_URL_HEADER, "http://localhost");
+    headers.put(OKAPI_TENANT_HEADER, TENANT_ID);
+    headers.put(OKAPI_TOKEN_HEADER, TOKEN);
+    return new OkapiConnectionParams(headers, mock(Vertx.class));
+  }
+
+}

--- a/mod-source-record-manager-server/src/test/java/org/folio/verticle/consumers/errorhandlers/errorpayloadbuilders/EdifactErrorPayloadBuilderTest.java
+++ b/mod-source-record-manager-server/src/test/java/org/folio/verticle/consumers/errorhandlers/errorpayloadbuilders/EdifactErrorPayloadBuilderTest.java
@@ -1,4 +1,4 @@
-package org.folio.verticle.consumers.errorpayloadbuilders;
+package org.folio.verticle.consumers.errorhandlers.errorpayloadbuilders;
 
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;

--- a/mod-source-record-manager-server/src/test/java/org/folio/verticle/consumers/errorhandlers/errorpayloadbuilders/MarcBibErrorPayloadBuilderTest.java
+++ b/mod-source-record-manager-server/src/test/java/org/folio/verticle/consumers/errorhandlers/errorpayloadbuilders/MarcBibErrorPayloadBuilderTest.java
@@ -1,4 +1,4 @@
-package org.folio.verticle.consumers.errorpayloadbuilders;
+package org.folio.verticle.consumers.errorhandlers.errorpayloadbuilders;
 
 import io.vertx.core.Future;
 import io.vertx.core.Vertx;


### PR DESCRIPTION
## Purpose
Previously in case of some exception occurs with DB while parsing raw records - DI_ERROR have been sent, but without info about record, so as a result the final imports completes without stucking, but also without any info regarding log entries and reasons of failures.
Need to improve visibility regarding errors to the end users.

## Approach
Add logic to parse records from initial raw records in error handlers 
For testing I tried to simulate by throwing RuntimeException while working with DB in some processing handler.

The UI Landing page would look like as this:
![image](https://user-images.githubusercontent.com/25097693/154031923-91da439f-798f-4c8f-a7d1-21289a258d4e.png)

The View All page would look like as this:
![image](https://user-images.githubusercontent.com/25097693/154032104-9cb44a49-e931-4931-a8ad-060fd895afa9.png)

The Details page (for each log entry) would look like as this:
![image](https://user-images.githubusercontent.com/25097693/154032252-f49dbd45-b3ba-4c59-8f30-b60b20ee68ff.png)


## Learning
https://issues.folio.org/browse/MODSOURMAN-699