### PR TITLE
MODSOURCE-467 Set WARN level for Kafka ProducerConfig/ConsumerConfig messages

### DIFF
--- a/mod-source-record-manager-server/src/main/resources/log4j2.properties
+++ b/mod-source-record-manager-server/src/main/resources/log4j2.properties
@@ -25,3 +25,9 @@ logger.cql2pgjson.level = OFF
 logger.folio_rest.name = org.folio.rest
 logger.folio_rest.level = WARN
 logger.folio_rest.appenderRef.stdout.ref = STDOUT
+
+#disable ProducerConfig/ConsumerConfig messages in log
+logger.kafka.name = org.apache.kafka
+logger.kafka.level = warn
+logger.kafka.additivity = false
+logger.kafka.appenderRef.stdout.ref = STDOUT


### PR DESCRIPTION
## Purpose
Reduce amount of logging of KafkaProducerConfig, KafkaConsumerConfig 

## Approach
Set WARN level for Kafka ProducerConfig/ConsumerConfig messages
