### PR TITLE
MODDATAIMP-635 Check if any 3d party dependencies should be update for DI modules

### DIFF
--- a/mod-source-record-manager-server/pom.xml
+++ b/mod-source-record-manager-server/pom.xml
@@ -14,8 +14,8 @@
     <sonar.exclusions>org.folio.services.mappers.processor.**</sonar.exclusions>
     <sonar.exclusions>**/org/folio/rest/impl/ModTenantAPI.java</sonar.exclusions>
     <sonar.coverage.exclusions>**/services/JournalRecordService.java</sonar.coverage.exclusions>
-    <lombok.version>1.18.20</lombok.version>
-    <testcontainers.version>1.15.3</testcontainers.version>
+    <lombok.version>1.18.22</lombok.version>
+    <testcontainers.version>1.16.3</testcontainers.version>
     <kafkaclients.version>3.1.0</kafkaclients.version>
   </properties>
 
@@ -60,12 +60,12 @@
     <dependency>
       <groupId>io.xlate</groupId>
       <artifactId>staedi</artifactId>
-      <version>1.16.0</version>
+      <version>1.19.0</version>
     </dependency>
     <dependency>
       <groupId>org.marc4j</groupId>
       <artifactId>marc4j</artifactId>
-      <version>2.9.1</version>
+      <version>2.9.2</version>
     </dependency>
     <dependency>
       <groupId>org.apache.kafka</groupId>
@@ -190,13 +190,13 @@
     <dependency>
       <groupId>org.springframework</groupId>
       <artifactId>spring-test</artifactId>
-      <version>5.2.6.RELEASE</version>
+      <version>5.3.16</version>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>com.github.ben-manes.caffeine</groupId>
       <artifactId>caffeine</artifactId>
-      <version>2.8.5</version>
+      <version>3.0.5</version>
     </dependency>
     <dependency>
       <groupId>io.vertx</groupId>
@@ -230,7 +230,7 @@
     <dependency>
       <groupId>org.assertj</groupId>
       <artifactId>assertj-core</artifactId>
-      <version>3.20.2</version>
+      <version>3.22.0</version>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -22,7 +22,7 @@
     <raml-module-builder.version>33.2.6</raml-module-builder.version>
     <vertx.version>4.2.5</vertx.version>
     <junit.version>4.13.2</junit.version>
-    <rest-assured.version>4.3.1</rest-assured.version>
+    <rest-assured.version>4.5.1</rest-assured.version>
     <wiremock.version>2.27.2</wiremock.version>
     <main.basedir>${project.basedir}</main.basedir>
     <ramlfiles_path>${basedir}/ramls</ramlfiles_path>


### PR DESCRIPTION
## Purpose
Using the latest versions helps us avoid possible problems with the libraries.

## Approach

- upgraded lombook from 1.18.21 to 1.18.22
- upgraded testcontainer from 1.15.3 to 1.16.3
- upgraded staedi from 1.16.0 to 1.19.0
- upgraded marc4j from 2.9.1 to 2.9.2
- upgraded spring-test from 5.2.6.RELEASE to 5.3.16
- upgraded caffeine from 2.8.5 to 3.0.5
- upgraded assertj-core from 3.20.2 to 3.22.0
- upgraded rest-assured from 4.3.1 to 4.5.1

## Learning
[MODDATAIMP-635](https://issues.folio.org/browse/MODDATAIMP-635)
