### PR TITLE
MODSOURMAN-719 The 001 is copied to the 035 when the record is updated even though it is unnecessary

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -35,6 +35,7 @@
 * [MODSOURMAN-682](https://issues.folio.org/browse/MODSOURMAN-682) Consume Authority log event
 * [MODSOURMAN-699](https://issues.folio.org/browse/MODSOURMAN-699) Fix Can`t map 'RECORD' or/and 'MARC_BIBLIOGRAPHIC' statements from logs
 * [MODSOURMAN-714](https://issues.folio.org/browse/MODSOURMAN-714) Legacy 999 (non-ff) fields cause data import failure
+* [MODSOURMAN-719](https://issues.folio.org/browse/MODSOURMAN-719) The 001 is copied to the 035 when the record is updated even though it is unnecessary
 
 ## 2022-02-24 v3.2.9
 * [MODSOURMAN-706](https://issues.folio.org/browse/MODSOURMAN-706) Error loading MappingParametersSnapshot

--- a/mod-source-record-manager-server/src/main/java/org/folio/services/afterprocessing/HrIdFieldServiceImpl.java
+++ b/mod-source-record-manager-server/src/main/java/org/folio/services/afterprocessing/HrIdFieldServiceImpl.java
@@ -4,6 +4,7 @@ import org.folio.rest.jaxrs.model.Record;
 import org.springframework.stereotype.Service;
 
 import java.util.List;
+import java.util.Objects;
 
 import static org.apache.commons.lang3.StringUtils.isBlank;
 import static org.folio.services.afterprocessing.AdditionalFieldsUtil.addDataFieldToMarcRecord;
@@ -22,10 +23,13 @@ public class HrIdFieldServiceImpl implements HrIdFieldService {
   @Override
   public void move001valueTo035Field(List<Record> records) {
     records.stream().parallel().forEach(record -> {
-      String valueFrom001 = getValue(record, TAG_001, ' ');
-      String valueFor035 = mergeFieldsFor035(getValue(record, TAG_003, ' '), valueFrom001);
-      if (valueFrom001 != null && !isFieldExist(record, TAG_035, SUBFIELD_FOR_035, valueFor035)) {
-        addDataFieldToMarcRecord(record, TAG_035, INDICATOR_FOR_035, INDICATOR_FOR_035, SUBFIELD_FOR_035, valueFor035);
+      String valueFrom035 = getValue(record, TAG_035, SUBFIELD_FOR_035);
+      if (Objects.isNull(valueFrom035)) {
+        String valueFrom001 = getValue(record, TAG_001, ' ');
+        String valueFor035 = mergeFieldsFor035(getValue(record, TAG_003, ' '), valueFrom001);
+        if (valueFrom001 != null && !isFieldExist(record, TAG_035, SUBFIELD_FOR_035, valueFor035)) {
+          addDataFieldToMarcRecord(record, TAG_035, INDICATOR_FOR_035, INDICATOR_FOR_035, SUBFIELD_FOR_035, valueFor035);
+        }
       }
     });
   }

--- a/mod-source-record-manager-server/src/test/java/org/folio/services/HrIdFieldServiceTest.java
+++ b/mod-source-record-manager-server/src/test/java/org/folio/services/HrIdFieldServiceTest.java
@@ -58,4 +58,25 @@ public class HrIdFieldServiceTest {
     // then
     Assert.assertEquals(expectedParsedContent, record.getParsedRecord().getContent());
   }
+
+  @Test
+  public void shouldNotAdd035FieldIf035FieldExists(){
+    // given
+    String parsedContent = "{\"leader\":\"00115nam  22000731a 4500\",\"fields\":[{\"001\":\"in001\"},{\"003\":\"in001\"},{\"035\":{\"subfields\":[{\"a\":\"(test)data\"}],\"ind1\":\" \",\"ind2\":\" \"}},{\"507\":{\"subfields\":[{\"a\":\"data\"}],\"ind1\":\" \",\"ind2\":\" \"}},{\"500\":{\"subfields\":[{\"a\":\"data\"}],\"ind1\":\" \",\"ind2\":\" \"}}]}";
+    String expectedParsedContent = "{\"leader\":\"00115nam  22000731a 4500\",\"fields\":[{\"001\":\"in001\"},{\"003\":\"in001\"},{\"035\":{\"subfields\":[{\"a\":\"(test)data\"}],\"ind1\":\" \",\"ind2\":\" \"}},{\"507\":{\"subfields\":[{\"a\":\"data\"}],\"ind1\":\" \",\"ind2\":\" \"}},{\"500\":{\"subfields\":[{\"a\":\"data\"}],\"ind1\":\" \",\"ind2\":\" \"}}]}";
+    ParsedRecord parsedRecord = new ParsedRecord();
+    parsedRecord.setContent(parsedContent);
+
+    Record record = new Record().withId(UUID.randomUUID().toString())
+      .withParsedRecord(parsedRecord)
+      .withGeneration(0)
+      .withState(Record.State.ACTUAL)
+      .withExternalIdsHolder(new ExternalIdsHolder().withInstanceId("001").withInstanceHrid("in001"));
+
+    // when
+    HrIdFieldService hrIdFieldService = new HrIdFieldServiceImpl();
+    hrIdFieldService.move001valueTo035Field(Lists.newArrayList(record));
+    // then
+    Assert.assertEquals(expectedParsedContent, record.getParsedRecord().getContent());
+  }
 }


### PR DESCRIPTION
## Purpose
FOLIO copies the 001 to the 035. The more times the record is re-imported, the more 035s are created.

## Approach
FOLIO does not copy the 001 into the 035 again because there is not a need to construct a new 035 since the record is being being updated, not created. Once an SRS MARC Bib has an 001 that matches the Instance HRID, it should be a protected field that is never overwritten with a new number, and is not moved into an 035 field.

## Learning
[MODSOURMAN-719](https://issues.folio.org/browse/MODSOURMAN-719)
