### PR TITLE
MODSOURMAN-722. Journal does not show error status when importing EDIFACT

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,7 @@
 ## 2022-xx-xx v3.4.0-SNAPSHOT
 * [MODSOURMAN-691](https://issues.folio.org/browse/MODSOURMAN-691) Support Delete MARC Authority Action
 * [MODSOURMAN-707](https://issues.folio.org/browse/MODSOURMAN-707) Suppress Delete Authority job logs from Data Import log UI
+* [MODSOURMAN-722](https://issues.folio.org/browse/MODSOURMAN-722) Journal does not show error status when importing EDIFACT
 
 ## 2022-03-03 v3.3.0
 * [MODSOURMAN-694](https://issues.folio.org/browse/MODSOURMAN-694) Improve sql query for retrieving job execution sourcechunks


### PR DESCRIPTION
## Purpose
Cover more cases for showing error messages in case of Edifact import failures 

## Approach
### Call to create invoice lines without vendor reference number in profile
**Logs in mod-invoice:**
` CreateInvoiceEventHandler Error during invoice creation
java.util.concurrent.CompletionException: org.folio.invoices.rest.exceptions.HttpException: {"errors":[{"message":"must not be null","type":"1","code":"-1","parameters":[{"key":"vendorInvoiceNo","value":"null"}]}]}`
**View all page screen**
As you can see, in case of missing vendorReferenceNumber in profile default 0 value provided to be able to build journal records and show errors
![WIthout_vendor_reference_number](https://user-images.githubusercontent.com/25097693/158758965-9d2c3d7a-8944-4e40-8eba-3016440dc4f1.png)
**Details page**
![Without_vendor_reference_number_details_page](https://user-images.githubusercontent.com/25097693/158759237-f28d1642-a3e6-4498-a95f-75b3701634bf.png)

### Call to create invoice lines without description(title) in profile
**Logs in mod-invoice:**
`2022-03-17T07:53:29,671 ERROR [vert.x-worker-thread-7   ] CreateInvoiceEventHandler Error to create invoice line with number 18
java.util.concurrent.CompletionException: org.folio.invoices.rest.exceptions.HttpException: {"errors":[{"message":"must not be null","type":"1","code":"-1","parameters":[{"key":"description","value":"null"}]}]}`
**View all page screen**
Default value 'No content' provided in case of missing description(title) when creating invoice lines
![Create_invoice_lines_failed](https://user-images.githubusercontent.com/25097693/158762511-7f5269dc-802a-4677-9971-9d08e068a1e1.png)
**Details page**
![Create_invoice_failed_details_page](https://user-images.githubusercontent.com/25097693/158762921-115f8074-36cd-49ee-8254-327860dac996.png)

### Call to get acquisition units
Call to get acquisition units occurred after invoice line created and no changes made to show correct error messages
**View all page screen**
![Get_aquizition_units_errors](https://user-images.githubusercontent.com/25097693/158763328-97a54d13-8be4-4de6-a68d-2a1cdb9e7d6b.png)
**Details page**
![Get_aquizition_units_errors_detailed_page](https://user-images.githubusercontent.com/25097693/158763362-c64eb361-0e8c-4d41-b949-d27f3771b1f2.png)

## To Do
Currently if there are some error in mapping profile such as incorrect format of some numbers, dates etc - EDIFACT could not be parsed to INVOICE and INVOICE_LINES so some general error message should be added to View all page (scope of Morning Glory feature work including UI and BE)

## Learning
https://issues.folio.org/browse/MODSOURMAN-722
