### PR TITLE
MODSOURMAN-724 SRM does not process and save error records

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -2,6 +2,7 @@
 * [MODSOURMAN-691](https://issues.folio.org/browse/MODSOURMAN-691) Support Delete MARC Authority Action
 * [MODSOURMAN-707](https://issues.folio.org/browse/MODSOURMAN-707) Suppress Delete Authority job logs from Data Import log UI
 * [MODSOURMAN-722](https://issues.folio.org/browse/MODSOURMAN-722) Journal does not show error status when importing EDIFACT
+* [MODSOURMAN-724](https://issues.folio.org/browse/MODSOURMAN-724) SRM does not process and save error records
 
 ## 2022-03-03 v3.3.0
 * [MODSOURMAN-694](https://issues.folio.org/browse/MODSOURMAN-694) Improve sql query for retrieving job execution sourcechunks

--- a/mod-source-record-manager-server/src/main/java/org/folio/verticle/consumers/util/MarcImportEventsHandler.java
+++ b/mod-source-record-manager-server/src/main/java/org/folio/verticle/consumers/util/MarcImportEventsHandler.java
@@ -121,11 +121,11 @@ public class MarcImportEventsHandler implements SpecificEventHandler {
 
               return titleExtractor.apply(parsedRecord, mappingRules);
             })
-            .map(title -> Future.succeededFuture(journalRecord.withTitle(title)))
-            .orElse(Future.succeededFuture(journalRecord.withTitle(NO_TITLE_MESSAGE))));
+            .map(title -> Future.succeededFuture(journalRecord.withTitle(StringUtils.defaultIfEmpty(journalRecord.getTitle(), NO_TITLE_MESSAGE))))
+            .orElse(Future.succeededFuture(journalRecord)));
       }
     }
 
-    return Future.succeededFuture(journalRecord.withTitle(StringUtils.defaultIfEmpty(journalRecord.getTitle(), NO_TITLE_MESSAGE)));
+    return Future.succeededFuture(journalRecord.withTitle(NO_TITLE_MESSAGE));
   }
 }

--- a/mod-source-record-manager-server/src/main/java/org/folio/verticle/consumers/util/MarcImportEventsHandler.java
+++ b/mod-source-record-manager-server/src/main/java/org/folio/verticle/consumers/util/MarcImportEventsHandler.java
@@ -106,8 +106,6 @@ public class MarcImportEventsHandler implements SpecificEventHandler {
   private Future<JournalRecord> populateRecordTitleIfNeeded(JournalRecord journalRecord,
                                                             DataImportEventPayload eventPayload) {
     var entityType = journalRecord.getEntityType();
-    Optional.ofNullable(journalRecord.getTitle())
-      .ifPresentOrElse(title -> {}, () -> journalRecord.setTitle(NO_MARC_TITLE_MESSAGE));
 
     if (entityType == MARC_BIBLIOGRAPHIC || entityType == MARC_AUTHORITY) {
       String recordAsString = eventPayload.getContext().get(entityType.value());
@@ -127,6 +125,8 @@ public class MarcImportEventsHandler implements SpecificEventHandler {
             .orElse(Future.succeededFuture(journalRecord)));
       }
     }
+
+    journalRecord.setTitle(StringUtils.defaultIfEmpty(journalRecord.getTitle(), NO_MARC_TITLE_MESSAGE));
 
     return Future.succeededFuture(journalRecord);
   }

--- a/mod-source-record-manager-server/src/main/java/org/folio/verticle/consumers/util/MarcImportEventsHandler.java
+++ b/mod-source-record-manager-server/src/main/java/org/folio/verticle/consumers/util/MarcImportEventsHandler.java
@@ -106,6 +106,7 @@ public class MarcImportEventsHandler implements SpecificEventHandler {
   private Future<JournalRecord> populateRecordTitleIfNeeded(JournalRecord journalRecord,
                                                             DataImportEventPayload eventPayload) {
     var entityType = journalRecord.getEntityType();
+    journalRecord.setTitle(NO_TITLE_MESSAGE);
 
     if (entityType == MARC_BIBLIOGRAPHIC || entityType == MARC_AUTHORITY) {
       String recordAsString = eventPayload.getContext().get(entityType.value());
@@ -121,11 +122,11 @@ public class MarcImportEventsHandler implements SpecificEventHandler {
 
               return titleExtractor.apply(parsedRecord, mappingRules);
             })
-            .map(title -> Future.succeededFuture(journalRecord.withTitle(StringUtils.defaultIfEmpty(journalRecord.getTitle(), NO_TITLE_MESSAGE))))
-            .orElse(Future.succeededFuture(journalRecord)));
+            .map(title -> Future.succeededFuture(journalRecord.withTitle(title)))
+            .orElseGet(() -> Future.succeededFuture(journalRecord)));
       }
     }
 
-    return Future.succeededFuture(journalRecord.withTitle(NO_TITLE_MESSAGE));
+    return Future.succeededFuture(journalRecord);
   }
 }

--- a/mod-source-record-manager-server/src/main/java/org/folio/verticle/consumers/util/MarcImportEventsHandler.java
+++ b/mod-source-record-manager-server/src/main/java/org/folio/verticle/consumers/util/MarcImportEventsHandler.java
@@ -33,7 +33,7 @@ public class MarcImportEventsHandler implements SpecificEventHandler {
 
   public static final String INSTANCE_TITLE_FIELD_PATH = "title";
 
-  private static final String NO_MARC_TITLE_MESSAGE = "No content";
+  private static final String NO_TITLE_MESSAGE = "No content";
 
   private static final Map<JournalRecord.EntityType, BiFunction<ParsedRecord, JsonObject, String>> titleExtractorMap =
     Map.of(
@@ -122,12 +122,10 @@ public class MarcImportEventsHandler implements SpecificEventHandler {
               return titleExtractor.apply(parsedRecord, mappingRules);
             })
             .map(title -> Future.succeededFuture(journalRecord.withTitle(title)))
-            .orElse(Future.succeededFuture(journalRecord)));
+            .orElse(Future.succeededFuture(journalRecord.withTitle(NO_TITLE_MESSAGE))));
       }
     }
 
-    journalRecord.setTitle(StringUtils.defaultIfEmpty(journalRecord.getTitle(), NO_MARC_TITLE_MESSAGE));
-
-    return Future.succeededFuture(journalRecord);
+    return Future.succeededFuture(journalRecord.withTitle(StringUtils.defaultIfEmpty(journalRecord.getTitle(), NO_TITLE_MESSAGE)));
   }
 }


### PR DESCRIPTION
## Purpose
Link should be clickable when we click, but when SRS send DI error event records without parsed record have not information about title.

## Approach

- Added default title when we receive title without any data

## Learning
[MODSOURMAN-724](https://issues.folio.org/browse/MODSOURMAN-724)
