### PR TITLE
MODSOURMAN-715 marc record type NA causes data-import to not complete

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -3,6 +3,7 @@
 * [MODSOURMAN-707](https://issues.folio.org/browse/MODSOURMAN-707) Suppress Delete Authority job logs from Data Import log UI
 * [MODSOURMAN-722](https://issues.folio.org/browse/MODSOURMAN-722) Journal does not show error status when importing EDIFACT
 * [MODSOURMAN-724](https://issues.folio.org/browse/MODSOURMAN-724) SRM does not process and save error records
+* [MODSOURMAN-715](https://issues.folio.org/browse/MODSOURMAN-715) marc record type NA causes data-import to not complete
 
 ## 2022-03-03 v3.3.0
 * [MODSOURMAN-694](https://issues.folio.org/browse/MODSOURMAN-694) Improve sql query for retrieving job execution sourcechunks

--- a/mod-source-record-manager-server/src/main/java/org/folio/services/ChangeEngineServiceImpl.java
+++ b/mod-source-record-manager-server/src/main/java/org/folio/services/ChangeEngineServiceImpl.java
@@ -500,7 +500,7 @@ public class ChangeEngineServiceImpl implements ChangeEngineService {
 
   private void checkLeaderLine(MarcRecordType marcRecordType, ParsedResult recordParsedResult, JobExecution jobExecution, String recordId, String chunkId) {
     String fileName = StringUtils.defaultIfEmpty(jobExecution.getFileName(), "No file name");
-    JsonObject parsedRecord = recordParsedResult.getParsedRecord();
+    JsonObject parsedRecord = Objects.requireNonNullElse(recordParsedResult.getParsedRecord(), new JsonObject());
     if(parsedRecord.containsKey("leader") && marcRecordType == MarcRecordType.NA) {
       recordParsedResult.setHasError(true);
       recordParsedResult.setErrors(new JsonObject()

--- a/mod-source-record-manager-server/src/test/java/org/folio/rest/impl/changeManager/ChangeManagerAPITest.java
+++ b/mod-source-record-manager-server/src/test/java/org/folio/rest/impl/changeManager/ChangeManagerAPITest.java
@@ -1829,7 +1829,7 @@ public class ChangeManagerAPITest extends AbstractRestTest {
       .observeFor(30, TimeUnit.SECONDS)
       .build());
 
-    Event obtainedEvent = Json.decodeValue(observedValues.get(5), Event.class);
+    Event obtainedEvent = Json.decodeValue(observedValues.get(6), Event.class);
     assertEquals(DI_RAW_RECORDS_CHUNK_PARSED.value(), obtainedEvent.getEventType());
     RecordCollection recordCollection = Json
       .decodeValue(obtainedEvent.getEventPayload(), RecordCollection.class);
@@ -1873,11 +1873,11 @@ public class ChangeManagerAPITest extends AbstractRestTest {
     async.complete();
 
     String topicToObserve = formatToKafkaTopicName(DI_RAW_RECORDS_CHUNK_PARSED.value());
-    List<String> observedValues = kafkaCluster.observeValues(ObserveKeyValues.on(topicToObserve, 1)
+    List<String> observedValues = kafkaCluster.observeValues(ObserveKeyValues.on(topicToObserve, 3)
       .observeFor(30, TimeUnit.SECONDS)
       .build());
 
-    Event obtainedEvent = Json.decodeValue(observedValues.get(0), Event.class);
+    Event obtainedEvent = Json.decodeValue(observedValues.get(2), Event.class);
     assertEquals(DI_RAW_RECORDS_CHUNK_PARSED.value(), obtainedEvent.getEventType());
     RecordCollection recordCollection = Json
       .decodeValue(obtainedEvent.getEventPayload(), RecordCollection.class);

--- a/mod-source-record-manager-server/src/test/java/org/folio/rest/impl/changeManager/ChangeManagerAPITest.java
+++ b/mod-source-record-manager-server/src/test/java/org/folio/rest/impl/changeManager/ChangeManagerAPITest.java
@@ -7,6 +7,7 @@ import static org.hamcrest.Matchers.everyItem;
 import static org.hamcrest.Matchers.greaterThanOrEqualTo;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.notNullValue;
+import static org.hamcrest.Matchers.containsString;
 import static org.junit.Assert.assertEquals;
 import static com.github.tomakehurst.wiremock.client.WireMock.post;
 import static com.github.tomakehurst.wiremock.client.WireMock.serverError;
@@ -74,6 +75,7 @@ import org.folio.rest.jaxrs.model.RunBy;
 import org.folio.rest.jaxrs.model.StatusDto;
 import org.folio.services.Status;
 import org.folio.services.afterprocessing.AdditionalFieldsUtil;
+import org.hamcrest.MatcherAssert;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
@@ -99,6 +101,7 @@ public class ChangeManagerAPITest extends AbstractRestTest {
   private static final String CORRECT_RAW_RECORD_3 = "03401nam  22004091i 4500001001200000003000800012005001700020006001800037007001500055008004100070020003200111020003500143020004300178020004000221040002100261050002700282082001900309245016200328300002300490500004700513504005100560505178700611588004702398650003702445650004502482650002902527650003602556700005502592700006102647710002302708730001902731776005902750856011902809935001502928980003402943981001402977\u001Eybp10134220\u001ENhCcYBP\u001E20130220102526.4\u001Em||||||||d|||||||\u001Ecr||n|||||||||\u001E130220s2013    ncu     ob    001 0 eng d\u001E  \u001Fa1476601852 (electronic bk.)\u001E  \u001Fa9781476601854 (electronic bk.)\u001E  \u001Fz9780786471140 (softcover : alk. paper)\u001E  \u001Fz078647114X (softcover : alk. paper)\u001E  \u001FaNhCcYBP\u001FcNhCcYBP\u001E 4\u001FaPN1995.9.V46\u001FbG37 2013\u001E04\u001Fa791.43/656\u001F223\u001E00\u001FaGame on, Hollywood!\u001Fh[electronic resource] :\u001Fbessays on the intersection of video games and cinema /\u001Fcedited by Gretchen Papazian and Joseph Michael Sommers.\u001E  \u001Fa1 online resource.\u001E  \u001FaDescription based on print version record.\u001E  \u001FaIncludes bibliographical references and index.\u001E0 \u001FaIntroduction: manifest narrativity-video games, movies, and art and adaptation / Gretchen Papazian and Joseph Michael Sommers -- The rules of engagement: watching, playing and other narrative processes. Playing the Buffyverse, playing the gothic: genre, gender and cross-media interactivity in Buffy the vampire slayer: chaos bleeds / Katrin Althans -- Dead eye: the spectacle of torture porn in Dead rising / Deborah Mellamphy -- Playing (with) the western: classical Hollywood genres in modern video games / Jason W. Buel -- Game-to-film adaptation and how Prince of Persia: the sands of time negotiates the difference between player and audience / Ben S. Bunting, Jr -- Translation between forms of interactivity: how to build the better adaptation / Marcus Schulzke -- The terms of the tale: time, place and other ideologically constructed conditions. -- Playing (in) the city: the warriors and images of urban disorder / Aubrey Anable -- When did Dante become a scythe-wielding badass? modeling adaption and shifting gender convention in Dante's Inferno / Denise A. Ayo -- \"Some of this happened to the other fellow\": remaking Goldeneye with Daniel Craig / David McGowan -- Zombie stripper geishas in the new global economy: racism and sexism in video games / Stewart Chang -- Stories, stories everywhere (and nowhere just the same): transmedia texts. \"My name is Alan Wake. I'm a writer.\": crafting narrative complexity in the age of transmedia storytelling / Michael Fuchs -- Millions of voices: Star wars, digital games, fictional worlds and franchise canon / Felan Parker -- The hype man as racial stereotype, parody and ghost in Afro samurai / Treaandrea M. Russworm -- Epic nostalgia: narrative play and transmedia storytelling in Disney epic Mickey / Lisa K. Dusenberry.\u001E  \u001FaDescription based on print version record.\u001E 0\u001FaMotion pictures and video games.\u001E 0\u001FaFilm adaptations\u001FxHistory and criticism.\u001E 0\u001FaVideo games\u001FxAuthorship.\u001E 0\u001FaConvergence (Telecommunication)\u001E1 \u001FaPapazian, Gretchen,\u001Fd1968-\u001Feeditor of compilation.\u001E1 \u001FaSommers, Joseph Michael,\u001Fd1976-\u001Feeditor of  compilation.\u001E2 \u001FaEbooks Corporation\u001E0 \u001FaEbook Library.\u001E08\u001FcOriginal\u001Fz9780786471140\u001Fz078647114X\u001Fw(DLC)  2012051432\u001E40\u001FzConnect to e-book on Ebook Library\u001Fuhttp://qut.eblib.com.au.AU/EBLWeb/patron/?target=patron&extendedid=P_1126326_0\u001E  \u001Fa.o13465405\u001E  \u001Fa130307\u001Fb6000\u001Fe6000\u001Ff243967\u001Fg1\u001E  \u001FbOM\u001Fcnlnet\u001E\u001D";
   private static final String CORRECT_MARC_HOLDINGS_RAW_RECORD = "00182cx  a22000851  4500001000900000004000800009005001700017008003300034852002900067\u001E10245123\u001E9928371\u001E20170607135730.0\u001E1706072u    8   4001uu   0901128\u001E0 \u001Fbfine\u001FhN7433.3\u001Fi.B87 2014\u001E\u001D";
   private static final String RAW_RECORD_WITH_999_ff_s_SUBFIELD = "00948nam a2200241 a 4500001000800000003000400008005001700012008004100029035002100070035002000091040002300111041001300134100002300147245007900170260005800249300002400307440007100331650003600402650005500438650006900493655006500562999007900627\u001E1007048\u001EICU\u001E19950912000000.0\u001E891218s1983    wyu      d    00010 eng d\u001E  \u001Fa(ICU)BID12424550\u001E  \u001Fa(OCoLC)16105467\u001E  \u001FaPAU\u001FcPAU\u001Fdm/c\u001FdICU\u001E0 \u001Faeng\u001Faarp\u001E1 \u001FaSalzmann, Zdeněk\u001E10\u001FaDictionary of contemporary Arapaho usage /\u001Fccompiled by Zdeněk Salzmann.\u001E0 \u001FaWind River, Wyoming :\u001FbWind River Reservation,\u001Fc1983.\u001E  \u001Fav, 231 p. ;\u001Fc28 cm.\u001E 0\u001FaArapaho language and culture instructional materials series\u001Fvno. 4\u001E 0\u001FaArapaho language\u001FxDictionaries.\u001E 0\u001FaIndians of North America\u001FxLanguages\u001FxDictionaries.\u001E 7\u001FaArapaho language.\u001F2fast\u001F0http://id.worldcat.org/fast/fst00812722\u001E 7\u001FaDictionaries.\u001F2fast\u001F0http://id.worldcat.org/fast/fst01423826\u001Eff\u001Fie27a5374-0857-462e-ac84-fb4795229c7a\u001Fse27a5374-0857-462e-ac84-fb4795229c7a\u001E\u001D";
+  private static final String RAW_RECORD_WITH_INVALID_LEADER = "01342nhm a2200289 a 4500005001700000008004100017035002000058040001300078041000800091043001200099245003000111260005600141300002100197336008000218337007100298338006900369350001500438500007900453530004900532650008200581651006500663650007900728650006300807651006600870856009600936035002001032\u001E20020829132600.0\u001E850404m19839999ctu     ab    00000dmul d\u001E  \u001Fa(ICU)BID8683551\u001E  \u001FaICU\u001FcICU\u001E0 \u001Famul\u001E  \u001Fan-us---\u001E04\u001FaThe Immigrant in America.\u001E0 \u001FaWoodbridge, Conn. :\u001FbResearch Publications,\u001Fc[1983-\u001E  \u001Fareels. ;\u001Fc35 mm.\u001E  \u001Faunspecified\u001Fbzzz\u001F2rdacontent\u001F0http://id.loc.gov/vocabulary/contentTypes/zzz\u001E  \u001Faunmediated\u001Fbn\u001F2rdamedia\u001F0http://id.loc.gov/vocabulary/mediaTypes/n\u001E  \u001Favolume\u001Fbnc\u001F2rdacarrier\u001F0http://id.loc.gov/vocabulary/carriers/nc\u001E  \u001Fa$17,000.00\u001E  \u001FaAccompanying guide to the collection on microfilm has call no. JV6455.I56.\u001E  \u001FaSearch guide also available on the Internet.\u001E 0\u001FaNoncitizens\u001FzUnited States\u001F0http://id.loc.gov/authorities/subjects/sh85003551\u001E 0\u001FaUnited States\u001FxEmigration and immigration\u001FxBio-bibliography.\u001E 7\u001FaEmigration and immigration.\u001F2fast\u001F0http://id.worldcat.org/fast/fst00908690\u001E 7\u001FaImmigrants.\u001F2fast\u001F0http://id.worldcat.org/fast/fst00967712\u001E 7\u001FaUnited States.\u001F2fast\u001F0http://id.worldcat.org/fast/fst01204155\u001E41\u001FzSelect search guide from pull down menu at:\u001Fuhttp://microformguides.gale.com/SearchForm.asp\u001E  \u001Fa(OCoLC)43567633\u001E\u001D";
   private static final String DEFAULT_JOB_PROFILE_ID = "22fafcc3-f582-493d-88b0-3c538480cd83";
   private static final String JOB_PROFILE_ID = UUID.randomUUID().toString();
 
@@ -150,6 +153,15 @@ public class ChangeManagerAPITest extends AbstractRestTest {
       .withCounter(15)
       .withContentType(RecordsMetadata.ContentType.MARC_RAW))
     .withInitialRecords(Collections.singletonList(new InitialRecord().withRecord(RAW_RECORD_WITH_999_ff_s_SUBFIELD))
+    );
+
+  private RawRecordsDto rawRecordsDto_4 = new RawRecordsDto()
+    .withId(UUID.randomUUID().toString())
+    .withRecordsMetadata(new RecordsMetadata()
+      .withLast(false)
+      .withCounter(15)
+      .withContentType(RecordsMetadata.ContentType.MARC_RAW))
+    .withInitialRecords(Collections.singletonList(new InitialRecord().withRecord(RAW_RECORD_WITH_INVALID_LEADER))
     );
 
   @Spy
@@ -1825,4 +1837,52 @@ public class ChangeManagerAPITest extends AbstractRestTest {
     Assert.assertEquals("e27a5374-0857-462e-ac84-fb4795229c7a", recordCollection.getRecords().get(0).getMatchedId());
     Assert.assertEquals("e27a5374-0857-462e-ac84-fb4795229c7a", AdditionalFieldsUtil.getValue(recordCollection.getRecords().get(0), "999", 's'));
   }
+
+  @Test
+  public void shouldSetErrorToRecordWithInvalidLeaderLine(TestContext testContext) throws InterruptedException {
+    InitJobExecutionsRsDto response =
+      constructAndPostInitJobExecutionRqDto(1);
+    List<JobExecution> createdJobExecutions = response.getJobExecutions();
+    assertThat(createdJobExecutions.size(), is(1));
+    JobExecution jobExec = createdJobExecutions.get(0);
+
+    WireMock.stubFor(post(RECORDS_SERVICE_URL)
+      .willReturn(created().withTransformers(RequestToResponseTransformer.NAME)));
+
+    Async async = testContext.async();
+    RestAssured.given()
+      .spec(spec)
+      .body(new JobProfileInfo()
+        .withName("MARC records")
+        .withId(DEFAULT_JOB_PROFILE_ID)
+        .withDataType(DataType.MARC))
+      .when()
+      .put(JOB_EXECUTION_PATH + jobExec.getId() + JOB_PROFILE_PATH)
+      .then()
+      .statusCode(HttpStatus.SC_OK);
+    async.complete();
+
+    async = testContext.async();
+    RestAssured.given()
+      .spec(spec)
+      .body(rawRecordsDto_4)
+      .when()
+      .post(JOB_EXECUTION_PATH + jobExec.getId() + RECORDS_PATH)
+      .then()
+      .statusCode(HttpStatus.SC_NO_CONTENT);
+    async.complete();
+
+    String topicToObserve = formatToKafkaTopicName(DI_RAW_RECORDS_CHUNK_PARSED.value());
+    List<String> observedValues = kafkaCluster.observeValues(ObserveKeyValues.on(topicToObserve, 1)
+      .observeFor(30, TimeUnit.SECONDS)
+      .build());
+
+    Event obtainedEvent = Json.decodeValue(observedValues.get(0), Event.class);
+    assertEquals(DI_RAW_RECORDS_CHUNK_PARSED.value(), obtainedEvent.getEventType());
+    RecordCollection recordCollection = Json
+      .decodeValue(obtainedEvent.getEventPayload(), RecordCollection.class);
+    assertEquals(1, recordCollection.getRecords().size());
+    MatcherAssert.assertThat(recordCollection.getRecords().get(0).getErrorRecord().getDescription(), containsString("Error during analyze leader line for determining record type"));
+  }
+
 }


### PR DESCRIPTION
## Purpose
The record type is determined by the seventh character. In the attached file, the 7th character is simply specified as a space.
Invalid LDR exapmle which had a space in seventh character:
=LDR 05953c m 2201213bi 4500
Before this changes we can observe strange behaviour after importing mrc files with incorrect leader:
![image](https://user-images.githubusercontent.com/89521577/159084081-57ea113d-a588-4387-a14b-d22126edd9b9.png)
![image](https://user-images.githubusercontent.com/89521577/159084110-c4308640-7a7f-4ce8-b971-b3e982a32737.png)
![image](https://user-images.githubusercontent.com/89521577/159084138-2d48bf5b-3f34-47e1-ae47-574a8441ddb1.png)
And after changes data-import will discard records with invalid LDR:
![image](https://user-images.githubusercontent.com/89521577/159084268-30a56a5c-c205-4e7b-9b5d-bc34438f31b4.png)
![image](https://user-images.githubusercontent.com/89521577/159084281-f1fbb55b-c191-426a-a835-67c1c8965093.png)
![image](https://user-images.githubusercontent.com/89521577/159084302-dd7744e9-9658-43f9-8e10-ae7eede3d4aa.png)

## Approach

- Checked existing leader line and MARC record type after analyzing parsed record. Set error record in the case of an incorrect LDR.

## Learning
[MODSOURMAN-715](https://issues.folio.org/browse/MODSOURMAN-715)
[MODDATAIMP-654](https://issues.folio.org/browse/MODDATAIMP-654)
