### PR TITLE
MODSOURMAN-712. Timeout when importing MARC files

### DIFF
--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -575,7 +575,7 @@
       },
       {
         "name": "DB_MAXPOOLSIZE",
-        "value": "5"
+        "value": "15"
       },
       {
         "name": "KAFKA_HOST",


### PR DESCRIPTION
## Purpose
Increase DB max connections size for Vertx connection pool from 5 to 15

## Approach
Time to time we observe DB timeout issues in SRM, most often at the start of day during first import.
Connections in Vertx connection pool not always open, and when there is no application activity - connection pool can contain 0 opened connections. So this increasing of connection will not be additionally load the database when app idle, only in case of spikes

## Learning
https://issues.folio.org/browse/MODSOURMAN-712
