### PR TITLE
MODDATAIMP-472 build journal record when no record present

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -5,6 +5,7 @@
 * [MODSOURMAN-724](https://issues.folio.org/browse/MODSOURMAN-724) SRM does not process and save error records
 * [MODSOURMAN-727](https://issues.folio.org/browse/MODSOURMAN-727) Fix mapping for Authority 010 tag
 * [MODSOURMAN-715](https://issues.folio.org/browse/MODSOURMAN-715) marc record type NA causes data-import to not complete
+* [MODDATAIMP-472](https://issues.folio.org/browse/MODDATAIMP-472) EDIFACT files with txt file extensions do not import
 
 ## 2022-03-03 v3.3.0
 * [MODSOURMAN-694](https://issues.folio.org/browse/MODSOURMAN-694) Improve sql query for retrieving job execution sourcechunks

--- a/mod-source-record-manager-server/src/main/java/org/folio/services/journal/JournalUtil.java
+++ b/mod-source-record-manager-server/src/main/java/org/folio/services/journal/JournalUtil.java
@@ -1,6 +1,7 @@
 package org.folio.services.journal;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.common.base.Strings;
 import io.vertx.core.json.JsonObject;
 import org.folio.DataImportEventPayload;
 import org.folio.rest.jaxrs.model.DataImportEventTypes;
@@ -10,6 +11,7 @@ import org.folio.rest.jaxrs.model.Record;
 import java.util.Date;
 import java.util.HashMap;
 import java.util.Optional;
+import java.util.UUID;
 
 import static org.apache.commons.lang3.StringUtils.EMPTY;
 import static org.apache.commons.lang3.StringUtils.isAnyEmpty;
@@ -63,7 +65,16 @@ public class JournalUtil {
       HashMap<String, String> eventPayloadContext = eventPayload.getContext();
 
       String recordAsString = extractRecord(eventPayloadContext);
-      Record record = new ObjectMapper().readValue(recordAsString, Record.class);
+      Record record;
+      if (Strings.isNullOrEmpty(recordAsString)) {
+        // create stub record since none was introduced
+        record = new Record()
+          .withId(UUID.randomUUID().toString())
+          .withSnapshotId(eventPayload.getJobExecutionId())
+          .withOrder(0);
+      } else {
+        record = new ObjectMapper().readValue(recordAsString, Record.class);
+      }
       String entityAsString = eventPayloadContext.get(entityType.value());
 
       JournalRecord journalRecord = new JournalRecord()

--- a/mod-source-record-manager-server/src/main/java/org/folio/services/journal/JournalUtil.java
+++ b/mod-source-record-manager-server/src/main/java/org/folio/services/journal/JournalUtil.java
@@ -1,8 +1,8 @@
 package org.folio.services.journal;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.google.common.base.Strings;
 import io.vertx.core.json.JsonObject;
+import org.apache.commons.lang3.StringUtils;
 import org.folio.DataImportEventPayload;
 import org.folio.rest.jaxrs.model.DataImportEventTypes;
 import org.folio.rest.jaxrs.model.JournalRecord;
@@ -66,7 +66,7 @@ public class JournalUtil {
 
       String recordAsString = extractRecord(eventPayloadContext);
       Record record;
-      if (Strings.isNullOrEmpty(recordAsString)) {
+      if (StringUtils.isBlank(recordAsString)) {
         // create stub record since none was introduced
         record = new Record()
           .withId(UUID.randomUUID().toString())


### PR DESCRIPTION
## Purpose
Prevent exceptions when an event payload does not have any records in its context. This allows DI_ERROR events, that have been emitted before any records could be instantiated, to be persisted to the job execution. This provides better errors to users of Data Import.

## Approach
Provide a stub record when there aren't any records in the event payload. it will be used to convey the job execution id into the journal record. A random UUID is used as the identifier of the stub record due to assumptions in DI data flow that each journal record points to a distinct source record.

## Potential Issues
The stub record is not actually stored in mod-source-record-storage.
