### PR TITLE
MODSOURMAN-712. Timeout when importing MARC files & Fixes of title's population

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -5,6 +5,7 @@
 * [MODSOURMAN-724](https://issues.folio.org/browse/MODSOURMAN-724) SRM does not process and save error records
 * [MODSOURMAN-727](https://issues.folio.org/browse/MODSOURMAN-727) Fix mapping for Authority 010 tag
 * [MODSOURMAN-715](https://issues.folio.org/browse/MODSOURMAN-715) marc record type NA causes data-import to not complete
+* [MODSOURMAN-732](https://issues.folio.org/browse/MODSOURMAN-732) Upgrade Vertx to 4.2.6
 
 ## 2022-03-03 v3.3.0
 * [MODSOURMAN-694](https://issues.folio.org/browse/MODSOURMAN-694) Improve sql query for retrieving job execution sourcechunks

--- a/mod-source-record-manager-server/pom.xml
+++ b/mod-source-record-manager-server/pom.xml
@@ -19,25 +19,6 @@
     <kafkaclients.version>3.1.0</kafkaclients.version>
   </properties>
 
-  <dependencyManagement>
-    <dependencies>
-      <dependency>
-        <groupId>org.apache.logging.log4j</groupId>
-        <artifactId>log4j-bom</artifactId>
-        <version>2.17.0</version>
-        <type>pom</type>
-        <scope>import</scope>
-      </dependency>
-      <dependency>
-        <groupId>io.vertx</groupId>
-        <artifactId>vertx-stack-depchain</artifactId>
-        <version>${vertx.version}</version>
-        <type>pom</type>
-        <scope>import</scope>
-      </dependency>
-    </dependencies>
-  </dependencyManagement>
-
   <dependencies>
     <dependency>
       <groupId>org.folio</groupId>

--- a/mod-source-record-manager-server/src/main/java/org/folio/verticle/consumers/util/MarcImportEventsHandler.java
+++ b/mod-source-record-manager-server/src/main/java/org/folio/verticle/consumers/util/MarcImportEventsHandler.java
@@ -106,9 +106,9 @@ public class MarcImportEventsHandler implements SpecificEventHandler {
   private Future<JournalRecord> populateRecordTitleIfNeeded(JournalRecord journalRecord,
                                                             DataImportEventPayload eventPayload) {
     var entityType = journalRecord.getEntityType();
-    journalRecord.setTitle(NO_TITLE_MESSAGE);
 
     if (entityType == MARC_BIBLIOGRAPHIC || entityType == MARC_AUTHORITY) {
+      journalRecord.setTitle(NO_TITLE_MESSAGE);
       String recordAsString = eventPayload.getContext().get(entityType.value());
       if (StringUtils.isNotBlank(recordAsString)) {
         var parsedRecord = Json.decodeValue(recordAsString, Record.class).getParsedRecord();

--- a/pom.xml
+++ b/pom.xml
@@ -20,7 +20,7 @@
 
   <properties>
     <raml-module-builder.version>33.2.7</raml-module-builder.version>
-    <vertx.version>4.2.5</vertx.version>
+    <vertx.version>4.2.6</vertx.version>
     <junit.version>4.13.2</junit.version>
     <rest-assured.version>4.3.1</rest-assured.version>
     <wiremock.version>2.27.2</wiremock.version>
@@ -169,6 +169,25 @@
       <url>https://repository.folio.org/repository/maven-folio</url>
     </repository>
   </repositories>
+
+  <dependencyManagement>
+    <dependencies>
+      <dependency>
+        <groupId>org.apache.logging.log4j</groupId>
+        <artifactId>log4j-bom</artifactId>
+        <version>2.17.0</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
+      <dependency>
+        <groupId>io.vertx</groupId>
+        <artifactId>vertx-stack-depchain</artifactId>
+        <version>${vertx.version}</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
+    </dependencies>
+  </dependencyManagement>
 
   <distributionManagement>
     <repository>


### PR DESCRIPTION
## Purpose
**1. Fix issue with populating titles**
When importing valid marc file some titles populated incorrectly with title 'No content'. It has been introduced after some latest changes.
UI looks like this:
![image](https://user-images.githubusercontent.com/25097693/159928901-b04f8b70-d300-4305-b0d6-196b2ef088e7.png)

**2. Upgrade to new Vertx**
Also new version of Vertx has been released that also contains some fixes regarding sql connection pool and http connections fixes.
Release notes:
https://github.com/vert-x3/wiki/wiki/4.2.6-Release-Notes#vertx

## Approach
Dont populate default titles for entity types like Instance, populate it only for MARC_BIBLIOGRAPHIC and MARC_AUTHORITY.
For EDIFACT there is separate handler no modification needed.
Also update Vertx to new version to make connection pool more stable.

## Learning
https://issues.folio.org/browse/MODSOURMAN-732
