### PR TITLE
MODSOURMAN-734: Increase memory in ModuleDescriptor

### DIFF
--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -530,7 +530,7 @@
     "dockerPull": false,
     "dockerArgs": {
       "HostConfig": {
-        "Memory": 715827883,
+        "Memory": 1073741824,
         "PortBindings": {
           "8081/tcp": [
             {


### PR DESCRIPTION
## Purpose
PgException: FATAL: password authentication failed

## Approach
Increase memory in ModuleDescriptor for fix it

## Learning
https://issues.folio.org/browse/MODSOURMAN-734
