### PR TITLE
MODSOURMAN-728 - Fails to upgrade from mod-source-record-manager-3.3.0-SNAPSHOT.115 to v3.3.0

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -8,6 +8,9 @@
 * [MODSOURMAN-732](https://issues.folio.org/browse/MODSOURMAN-732) Upgrade Vertx to 4.2.6
 * [MODDATAIMP-472](https://issues.folio.org/browse/MODDATAIMP-472) EDIFACT files with txt file extensions do not import
 
+## 2022-xx-xx v3.3.2-SNAPSHOT
+* [MODSOURMAN-728](https://issues.folio.org/browse/MODSOURMAN-728) Fails to upgrade from mod-source-record-manager-3.3.0-SNAPSHOT.115 to v3.3.0
+
 ## 2022-03-03 v3.3.0
 * [MODSOURMAN-694](https://issues.folio.org/browse/MODSOURMAN-694) Improve sql query for retrieving job execution sourcechunks
 * [MODSOURMAN-695](https://issues.folio.org/browse/MODSOURMAN-695) Upgrade RMB and Vertx versions that contain fixes for the connection pool

--- a/mod-source-record-manager-server/src/main/resources/templates/db_scripts/job_execution_source_chunks_table.sql
+++ b/mod-source-record-manager-server/src/main/resources/templates/db_scripts/job_execution_source_chunks_table.sql
@@ -1,0 +1,1 @@
+ALTER TABLE job_execution_source_chunks ADD COLUMN IF NOT EXISTS jobExecutionId UUID;

--- a/mod-source-record-manager-server/src/main/resources/templates/db_scripts/schema.json
+++ b/mod-source-record-manager-server/src/main/resources/templates/db_scripts/schema.json
@@ -31,6 +31,7 @@
       "tableName": "job_execution_source_chunks",
       "fromModuleVersion": "mod-source-record-manager-3.1.0",
       "withMetadata": false,
+      "customSnippetPath": "job_execution_source_chunks_table.sql",
       "index": [
         {
           "fieldName": "id",
@@ -42,13 +43,6 @@
         },
         {
           "fieldName": "last",
-          "tOps": "ADD"
-        }
-      ],
-      "foreignKeys": [
-        {
-          "fieldName": "jobExecutionId",
-          "targetTable": "job_executions",
           "tOps": "ADD"
         }
       ]


### PR DESCRIPTION
## Purpose
RMB keeps trying to create FK constraint for "job_execution_source_chunks" table on old "job_executions" table, despite "fromModuleVersion" contains preceded to Lotus module version. This causes an error during upgrading the module from Lotus version to subsequent versions.



## Learning
[MODSOURMAN-728](https://issues.folio.org/browse/MODSOURMAN-728)