### PR TITLE
MODSOURMAN-744: mapping_rules migration fails on missing "mappingRule"

### DIFF
--- a/mod-source-record-manager-server/src/main/resources/templates/db_scripts/cleanup_mapping_rules.sql
+++ b/mod-source-record-manager-server/src/main/resources/templates/db_scripts/cleanup_mapping_rules.sql
@@ -1,0 +1,19 @@
+-- Delete bogus rules: Rules without "mappingRules" property in their jsonb field; and
+-- all but the first (smallest id) rule of that recordType with "mappingRules" property.
+
+-- This doesn't run automatically. Run it manually, for example
+-- psql -c 'SET search_path TO diku_mod_source_record_manager' -f cleanup_mapping_rules.sql
+
+DELETE FROM mapping_rules WHERE record_type = 'MARC_BIB' AND id IS DISTINCT FROM
+    (SELECT min(id) FROM mapping_rules WHERE record_type = 'MARC_BIB' AND jsonb ? 'mappingRules');
+DELETE FROM mapping_rules WHERE record_type = 'MARC_HOLDING' AND id IS DISTINCT FROM
+    (SELECT min(id) FROM mapping_rules WHERE record_type = 'MARC_HOLDING' AND jsonb ? 'mappingRules');
+DO $$
+BEGIN
+  BEGIN
+    DELETE FROM mapping_rules WHERE record_type = 'MARC_AUTHORITY' AND id IS DISTINCT FROM
+        (SELECT min(id) FROM mapping_rules WHERE record_type = 'MARC_AUTHORITY' AND jsonb ? 'mappingRules');
+  EXCEPTION
+    WHEN invalid_text_representation THEN NULL;  -- enum MARC_AUTHORITY may not exist yet
+  END;
+END $$;

--- a/mod-source-record-manager-server/src/main/resources/templates/db_scripts/schema.json
+++ b/mod-source-record-manager-server/src/main/resources/templates/db_scripts/schema.json
@@ -174,6 +174,11 @@
     },
     {
       "run": "after",
+      "snippetPath": "unique_mapping_rules.sql",
+      "fromModuleVersion": "mod-source-record-manager-3.3.3"
+    },
+    {
+      "run": "after",
       "snippet": "ALTER TYPE rule_type ADD VALUE IF NOT EXISTS 'MARC_AUTHORITY';",
       "fromModuleVersion": "mod-source-record-manager-3.3.0"
     },
@@ -196,11 +201,6 @@
       "run": "after",
       "snippet": "ALTER TABLE journal_records ADD COLUMN IF NOT EXISTS instance_id text; ALTER TABLE journal_records ADD COLUMN IF NOT EXISTS holdings_id text;",
       "fromModuleVersion": "mod-source-record-manager-3.3.0"
-    },
-    {
-      "run": "after",
-      "snippetPath": "unique_mapping_rules.sql",
-      "fromModuleVersion": "mod-source-record-manager-3.3.3"
     },
     {
       "run": "after",

--- a/mod-source-record-manager-server/src/main/resources/templates/db_scripts/schema.json
+++ b/mod-source-record-manager-server/src/main/resources/templates/db_scripts/schema.json
@@ -199,6 +199,11 @@
     },
     {
       "run": "after",
+      "snippetPath": "unique_mapping_rules.sql",
+      "fromModuleVersion": "mod-source-record-manager-3.3.3"
+    },
+    {
+      "run": "after",
       "snippet": "ALTER TABLE job_execution ADD COLUMN IF NOT EXISTS job_profile_hidden BOOLEAN; UPDATE job_execution SET job_profile_hidden = 'f'; ALTER TABLE job_execution ALTER COLUMN job_profile_hidden SET NOT NULL; ALTER TABLE job_execution ALTER COLUMN job_profile_hidden SET DEFAULT FALSE;",
       "fromModuleVersion": "mod-source-record-manager-3.4.0"
     }

--- a/mod-source-record-manager-server/src/main/resources/templates/db_scripts/schema.json
+++ b/mod-source-record-manager-server/src/main/resources/templates/db_scripts/schema.json
@@ -159,7 +159,7 @@
     },
     {
       "run": "after",
-      "snippet": "DO $$ BEGIN BEGIN create type rule_type AS ENUM ('MARC_BIB', 'MARC_HOLDING'); EXCEPTION WHEN duplicate_object THEN NULL; END; END $$; ALTER TABLE mapping_rules ADD COLUMN IF NOT EXISTS record_type rule_type NOT NULL DEFAULT 'MARC_BIB';",
+      "snippet": "DO $$ BEGIN BEGIN create type rule_type AS ENUM ('MARC_BIB', 'MARC_HOLDING', 'MARC_AUTHORITY'); EXCEPTION WHEN duplicate_object THEN NULL; END; END $$; ALTER TABLE mapping_rules ADD COLUMN IF NOT EXISTS record_type rule_type NOT NULL DEFAULT 'MARC_BIB';",
       "fromModuleVersion": "mod-source-record-manager-3.2.0"
     },
     {

--- a/mod-source-record-manager-server/src/main/resources/templates/db_scripts/unique_mapping_rules.sql
+++ b/mod-source-record-manager-server/src/main/resources/templates/db_scripts/unique_mapping_rules.sql
@@ -1,25 +1,8 @@
--- Delete bogus rules: Rules without "mappingRules" property in their jsonb field; and
--- all but the first (smallest id) rule of that recordType with "mappingRules" property.
-
-DELETE FROM mapping_rules WHERE record_type = 'MARC_BIB' AND id IS DISTINCT FROM
-    (SELECT min(id) FROM mapping_rules WHERE record_type = 'MARC_BIB' AND jsonb ? 'mappingRules');
-DELETE FROM mapping_rules WHERE record_type = 'MARC_HOLDING' AND id IS DISTINCT FROM
-    (SELECT min(id) FROM mapping_rules WHERE record_type = 'MARC_HOLDING' AND jsonb ? 'mappingRules');
-DO $$
-BEGIN
-  BEGIN
-    DELETE FROM mapping_rules WHERE record_type = 'MARC_AUTHORITY' AND id IS DISTINCT FROM
-        (SELECT min(id) FROM mapping_rules WHERE record_type = 'MARC_AUTHORITY' AND jsonb ? 'mappingRules');
-  EXCEPTION
-    WHEN invalid_text_representation THEN NULL;  -- enum MARC_AUTHORITY may not exist yet
-  END;
-END $$;
-
 DO $$
 BEGIN
   BEGIN
     ALTER TABLE mapping_rules ADD CONSTRAINT unique_record_type UNIQUE (record_type);
   EXCEPTION
-    WHEN duplicate_table THEN NULL;
+    WHEN duplicate_table THEN NULL;  -- ignore if constraint already exists
   END;
 END $$;

--- a/mod-source-record-manager-server/src/main/resources/templates/db_scripts/unique_mapping_rules.sql
+++ b/mod-source-record-manager-server/src/main/resources/templates/db_scripts/unique_mapping_rules.sql
@@ -1,0 +1,18 @@
+-- Delete bogus rules: Rules without "mappingRules" property in their jsonb field; and
+-- all but the first (smallest id) rule of that recordType with "mappingRules" property.
+
+DELETE FROM mapping_rules WHERE record_type = 'MARC_BIB' AND id IS DISTINCT FROM
+    (SELECT min(id) FROM mapping_rules WHERE record_type = 'MARC_BIB' AND jsonb ? 'mappingRules');
+DELETE FROM mapping_rules WHERE record_type = 'MARC_HOLDING' AND id IS DISTINCT FROM
+    (SELECT min(id) FROM mapping_rules WHERE record_type = 'MARC_HOLDING' AND jsonb ? 'mappingRules');
+DELETE FROM mapping_rules WHERE record_type = 'MARC_AUTHORITY' AND id IS DISTINCT FROM
+    (SELECT min(id) FROM mapping_rules WHERE record_type = 'MARC_AUTHORITY' AND jsonb ? 'mappingRules');
+
+DO $$
+BEGIN
+  BEGIN
+    ALTER TABLE mapping_rules ADD CONSTRAINT unique_record_type UNIQUE (record_type);
+  EXCEPTION
+    WHEN duplicate_table THEN NULL;
+  END;
+END $$;

--- a/mod-source-record-manager-server/src/main/resources/templates/db_scripts/unique_mapping_rules.sql
+++ b/mod-source-record-manager-server/src/main/resources/templates/db_scripts/unique_mapping_rules.sql
@@ -5,8 +5,15 @@ DELETE FROM mapping_rules WHERE record_type = 'MARC_BIB' AND id IS DISTINCT FROM
     (SELECT min(id) FROM mapping_rules WHERE record_type = 'MARC_BIB' AND jsonb ? 'mappingRules');
 DELETE FROM mapping_rules WHERE record_type = 'MARC_HOLDING' AND id IS DISTINCT FROM
     (SELECT min(id) FROM mapping_rules WHERE record_type = 'MARC_HOLDING' AND jsonb ? 'mappingRules');
-DELETE FROM mapping_rules WHERE record_type = 'MARC_AUTHORITY' AND id IS DISTINCT FROM
-    (SELECT min(id) FROM mapping_rules WHERE record_type = 'MARC_AUTHORITY' AND jsonb ? 'mappingRules');
+DO $$
+BEGIN
+  BEGIN
+    DELETE FROM mapping_rules WHERE record_type = 'MARC_AUTHORITY' AND id IS DISTINCT FROM
+        (SELECT min(id) FROM mapping_rules WHERE record_type = 'MARC_AUTHORITY' AND jsonb ? 'mappingRules');
+  EXCEPTION
+    WHEN invalid_text_representation THEN NULL;  -- enum MARC_AUTHORITY may not exist yet
+  END;
+END $$;
 
 DO $$
 BEGIN


### PR DESCRIPTION
Add unique constraint on mapping_rules.unique_record_type to prevent duplicate records.

Provide a script to run manually that delete bogus rules: Rules without "mappingRules"
property in their jsonb field; and all but the first (smallest id) rule of that recordType
with "mappingRules" property.

## Learning
Add unique constraint from the beginning on. This avoids cleanup work that takes much more effort.
