### PR TITLE
MODSOURMAN-751. Improve sql queries to know is processing completed and is contain error chunks

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -7,6 +7,7 @@
 * [MODSOURMAN-715](https://issues.folio.org/browse/MODSOURMAN-715) marc record type NA causes data-import to not complete
 * [MODSOURMAN-732](https://issues.folio.org/browse/MODSOURMAN-732) Upgrade Vertx to 4.2.6
 * [MODDATAIMP-472](https://issues.folio.org/browse/MODDATAIMP-472) EDIFACT files with txt file extensions do not import
+* [MODSOURMAN-751](https://issues.folio.org/browse/MODSOURMAN-751) Improve sql query used by UI to know is processing completed
 
 ## 2022-xx-xx v3.3.3-SNAPSHOT
 * [MODSOURMAN-746](https://issues.folio.org/browse/MODSOURMAN-746) Avoid creation of trigger for old job progress table which cases an error during jobProgress saving

--- a/mod-source-record-manager-server/src/main/java/org/folio/dao/JobExecutionSourceChunkDaoImpl.java
+++ b/mod-source-record-manager-server/src/main/java/org/folio/dao/JobExecutionSourceChunkDaoImpl.java
@@ -157,7 +157,7 @@ public class JobExecutionSourceChunkDaoImpl implements JobExecutionSourceChunkDa
       String query = String.format(ARE_THERE_ANY_ERRORS_DURING_PROCESSING_QUERY, jobExecutionId);
       pgClientFactory.createInstance(tenantId).select(query, promise);
     } catch (Exception e) {
-      LOGGER.error("Error while checking if any errors occurred for JobExecution {}", e, jobExecutionId);
+      LOGGER.error("Error while checking if any errors occurred for JobExecution {}", jobExecutionId, e);
       promise.fail(e);
     }
     return promise.future().map(resultSet -> resultSet.iterator().next().getBoolean(0));

--- a/mod-source-record-manager-server/src/main/java/org/folio/dao/JobExecutionSourceChunkDaoImpl.java
+++ b/mod-source-record-manager-server/src/main/java/org/folio/dao/JobExecutionSourceChunkDaoImpl.java
@@ -59,8 +59,7 @@ public class JobExecutionSourceChunkDaoImpl implements JobExecutionSourceChunkDa
     try {
       String query = format(INSERT_QUERY, convertToPsqlStandard(tenantId), TABLE_NAME);
       Tuple queryParams = Tuple.of(
-        StringUtils.isNotBlank(jobExecutionChunk.getId()) ? jobExecutionChunk.getId() :
-          /* generate UUID for the empty last chunk */ UUID.randomUUID().toString(),
+        StringUtils.defaultIfEmpty(jobExecutionChunk.getId(), /* generate UUID for the empty last chunk */ UUID.randomUUID().toString()),
         JsonObject.mapFrom(jobExecutionChunk),
         jobExecutionChunk.getJobExecutionId());
       pgClientFactory.createInstance(tenantId).execute(query, queryParams, promise);

--- a/mod-source-record-manager-server/src/main/java/org/folio/services/EventDrivenChunkProcessingServiceImpl.java
+++ b/mod-source-record-manager-server/src/main/java/org/folio/services/EventDrivenChunkProcessingServiceImpl.java
@@ -61,9 +61,9 @@ public class EventDrivenChunkProcessingServiceImpl extends AbstractChunkProcessi
 
   private Future<Boolean> updateJobExecutionIfAllSourceChunksMarkedAsError(String jobExecutionId, OkapiConnectionParams params) {
     return jobExecutionSourceChunkDao.get("jobExecutionId==" + jobExecutionId + " AND last==true", 0, 1, params.getTenantId())
-      .compose(chunks -> isNotEmpty(chunks) ? jobExecutionSourceChunkDao.isAllChunksProcessed(jobExecutionId, params.getTenantId()) : Future.succeededFuture(false))
-      .compose(isAllChunksError -> {
-        if (isAllChunksError) {
+      .compose(chunks -> isNotEmpty(chunks) ? jobExecutionSourceChunkDao.containsErrorChunks(jobExecutionId, params.getTenantId()) : Future.succeededFuture(false))
+      .compose(containsErrorChunks -> {
+        if (containsErrorChunks) {
           StatusDto statusDto = new StatusDto().withStatus(StatusDto.Status.ERROR).withErrorStatus(StatusDto.ErrorStatus.RECORD_UPDATE_ERROR);
           return jobExecutionProgressService.getByJobExecutionId(jobExecutionId, params.getTenantId())
             .compose(progress -> updateJobExecutionState(jobExecutionId, progress, statusDto, params));

--- a/mod-source-record-manager-server/src/main/java/org/folio/services/journal/InvoiceUtil.java
+++ b/mod-source-record-manager-server/src/main/java/org/folio/services/journal/InvoiceUtil.java
@@ -5,6 +5,8 @@ import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.vertx.core.json.JsonObject;
 import org.apache.commons.lang3.StringUtils;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.folio.DataImportEventPayload;
 import org.folio.rest.jaxrs.model.JournalRecord;
 import org.folio.rest.jaxrs.model.Record;
@@ -16,7 +18,6 @@ import java.util.Map;
 
 import static org.apache.commons.lang3.StringUtils.isAnyEmpty;
 import static org.apache.commons.lang3.StringUtils.isNotEmpty;
-import static org.folio.dao.JobExecutionSourceChunkDaoImpl.LOGGER;
 import static org.folio.rest.jaxrs.model.DataImportEventTypes.DI_ERROR;
 import static org.folio.rest.jaxrs.model.EntityType.EDIFACT_INVOICE;
 import static org.folio.rest.jaxrs.model.JournalRecord.ActionStatus;
@@ -25,6 +26,8 @@ import static org.folio.rest.jaxrs.model.JournalRecord.EntityType.INVOICE;
 import static org.folio.services.journal.JournalUtil.ERROR_KEY;
 
 public class InvoiceUtil {
+
+  private static final Logger LOGGER = LogManager.getLogger();
 
   public static final String INVOICE_LINES_KEY = "INVOICE_LINES";
   public static final String INVOICE_LINES_ERRORS_KEY = "INVOICE_LINES_ERRORS";

--- a/mod-source-record-manager-server/src/main/resources/templates/db_scripts/is_processing_completed.sql
+++ b/mod-source-record-manager-server/src/main/resources/templates/db_scripts/is_processing_completed.sql
@@ -11,10 +11,10 @@ BEGIN
         (
             SELECT count(id)
             FROM job_execution_source_chunks
-            WHERE (jsonb->>'jobExecutionId')::uuid = jobExecId
+            WHERE jobExecutionId = jobExecId
         ) INTO completed
     FROM job_execution_source_chunks
-    WHERE (jsonb->>'jobExecutionId')::uuid = jobExecId AND jsonb->>'state' IN ('COMPLETED', 'ERROR');
+    WHERE jobExecutionId = jobExecId AND jsonb->>'state' IN ('COMPLETED', 'ERROR');
 
     RETURN completed;
 END;

--- a/mod-source-record-manager-server/src/main/resources/templates/db_scripts/processing_contains_error_chunks.sql
+++ b/mod-source-record-manager-server/src/main/resources/templates/db_scripts/processing_contains_error_chunks.sql
@@ -9,7 +9,7 @@ DECLARE
 BEGIN
     SELECT count(id) > 0 INTO has_errors
     FROM job_execution_source_chunks
-    WHERE (jsonb->>'jobExecutionId')::uuid = jobExecId AND jsonb->>'state' = 'ERROR';
+    WHERE jobExecutionId = jobExecId AND jsonb->>'state' = 'ERROR';
 
     RETURN has_errors;
 END;

--- a/mod-source-record-manager-server/src/main/resources/templates/db_scripts/schema.json
+++ b/mod-source-record-manager-server/src/main/resources/templates/db_scripts/schema.json
@@ -82,8 +82,8 @@
     },
     {
       "run": "after",
-      "snippet": "CREATE OR REPLACE FUNCTION processing_contains_error_chunks(jobExecId uuid) RETURNS boolean AS $has_errors$ DECLARE has_errors boolean; BEGIN SELECT count(id) > 0 into has_errors FROM job_execution_source_chunks WHERE (jsonb->>'jobExecutionId')::uuid = jobExecId AND jsonb->>'state' = 'ERROR'; RETURN has_errors; END; $has_errors$ LANGUAGE plpgsql;",
-      "fromModuleVersion": "mod-source-record-manager-2.1.0"
+      "snippet": "CREATE OR REPLACE FUNCTION processing_contains_error_chunks(jobExecId uuid) RETURNS boolean AS $has_errors$ DECLARE has_errors boolean; BEGIN SELECT count(id) > 0 into has_errors FROM job_execution_source_chunks WHERE jobExecutionId = jobExecId AND jsonb->>'state' = 'ERROR'; RETURN has_errors; END; $has_errors$ LANGUAGE plpgsql;",
+      "fromModuleVersion": "mod-source-record-manager-3.3.6"
     },
     {
       "run": "after",

--- a/mod-source-record-manager-server/src/main/resources/templates/db_scripts/schema.json
+++ b/mod-source-record-manager-server/src/main/resources/templates/db_scripts/schema.json
@@ -77,8 +77,8 @@
     },
     {
       "run": "after",
-      "snippet": "CREATE OR REPLACE FUNCTION is_processing_completed(jobExecId uuid) RETURNS boolean AS $completed$ DECLARE completed boolean; BEGIN SELECT count(id) = (SELECT count(id) FROM job_execution_source_chunks WHERE (jsonb->>'jobExecutionId')::uuid = jobExecId) into completed FROM job_execution_source_chunks WHERE (jsonb->>'jobExecutionId')::uuid = jobExecId AND jsonb->>'state' IN ('COMPLETED', 'ERROR'); RETURN completed; END; $completed$ LANGUAGE plpgsql;",
-      "fromModuleVersion": "mod-source-record-manager-2.1.0"
+      "snippet": "CREATE OR REPLACE FUNCTION is_processing_completed(jobExecId uuid) RETURNS boolean AS $completed$ DECLARE completed boolean; BEGIN SELECT count(id) = (SELECT count(id) FROM job_execution_source_chunks WHERE jobExecutionId = jobExecId) into completed FROM job_execution_source_chunks WHERE jobExecutionId = jobExecId AND jsonb->>'state' IN ('COMPLETED', 'ERROR'); RETURN completed; END; $completed$ LANGUAGE plpgsql;",
+      "fromModuleVersion": "mod-source-record-manager-3.3.6"
     },
     {
       "run": "after",
@@ -189,6 +189,11 @@
       "run": "after",
       "snippet": "ALTER TABLE job_execution ADD COLUMN IF NOT EXISTS job_profile_hidden BOOLEAN; UPDATE job_execution SET job_profile_hidden = 'f'; ALTER TABLE job_execution ALTER COLUMN job_profile_hidden SET NOT NULL; ALTER TABLE job_execution ALTER COLUMN job_profile_hidden SET DEFAULT FALSE;",
       "fromModuleVersion": "mod-source-record-manager-3.4.0"
+    },
+    {
+      "run": "after",
+      "snippet": "DROP INDEX IF EXISTS job_execution_source_chunks_jobexecutionid_idx; CREATE INDEX job_execution_source_chunks_jobexecutionid_idx ON job_execution_source_chunks USING BTREE (jobExecutionId);",
+      "fromModuleVersion": "mod-source-record-manager-3.3.6"
     }
   ]
 }


### PR DESCRIPTION
## Purpose
Use common jobExecutionId column istead of jsonb one to speed-up performance, because when importing big files we saw, that quety took around 4 sec.
`13:45:13.477 [vert.x-worker-thread-13] WARN PostgresClient [20299737eqId] EXPLAIN ANALYZE SELECT is_processing_completed('da97355d-1eca-403d-9d7f-1eb7c36a33cc');
Result (cost=0.00..0.26 rows=1 width=1) (actual time=4079.293..4079.294 rows=1 loops=1)
Planning Time: 0.015 ms
Execution Time: 4079.320 ms` 

## Approach
SQL Trigger to fill jobExecutionId was deleted recently, so INSERT query has been modified to fill this field by java code.
Also old index that pointed to jsonb filed has been deleted and new index pointing to common column jobexecutionid created.

Also in this PR we switched to use containsErrorChunks() method instead of isAllChunksProcessed(), because isAllChunksProcessed designred to retrive COMPLETED and ERROR chunks, but we need to construct error dto in method  updateJobExecutionIfAllSourceChunksMarkedAsError() so we need to use containsErrorChunks

## Learning
https://issues.folio.org/browse/MODSOURMAN-751
