### PR TITLE
MODSOURMAN-756. Fix unnecessary No content logs in View All page when import fails

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -7,6 +7,7 @@
 * [MODSOURMAN-715](https://issues.folio.org/browse/MODSOURMAN-715) marc record type NA causes data-import to not complete
 * [MODSOURMAN-732](https://issues.folio.org/browse/MODSOURMAN-732) Upgrade Vertx to 4.2.6
 * [MODDATAIMP-472](https://issues.folio.org/browse/MODDATAIMP-472) EDIFACT files with txt file extensions do not import
+* [MODSOURMAN-756](https://issues.folio.org/browse/MODSOURMAN-751) Fix unnecessary No content logs in View All page when import fails
 
 ## 2022-xx-xx v3.3.3-SNAPSHOT
 * [MODSOURMAN-746](https://issues.folio.org/browse/MODSOURMAN-746) Avoid creation of trigger for old job progress table which cases an error during jobProgress saving


### PR DESCRIPTION
## Purpose
Not send DI_ERROR if processing of last chunk failed to avoid such screens in UI, instead use logging for last chunk processing
![image](https://user-images.githubusercontent.com/25097693/161931030-34cb87f0-60b1-4b46-9870-c625952919c4.png)

After fix after importing the same file UI looks like this:
![image](https://user-images.githubusercontent.com/25097693/161935986-35705d21-369b-4a54-8bd9-734b76cd376c.png)


## Approach
Modify RawMarcChunkErrorHandler to skip sending DI_ERROR for the last chunk

## Learning
https://issues.folio.org/browse/MODSOURMAN-756
