### PR TITLE
MODSOURMAN-763 Weird log display for a job that updates or creates

### DIFF
--- a/mod-source-record-manager-server/src/main/java/org/folio/verticle/consumers/util/JournalParams.java
+++ b/mod-source-record-manager-server/src/main/java/org/folio/verticle/consumers/util/JournalParams.java
@@ -104,7 +104,7 @@ public class JournalParams {
       @Override
       public Optional<JournalParams> getJournalParams(DataImportEventPayload eventPayload) {
         return Optional.of(new JournalParams(JournalRecord.ActionType.UPDATE,
-          JournalRecord.EntityType.INSTANCE,
+          JournalRecord.EntityType.MARC_BIBLIOGRAPHIC,
           JournalRecord.ActionStatus.COMPLETED));
       }
     },

--- a/mod-source-record-manager-server/src/test/java/org/folio/verticle/consumers/util/JournalParamsTest.java
+++ b/mod-source-record-manager-server/src/test/java/org/folio/verticle/consumers/util/JournalParamsTest.java
@@ -242,8 +242,8 @@ public class JournalParamsTest {
   }
 
   @Test
-  public void shouldPopulateEntityTypeMarcBibWhenEventTypeIsDiSrsMarcBibReadyFOrPostProcessing() {
-    populateEntityTypeAndActionTypeByEventType(DI_SRS_MARC_BIB_RECORD_MODIFIED_READY_FOR_POST_PROCESSING, JournalRecord.EntityType.INSTANCE, JournalRecord.ActionType.UPDATE);
+  public void shouldPopulateEntityTypeMarcBibWhenEventTypeIsDiSrsMarcBibReadyForPostProcessing() {
+    populateEntityTypeAndActionTypeByEventType(DI_SRS_MARC_BIB_RECORD_MODIFIED_READY_FOR_POST_PROCESSING, JournalRecord.EntityType.MARC_BIBLIOGRAPHIC, JournalRecord.ActionType.UPDATE);
   }
 
   @Test


### PR DESCRIPTION
## Purpose
Avoiding journal mapping problem as an example bellow :
_12:15:54.682 [vert.x-worker-thread-18] ERROR KafkaConsumerWrapper [37786800eqId] Error while processing a record - id: 52 subscriptionPattern: SubscriptionDefinition(eventType=DI_ERROR, subscriptionPattern=FOLIO\.Default\.\w{1,}\.DI_ERROR) offset: 6
org.folio.services.journal.JournalRecordMapperException: Failed to handle DI_ERROR event, because event payload context does not contain INSTANCE and/or MARC_BIBLIOGRAPHIC data
	at org.folio.services.journal.JournalUtil.buildJournalRecordByEvent(JournalUtil.java:48) ~[mod-source-record-manager-server-fat.jar:?]
	at org.folio.verticle.consumers.util.MarcImportEventsHandler.handle(MarcImportEventsHandler.java:98) ~[mod-source-record-manager-server-fat.jar:?]
	at org.folio.verticle.consumers.DataImportJournalKafkaHandler.processJournalEvent(DataImportJournalKafkaHandler.java:69) ~[mod-source-record-manager-server-fat.jar:?]_

## Approach
- Change entity type to MARC_BIBLIOGRAPHIC for DI_SRS_MARC_BIB_RECORD_MODIFIED_READY_FOR_POST_PROCESSING event.

## Learning
[MODSOURMAN-763](https://issues.folio.org/browse/MODSOURMAN-763)
