### PR TITLE
MODSOURMAN-776 FOLIO-3231 Use new api-lint and api-doc CI facilities

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,10 +1,10 @@
 buildMvn {
   publishModDescriptor = 'yes'
   mvnDeploy = 'yes'
-  publishAPI = 'yes'
   buildNode = 'jenkins-agent-java11'
 
   doApiLint = true
+  doApiDoc = true
   apiTypes = 'RAML'
   apiDirectories = 'ramls'
 

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -2,8 +2,11 @@ buildMvn {
   publishModDescriptor = 'yes'
   mvnDeploy = 'yes'
   publishAPI = 'yes'
-  runLintRamlCop = 'yes'
   buildNode = 'jenkins-agent-java11'
+
+  doApiLint = true
+  apiTypes = 'RAML'
+  apiDirectories = 'ramls'
 
   doDocker = {
     buildJavaDocker {

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # mod-source-record-manager
 
-Copyright (C) 2018-2020 The Open Library Foundation
+Copyright (C) 2018-2022 The Open Library Foundation
 
 This software is distributed under the terms of the Apache License,
 Version 2.0. See the file "[LICENSE](LICENSE)" for more information.

--- a/ramls/change-manager.raml
+++ b/ramls/change-manager.raml
@@ -48,12 +48,12 @@ resourceTypes:
       description: "Initialize JobExecutions"
       body:
         application/json:
-          schema: initJobExecutionsRqDto
+          type: initJobExecutionsRqDto
       responses:
         201:
           body:
             application/json:
-              schema: initJobExecutionsRsDto
+              type: initJobExecutionsRsDto
         500:
           description: "Internal server error"
           body:
@@ -111,7 +111,7 @@ resourceTypes:
           description: "Update JobExecution status"
           body:
             application/json:
-              schema: statusDto
+              type: statusDto
           responses:
             200:
               body:
@@ -138,7 +138,7 @@ resourceTypes:
           description: "Set JobProfile for JobExecution"
           body:
             application/json:
-              schema: jobProfileInfo
+              type: jobProfileInfo
           responses:
             200:
               body:
@@ -165,7 +165,7 @@ resourceTypes:
           description: "Receive chunk of raw records"
           body:
             application/json:
-              schema: rawRecordsDto
+              type: rawRecordsDto
           responses:
             204:
             400:
@@ -231,7 +231,7 @@ resourceTypes:
         is: [validate]
         body:
           application/json:
-            schema: parsedRecordDto
+            type: parsedRecordDto
         responses:
           202:
           400:

--- a/ramls/metadata-provider.raml
+++ b/ramls/metadata-provider.raml
@@ -97,7 +97,7 @@ resourceTypes:
         200:
           body:
             application/json:
-              schema: jobExecutionDtoCollection
+              type: jobExecutionDtoCollection
         500:
           description: "Internal server error"
           body:
@@ -109,7 +109,7 @@ resourceTypes:
           200:
             body:
               application/json:
-                schema: jobExecutionLogDto
+                type: jobExecutionLogDto
           500:
             description: "Internal server error"
             body:
@@ -133,7 +133,7 @@ resourceTypes:
         200:
           body:
             application/json:
-              schema: journalRecordCollection
+              type: journalRecordCollection
         400:
           description: "Bad request"
           body:
@@ -165,7 +165,7 @@ resourceTypes:
         200:
           body:
             application/json:
-              schema: jobLogEntryDtoCollection
+              type: jobLogEntryDtoCollection
         400:
           description: "Bad request"
           body:
@@ -178,7 +178,7 @@ resourceTypes:
         200:
           body:
             application/json:
-              schema: recordProcessingLogDto
+              type: recordProcessingLogDto
         400:
           description: "Bad request"
           body:


### PR DESCRIPTION
The doApiLint facility replaces runLintRamlCop
https://dev.folio.org/guides/api-lint/

The doApiDoc facility replaces publishAPI
https://dev.folio.org/guides/api-doc/

The https://dev.folio.org/reference/api/#mod-source-record-manager section of API documentation will be automatically reconfigured:
https://dev.folio.org/reference/api/#explain-gather-config

### TODO:
Please fix the JSON errors, as described in the subsequent comment.