### PR TITLE
MODSOURMAN-778 Add permission for Purchase Order Lines matching

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -11,6 +11,7 @@
 * [MODSOURMAN-756](https://issues.folio.org/browse/MODSOURMAN-756) Fix unnecessary No content logs in View All page when import fails
 * [MODSOURMAN-763](https://issues.folio.org/browse/MODSOURMAN-763) Weird log display for a job that updates or creates
 * [MODSOURMAN-767](https://issues.folio.org/browse/MODSOURMAN-767) Fix state is "In progress" after successful quickMarc update
+* [MODSOURMAN-778](https://issues.folio.org/browse/MODSOURMAN-778) Add permission for Purchase Order Lines matching
 
 ## 2022-xx-xx v3.3.3-SNAPSHOT
 * [MODSOURMAN-746](https://issues.folio.org/browse/MODSOURMAN-746) Avoid creation of trigger for old job progress table which cases an error during jobProgress saving

--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -243,7 +243,8 @@
             "source-storage.snapshots.get",
             "source-storage.snapshots.put",
             "source-storage.verified.records",
-            "users.collection.get"
+            "users.collection.get",
+            "orders.po-lines.collection.get"
           ]
         },
         {
@@ -343,7 +344,8 @@
             "source-storage.snapshots.get",
             "source-storage.snapshots.put",
             "source-storage.verified.records",
-            "users.collection.get"
+            "users.collection.get",
+            "orders.po-lines.collection.get"
           ]
         }
       ]


### PR DESCRIPTION
## Purpose
Add necessary permissions for POL matching

## Approach
- add permission `orders.po-lines.collection.get` to 'modulePermissions', POST method of 'source-manager-records'
- add permission `orders.po-lines.collection.get` to 'modulePermissions', PUT method of 'source-manager-parsed-records'

## Learning
[MODSOURMAN-778](https://issues.folio.org/browse/MODSOURMAN-778)
