### PR TITLE
MODSOURMAN-781 Populate dataImportEventPayload with correlationId value

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,4 +1,4 @@
-*
+#*
 !Dockerfile
 !docker*
 !mod-source-record-manager-server/target/*.jar

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "ramls/raml-storage"]
 	path = ramls/raml-storage
-	url = https://github.com/folio-org/data-import-raml-storage
+	url = https://github.com/folio-org/data-import-raml-storage.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "ramls/raml-storage"]
 	path = ramls/raml-storage
-	url = https://github.com/folio-org/data-import-raml-storage.git
+	url = https://github.com/folio-org/data-import-raml-storage

--- a/.rancher-pipeline.yml
+++ b/.rancher-pipeline.yml
@@ -9,18 +9,18 @@ stages:
   - publishImageConfig:
       dockerfilePath: ./Dockerfile
       buildContext: .
-      tag: docker.dev.folio.org/mod-source-record-manager:folijet-${CICD_EXECUTION_SEQUENCE}
+      tag: folioci/mod-source-record-manager:spitfire-${CICD_EXECUTION_SEQUENCE}
       pushRemote: true
-      registry: docker.dev.folio.org
+      registry: folioci
 - name: Deploy
   steps:
   - applyAppConfig:
-      catalogTemplate: p-gh7sb:folijet-helmcharts-mod-source-record-manager
+      catalogTemplate: p-4qb6b:spitfire-helmcharts-mod-source-record-manager
       version: 0.1.32
       answers:
-        image.repository: docker.dev.folio.org/mod-source-record-manager
-        image.tag: folijet-${CICD_EXECUTION_SEQUENCE}
-      targetNamespace: folijet
+        image.repository: folioci/mod-source-record-manager
+        image.tag: spitfire-${CICD_EXECUTION_SEQUENCE}
+      targetNamespace: spitfire
       name: mod-source-record-manager
 timeout: 60
 notification: {}

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,5 +8,10 @@ ENV VERTICLE_HOME /usr/verticles
 # Copy your fat jar to the container
 COPY mod-source-record-manager-server/target/${VERTICLE_FILE} ${VERTICLE_HOME}/${VERTICLE_FILE}
 
+# Copy local lib to the container
+ENV LIB_DIR ${VERTICLE_HOME}/lib
+RUN mkdir -p ${LIB_DIR}
+COPY mod-source-record-manager-server/lib/* ${LIB_DIR}/
+
 # Expose this port locally in the container.
 EXPOSE 8081

--- a/mod-source-record-manager-server/pom.xml
+++ b/mod-source-record-manager-server/pom.xml
@@ -198,10 +198,18 @@
       <artifactId>mod-data-import-converter-storage-client</artifactId>
       <version>1.14.0-SNAPSHOT</version>
     </dependency>
+<!--    <dependency>-->
+<!--      <groupId>org.folio</groupId>-->
+<!--      <artifactId>data-import-processing-core</artifactId>-->
+<!--      <version>3.4.0-SNAPSHOT</version>-->
+<!--    </dependency>-->
+    <!-- TODO: THE VERSION OF LIBRARY MUST BE CHANGED BACK ONCE TESTING ON RANCHER IS COMPLETE-->
     <dependency>
       <groupId>org.folio</groupId>
       <artifactId>data-import-processing-core</artifactId>
+      <scope>system</scope>
       <version>3.4.0-SNAPSHOT</version>
+      <systemPath>${basedir}/lib/data-import-processing-core-fat.jar</systemPath>
     </dependency>
     <dependency>
       <groupId>org.folio</groupId>
@@ -411,6 +419,7 @@
               <transformers>
                 <transformer implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
                   <manifestEntries>
+                    <Class-Path>lib/data-import-processing-core-fat.jar</Class-Path>
                     <Main-Class>org.folio.rest.RestLauncher</Main-Class>
                     <Main-Verticle>org.folio.rest.RestVerticle</Main-Verticle>
                     <Multi-Release>true</Multi-Release>

--- a/mod-source-record-manager-server/pom.xml
+++ b/mod-source-record-manager-server/pom.xml
@@ -201,7 +201,7 @@
     <dependency>
       <groupId>org.folio</groupId>
       <artifactId>data-import-processing-core</artifactId>
-      <version>3.3.0</version>
+      <version>3.4.0-SNAPSHOT</version>
     </dependency>
     <dependency>
       <groupId>org.folio</groupId>

--- a/mod-source-record-manager-server/src/main/java/org/folio/services/util/EventHandlingUtil.java
+++ b/mod-source-record-manager-server/src/main/java/org/folio/services/util/EventHandlingUtil.java
@@ -1,5 +1,12 @@
 package org.folio.services.util;
 
+import static org.apache.commons.lang3.StringUtils.isNotBlank;
+
+import static org.folio.services.util.RecordConversionUtil.RECORDS;
+
+import java.util.List;
+import java.util.UUID;
+
 import io.vertx.core.Future;
 import io.vertx.core.Promise;
 import io.vertx.core.Vertx;
@@ -10,23 +17,24 @@ import io.vertx.kafka.client.producer.KafkaProducer;
 import io.vertx.kafka.client.producer.KafkaProducerRecord;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+
+import org.folio.dataimport.util.OkapiConnectionParams;
 import org.folio.kafka.KafkaConfig;
 import org.folio.kafka.KafkaTopicNameHelper;
 import org.folio.processing.events.utils.PomReaderUtil;
+import org.folio.rest.jaxrs.model.DataImportEventPayload;
 import org.folio.rest.jaxrs.model.Event;
 import org.folio.rest.jaxrs.model.EventMetadata;
 import org.folio.rest.jaxrs.model.RecordCollection;
 import org.folio.rest.tools.utils.ModuleName;
 import org.folio.services.exceptions.RecordsPublishingException;
-import static org.folio.services.util.RecordConversionUtil.RECORDS;
-
-import java.util.List;
-import java.util.UUID;
 
 public final class EventHandlingUtil {
 
   private EventHandlingUtil() {
   }
+
+  static final String CORRELATION_ID_HEADER = "correlationId";
 
   private static final Logger LOGGER = LogManager.getLogger();
 
@@ -125,5 +133,21 @@ public final class EventHandlingUtil {
       promise.fail(new RecordsPublishingException(cause.getMessage(), recordCollection.getRecords()));
     }
     promise.fail(cause);
+  }
+
+  //Method is duplicated because there're two similar dto's from different sources
+  public static void populatePayloadWithHeadersData(DataImportEventPayload eventPayload, OkapiConnectionParams params) {
+    String correlationId = params.getHeaders().get(CORRELATION_ID_HEADER);
+    if (isNotBlank(correlationId)) {
+      eventPayload.setCorrelationId(correlationId);
+    }
+  }
+
+  //Method is duplicated because there're two similar dto's from different sources
+  public static void populatePayloadWithHeadersData(org.folio.DataImportEventPayload eventPayload, OkapiConnectionParams params) {
+    String correlationId = params.getHeaders().get(CORRELATION_ID_HEADER);
+    if (isNotBlank(correlationId)) {
+      eventPayload.setCorrelationId(correlationId);
+    }
   }
 }

--- a/mod-source-record-manager-server/src/main/java/org/folio/verticle/consumers/errorhandlers/RawMarcChunksErrorHandler.java
+++ b/mod-source-record-manager-server/src/main/java/org/folio/verticle/consumers/errorhandlers/RawMarcChunksErrorHandler.java
@@ -1,5 +1,11 @@
 package org.folio.verticle.consumers.errorhandlers;
 
+import static org.folio.rest.jaxrs.model.DataImportEventTypes.DI_ERROR;
+import static org.folio.services.util.EventHandlingUtil.populatePayloadWithHeadersData;
+
+import java.util.HashMap;
+import java.util.List;
+
 import io.vertx.core.Vertx;
 import io.vertx.core.json.Json;
 import io.vertx.kafka.client.consumer.KafkaConsumerRecord;
@@ -8,6 +14,10 @@ import org.apache.commons.collections4.CollectionUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.stereotype.Component;
+
 import org.folio.DataImportEventPayload;
 import org.folio.dataimport.util.OkapiConnectionParams;
 import org.folio.kafka.KafkaConfig;
@@ -22,14 +32,6 @@ import org.folio.services.exceptions.RecordsPublishingException;
 import org.folio.services.util.EventHandlingUtil;
 import org.folio.services.util.RecordConversionUtil;
 import org.folio.verticle.consumers.errorhandlers.payloadbuilders.DiErrorPayloadBuilder;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.beans.factory.annotation.Qualifier;
-import org.springframework.stereotype.Component;
-
-import java.util.HashMap;
-import java.util.List;
-
-import static org.folio.rest.jaxrs.model.DataImportEventTypes.DI_ERROR;
 
 @Component
 @Qualifier("RawMarcChunksErrorHandler")
@@ -125,6 +127,9 @@ public class RawMarcChunksErrorHandler implements ProcessRecordErrorHandler<Stri
       .withTenant(okapiParams.getTenantId())
       .withToken(okapiParams.getToken())
       .withContext(context);
+
+    populatePayloadWithHeadersData(payload, okapiParams);
+
     EventHandlingUtil.sendEventToKafka(okapiParams.getTenantId(), Json.encode(payload), DI_ERROR.value(),
       KafkaHeaderUtils.kafkaHeadersFromMultiMap(okapiParams.getHeaders()), kafkaConfig, null);
   }

--- a/mod-source-record-manager-server/src/test/java/org/folio/services/RecordPublishingServiceImplTest.java
+++ b/mod-source-record-manager-server/src/test/java/org/folio/services/RecordPublishingServiceImplTest.java
@@ -1,0 +1,91 @@
+package org.folio.services;
+
+import static org.junit.Assert.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.when;
+
+import static org.folio.rest.jaxrs.model.DataImportEventTypes.DI_SRS_MARC_BIB_RECORD_CREATED;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Optional;
+import java.util.UUID;
+
+import io.vertx.core.Future;
+import io.vertx.core.Vertx;
+import io.vertx.core.json.Json;
+import lombok.SneakyThrows;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.junit.MockitoJUnitRunner;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import org.folio.TestUtil;
+import org.folio.dataimport.util.OkapiConnectionParams;
+import org.folio.kafka.KafkaConfig;
+import org.folio.rest.jaxrs.model.DataImportEventPayload;
+import org.folio.rest.jaxrs.model.JobExecution;
+import org.folio.rest.jaxrs.model.JobProfileInfo;
+import org.folio.rest.jaxrs.model.ProfileSnapshotWrapper;
+import org.folio.rest.jaxrs.model.Record;
+import org.folio.services.util.EventHandlingUtil;
+
+@RunWith(MockitoJUnitRunner.class)
+public class RecordPublishingServiceImplTest {
+
+  private static final String MARC_BIB_RECORD_PATH = "src/test/resources/org/folio/rest/record.json";
+
+  private final OkapiConnectionParams okapiConnectionParams = new OkapiConnectionParams(new HashMap<>(), Vertx.vertx());
+
+  @Mock
+  private JobExecutionService jobExecutionService;
+  @Mock
+  private KafkaConfig kafkaConfig;
+  @Mock
+  private DataImportPayloadContextBuilder payloadContextBuilder;
+  @InjectMocks
+  private RecordsPublishingServiceImpl recordsPublishingService =
+    new RecordsPublishingServiceImpl(jobExecutionService, payloadContextBuilder, kafkaConfig);
+
+  @Before
+  public void setUp() {
+    ReflectionTestUtils.setField(recordsPublishingService, "maxDistributionNum", 10);
+  }
+
+  @Test
+  @SneakyThrows
+  public void shouldPopulateEventPayloadWithCorrelationIdWhenHeaderExists() {
+    Record record = Json.decodeValue(TestUtil.readFileFromPath(MARC_BIB_RECORD_PATH), Record.class);
+    String jobExecutionId = UUID.randomUUID().toString();
+
+    when(jobExecutionService.getJobExecutionById(anyString(), anyString()))
+      .thenReturn(Future.succeededFuture(Optional.of(getTestJobExecution())));
+
+    try (var mockedStatic = Mockito.mockStatic(EventHandlingUtil.class)) {
+      mockedStatic.when(() -> EventHandlingUtil.sendEventToKafka(any(), any(), any(), any(), any(), any()))
+        .thenReturn(Future.succeededFuture(true));
+
+      Boolean resultSucceeded = recordsPublishingService.sendEventsWithRecords(Collections.singletonList(record),
+        jobExecutionId,
+        okapiConnectionParams,
+        DI_SRS_MARC_BIB_RECORD_CREATED.value()).result();
+
+      assertTrue(resultSucceeded);
+      mockedStatic.verify(() -> EventHandlingUtil.populatePayloadWithHeadersData(any(DataImportEventPayload.class), any()));
+    }
+  }
+
+  private JobExecution getTestJobExecution() {
+    return new JobExecution().withId(UUID.randomUUID().toString())
+      .withJobProfileSnapshotWrapper(new ProfileSnapshotWrapper()
+        .withChildSnapshotWrappers(Collections.singletonList(new ProfileSnapshotWrapper())))
+      .withJobProfileInfo(new JobProfileInfo()
+        .withId(UUID.randomUUID().toString())
+        .withName("test").withDataType(JobProfileInfo.DataType.MARC));
+  }
+}

--- a/mod-source-record-manager-server/src/test/java/org/folio/services/util/EventHandlingUtilTest.java
+++ b/mod-source-record-manager-server/src/test/java/org/folio/services/util/EventHandlingUtilTest.java
@@ -1,0 +1,41 @@
+package org.folio.services.util;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.mock;
+
+import static org.folio.services.util.EventHandlingUtil.CORRELATION_ID_HEADER;
+
+import java.util.Map;
+import java.util.UUID;
+
+import io.vertx.core.Vertx;
+import org.junit.jupiter.api.Test;
+
+import org.folio.dataimport.util.OkapiConnectionParams;
+import org.folio.rest.jaxrs.model.DataImportEventPayload;
+
+class EventHandlingUtilTest {
+
+  @Test
+  void shouldPopulateEventPayloadWithCorrelationId() {
+    String correlationId = UUID.randomUUID().toString();
+    DataImportEventPayload eventPayload = new DataImportEventPayload();
+    OkapiConnectionParams params = new OkapiConnectionParams(Map.of(CORRELATION_ID_HEADER, correlationId), mock(Vertx.class));
+
+    EventHandlingUtil.populatePayloadWithHeadersData(eventPayload, params);
+
+    assertEquals(correlationId, eventPayload.getCorrelationId());
+  }
+
+  @Test
+  void shouldPopulateFolioEventPayloadWithCorrelationId() {
+    String correlationId = UUID.randomUUID().toString();
+    org.folio.DataImportEventPayload eventPayload = new org.folio.DataImportEventPayload();
+    OkapiConnectionParams params = new OkapiConnectionParams(Map.of(CORRELATION_ID_HEADER, correlationId), mock(Vertx.class));
+
+    EventHandlingUtil.populatePayloadWithHeadersData(eventPayload, params);
+
+    assertEquals(correlationId, eventPayload.getCorrelationId());
+  }
+
+}

--- a/mod-source-record-manager-server/src/test/java/org/folio/verticle/consumers/errorhandlers/RawMarcChunksErrorHandlerTest.java
+++ b/mod-source-record-manager-server/src/test/java/org/folio/verticle/consumers/errorhandlers/RawMarcChunksErrorHandlerTest.java
@@ -1,0 +1,33 @@
+package org.folio.verticle.consumers.errorhandlers;
+
+import static org.mockito.ArgumentMatchers.any;
+
+import io.vertx.core.json.Json;
+import io.vertx.kafka.client.consumer.KafkaConsumerRecord;
+import io.vertx.kafka.client.consumer.impl.KafkaConsumerRecordImpl;
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+import org.folio.DataImportEventPayload;
+import org.folio.rest.jaxrs.model.Event;
+import org.folio.services.util.EventHandlingUtil;
+
+class RawMarcChunksErrorHandlerTest {
+
+  private final RawMarcChunksErrorHandler errorHandler = new RawMarcChunksErrorHandler();
+
+  @Test
+  void shouldPopulateEventPayloadWithHeadersData() {
+
+    KafkaConsumerRecord<String, String> record = new KafkaConsumerRecordImpl<>(new ConsumerRecord<>("topic",
+      0, 0, "key", Json.encode(new Event())));
+
+    try (var mockedStatic = Mockito.mockStatic(EventHandlingUtil.class)) {
+      errorHandler.handle(new Throwable(), record);
+
+      mockedStatic.verify(() -> EventHandlingUtil.populatePayloadWithHeadersData(any(DataImportEventPayload.class), any()));
+    }
+  }
+
+}

--- a/mod-source-record-manager-server/src/test/java/org/folio/verticle/consumers/errorhandlers/StoredRecordChunksErrorHandlerTest.java
+++ b/mod-source-record-manager-server/src/test/java/org/folio/verticle/consumers/errorhandlers/StoredRecordChunksErrorHandlerTest.java
@@ -1,0 +1,45 @@
+package org.folio.verticle.consumers.errorhandlers;
+
+import static org.mockito.ArgumentMatchers.any;
+
+import static org.folio.rest.jaxrs.model.Record.RecordType.MARC_BIB;
+
+import java.util.Collections;
+
+import io.vertx.core.Future;
+import io.vertx.core.json.Json;
+import io.vertx.kafka.client.consumer.KafkaConsumerRecord;
+import io.vertx.kafka.client.consumer.impl.KafkaConsumerRecordImpl;
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+import org.folio.rest.jaxrs.model.DataImportEventPayload;
+import org.folio.rest.jaxrs.model.Event;
+import org.folio.rest.jaxrs.model.Record;
+import org.folio.rest.jaxrs.model.RecordsBatchResponse;
+import org.folio.services.util.EventHandlingUtil;
+
+class StoredRecordChunksErrorHandlerTest {
+
+  private final StoredRecordChunksErrorHandler errorHandler = new StoredRecordChunksErrorHandler(null, null);
+
+  @Test
+  void shouldPopulateEventPayloadWithHeadersData() {
+    Record record = new Record().withRecordType(MARC_BIB);
+    Event event = new Event().withEventPayload(Json.encode(new RecordsBatchResponse()
+      .withRecords(Collections.singletonList(record))));
+    KafkaConsumerRecord<String, String> kafkaRecord = new KafkaConsumerRecordImpl<>(new ConsumerRecord<>("topic",
+      0, 0, "key", Json.encode(event)));
+
+    try (var mockedStatic = Mockito.mockStatic(EventHandlingUtil.class)) {
+      mockedStatic.when(() -> EventHandlingUtil.sendEventToKafka(any(), any(), any(), any(), any(), any()))
+        .thenReturn(Future.succeededFuture(true));
+
+      errorHandler.handle(new Throwable(), kafkaRecord);
+
+      mockedStatic.verify(() -> EventHandlingUtil.populatePayloadWithHeadersData(any(DataImportEventPayload.class), any()));
+    }
+  }
+
+}

--- a/mod-source-record-manager-server/src/test/resources/org/folio/mapping/mappedBibRecord.json
+++ b/mod-source-record-manager-server/src/test/resources/org/folio/mapping/mappedBibRecord.json
@@ -137,6 +137,7 @@
       "staffOnly": false
     }
   ],
+  "administrativeNotes": [],
   "statisticalCodeIds": [],
   "natureOfContentTermIds": [],
   "precedingTitles": [],


### PR DESCRIPTION
## Purpose
`correlationId` header if it exists should be passed to all data-import events. It's needed to track events that are related to the same action.

## Approach
- Populate dataImportPayload with correlationId value
- Update tests
- Increase data-import-processing-core version

## Learning
[MODSOURMAN-781](https://issues.folio.org/browse/MODSOURMAN-781)
