### PR TITLE
MODSOURMAN-784 The status of instance is not updated in the Import log after uploading MARC file for modify

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -12,6 +12,7 @@
 * [MODSOURMAN-763](https://issues.folio.org/browse/MODSOURMAN-763) Weird log display for a job that updates or creates
 * [MODSOURMAN-767](https://issues.folio.org/browse/MODSOURMAN-767) Fix state is "In progress" after successful quickMarc update
 * [MODSOURMAN-778](https://issues.folio.org/browse/MODSOURMAN-778) Add permission for Purchase Order Lines matching
+* [MODSOURMAN-784](https://issues.folio.org/browse/MODSOURMAN-784) The status of instance is not updated in the Import log after uploading MARC file for modify
 
 ## 2022-xx-xx v3.3.3-SNAPSHOT
 * [MODSOURMAN-746](https://issues.folio.org/browse/MODSOURMAN-746) Avoid creation of trigger for old job progress table which cases an error during jobProgress saving

--- a/mod-source-record-manager-server/src/main/java/org/folio/verticle/consumers/util/JournalParams.java
+++ b/mod-source-record-manager-server/src/main/java/org/folio/verticle/consumers/util/JournalParams.java
@@ -104,7 +104,7 @@ public class JournalParams {
       @Override
       public Optional<JournalParams> getJournalParams(DataImportEventPayload eventPayload) {
         return Optional.of(new JournalParams(JournalRecord.ActionType.UPDATE,
-          JournalRecord.EntityType.MARC_BIBLIOGRAPHIC,
+          JournalRecord.EntityType.INSTANCE,
           JournalRecord.ActionStatus.COMPLETED));
       }
     },

--- a/mod-source-record-manager-server/src/test/java/org/folio/verticle/consumers/util/JournalParamsTest.java
+++ b/mod-source-record-manager-server/src/test/java/org/folio/verticle/consumers/util/JournalParamsTest.java
@@ -243,7 +243,7 @@ public class JournalParamsTest {
 
   @Test
   public void shouldPopulateEntityTypeMarcBibWhenEventTypeIsDiSrsMarcBibReadyForPostProcessing() {
-    populateEntityTypeAndActionTypeByEventType(DI_SRS_MARC_BIB_RECORD_MODIFIED_READY_FOR_POST_PROCESSING, JournalRecord.EntityType.MARC_BIBLIOGRAPHIC, JournalRecord.ActionType.UPDATE);
+    populateEntityTypeAndActionTypeByEventType(DI_SRS_MARC_BIB_RECORD_MODIFIED_READY_FOR_POST_PROCESSING, JournalRecord.EntityType.INSTANCE, JournalRecord.ActionType.UPDATE);
   }
 
   @Test


### PR DESCRIPTION
### Purpose
Allow instance links to be displayed in DI logs after modifying marc bib record.
![image](https://user-images.githubusercontent.com/89521577/165110940-c3dd4539-146a-4c6a-870c-7ba4c181c52c.png)


### Approach
Change entity type to INSTANCE for DI_SRS_MARC_BIB_RECORD_MODIFIED_READY_FOR_POST_PROCESSING event.
### Learning
[MODSOURMAN-784](https://issues.folio.org/browse/MODSOURMAN-784)