### PR TITLE
MODSOURMAN-771 - Added New Column is_deleted in jobexecution table

### DIFF
--- a/mod-source-record-manager-server/src/main/resources/templates/db_scripts/schema.json
+++ b/mod-source-record-manager-server/src/main/resources/templates/db_scripts/schema.json
@@ -179,6 +179,11 @@
       "run": "after",
       "snippet": "ALTER TABLE job_execution ADD COLUMN IF NOT EXISTS job_profile_hidden BOOLEAN; UPDATE job_execution SET job_profile_hidden = 'f'; ALTER TABLE job_execution ALTER COLUMN job_profile_hidden SET NOT NULL; ALTER TABLE job_execution ALTER COLUMN job_profile_hidden SET DEFAULT FALSE;",
       "fromModuleVersion": "mod-source-record-manager-3.4.0"
+    },
+    {
+      "run": "after",
+      "snippet": "ALTER TABLE job_execution ADD COLUMN IF NOT EXISTS is_deleted BOOLEAN; UPDATE job_execution SET is_deleted = FALSE; ALTER TABLE job_execution ALTER COLUMN is_deleted SET NOT NULL; ALTER TABLE job_execution ALTER COLUMN is_deleted SET DEFAULT FALSE;",
+      "fromModuleVersion": "mod-source-record-manager-3.4.0"
     }
   ]
 }


### PR DESCRIPTION
## Purpose
This column will be used to mark the records as soft-deleted and a later batch will process to hard delete these records.

## Approach
Due to the change in job_execution statuses, we could have faced the issue of directly deleting the records from multiple tables.
Hence, a batch job would be required to delete the records marked for deletion

#### TODOS and Open Questions
- [x] This change works locally.

