### PR TITLE
MODSOURMAN-791 Reduce parsed record string conversion into MARC4J record

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -16,6 +16,7 @@
 * [MODSOURMAN-784](https://issues.folio.org/browse/MODSOURMAN-784) The status of instance is not updated in the Import log after uploading MARC file for modify
 * [MODSOURMAN-780](https://issues.folio.org/browse/MODSOURMAN-780) Implement endpoint for adding summary for work accomplished in a job
 * [MODSOURMAN-779](https://issues.folio.org/browse/MODSOURMAN-779) Add "CANCELLED" status for Import jobs that are stopped by users.
+* [MODSOURMAN-791](https://issues.folio.org/browse/MODSOURMAN-791) Reduce Conversion of Parsed Content Into A MARC4J Record
 
 ## 2022-xx-xx v3.3.3-SNAPSHOT
 * [MODSOURMAN-746](https://issues.folio.org/browse/MODSOURMAN-746) Avoid creation of trigger for old job progress table which cases an error during jobProgress saving

--- a/mod-source-record-manager-server/src/main/java/org/folio/services/JobMonitoringServiceImpl.java
+++ b/mod-source-record-manager-server/src/main/java/org/folio/services/JobMonitoringServiceImpl.java
@@ -1,6 +1,7 @@
 package org.folio.services;
 
 import java.time.LocalDateTime;
+import java.time.ZoneOffset;
 import java.time.temporal.ChronoUnit;
 import java.util.Date;
 import java.util.List;
@@ -39,7 +40,7 @@ public class JobMonitoringServiceImpl implements JobMonitoringService {
 
   @Override
   public Future<List<JobMonitoring>> getInactiveJobMonitors(Long maxInactiveInterval, String tenantId) {
-    var lastInactiveDateTime = LocalDateTime.now().minus(maxInactiveInterval, ChronoUnit.MILLIS);
+    var lastInactiveDateTime = LocalDateTime.now(ZoneOffset.UTC).minus(maxInactiveInterval, ChronoUnit.MILLIS);
     return jobMonitoringDao.findByNotificationBeforeTimestamp(lastInactiveDateTime, false, tenantId);
   }
 

--- a/mod-source-record-manager-server/src/main/java/org/folio/services/afterprocessing/AdditionalFieldsUtil.java
+++ b/mod-source-record-manager-server/src/main/java/org/folio/services/afterprocessing/AdditionalFieldsUtil.java
@@ -12,7 +12,6 @@ import org.apache.commons.collections4.CollectionUtils;
 import org.folio.rest.jaxrs.model.Record;
 import org.marc4j.MarcJsonReader;
 import org.marc4j.MarcJsonWriter;
-import org.marc4j.MarcReader;
 import org.marc4j.MarcStreamWriter;
 import org.marc4j.MarcWriter;
 import org.marc4j.marc.ControlField;
@@ -26,7 +25,6 @@ import java.io.ByteArrayOutputStream;
 import java.nio.charset.StandardCharsets;
 import java.util.List;
 import java.util.Objects;
-import java.util.concurrent.ExecutionException;
 
 import static org.apache.commons.lang3.StringUtils.isNotEmpty;
 
@@ -327,7 +325,8 @@ public final class AdditionalFieldsUtil {
 
   /**
    * Generate a {@link org.marc4j.marc.Record} from {@link Record} passed in.
-   * Will return null when there is no parsed content string present
+   * Will return null when there is no parsed content string present. Generated MARC record will be saved into cache if
+   * its parsed content string is not present in the cache as a key
    */
   private static org.marc4j.marc.Record computeMarcRecord(Record record) {
     if (record != null

--- a/mod-source-record-manager-server/src/main/java/org/folio/services/afterprocessing/AdditionalFieldsUtil.java
+++ b/mod-source-record-manager-server/src/main/java/org/folio/services/afterprocessing/AdditionalFieldsUtil.java
@@ -62,7 +62,7 @@ public final class AdditionalFieldsUtil {
       };
 
     parsedRecordContentCache = CacheBuilder.newBuilder()
-      .maximumSize(25)
+      .maximumSize(2000)
       // weak keys allows parsed content strings that are used as keys to be garbage collected, even it is still
       // referenced by the cache.
       .weakKeys()

--- a/mod-source-record-manager-server/src/main/java/org/folio/services/afterprocessing/AdditionalFieldsUtil.java
+++ b/mod-source-record-manager-server/src/main/java/org/folio/services/afterprocessing/AdditionalFieldsUtil.java
@@ -40,8 +40,8 @@ public final class AdditionalFieldsUtil {
 
   private static final Logger LOGGER = LogManager.getLogger();
 
-  private static CacheLoader<Object, org.marc4j.marc.Record> parsedRecordContentCacheLoader;
-  private static LoadingCache<Object, org.marc4j.marc.Record> parsedRecordContentCache;
+  private final static CacheLoader<Object, org.marc4j.marc.Record> parsedRecordContentCacheLoader;
+  private final static LoadingCache<Object, org.marc4j.marc.Record> parsedRecordContentCache;
 
   static {
     // this function is executed when creating a new item to be saved in the cache.
@@ -115,7 +115,11 @@ public final class AdditionalFieldsUtil {
           // use stream writer to recalculate leader
           streamWriter.write(marcRecord);
           jsonWriter.write(marcRecord);
-          record.setParsedRecord(record.getParsedRecord().withContent(new JsonObject(new String(os.toByteArray())).encode()));
+
+          String parsedContentString = new JsonObject(os.toString()).encode();
+          // save parsed content string to cache then set it on the record
+          parsedRecordContentCache.put(parsedContentString, marcRecord);
+          record.setParsedRecord(record.getParsedRecord().withContent(parsedContentString));
           result = true;
         }
       }
@@ -146,10 +150,14 @@ public final class AdditionalFieldsUtil {
         // use stream writer to recalculate leader
         streamWriter.write(marcRecord);
         jsonWriter.write(marcRecord);
+
+        String parsedContentString = new JsonObject(os.toString()).encode();
+        // save parsed content string to cache then set it on the record
+        parsedRecordContentCache.put(parsedContentString, marcRecord);
         record.setParsedRecord(
             record
                 .getParsedRecord()
-                .withContent(new JsonObject(new String(os.toByteArray())).encode()));
+                .withContent(parsedContentString));
         result = true;
       }
     } catch (Exception e) {
@@ -180,10 +188,14 @@ public final class AdditionalFieldsUtil {
         // use stream writer to recalculate leader
         streamWriter.write(marcRecord);
         jsonWriter.write(marcRecord);
+
+        String parsedContentString = new JsonObject(os.toString()).encode();
+        // save parsed content string to cache then set it on the record
+        parsedRecordContentCache.put(parsedContentString, marcRecord);
         record.setParsedRecord(
             record
                 .getParsedRecord()
-                .withContent(new JsonObject(new String(os.toByteArray())).encode()));
+                .withContent(parsedContentString));
         result = true;
       }
     } catch (Exception e) {
@@ -314,7 +326,7 @@ public final class AdditionalFieldsUtil {
         record.setParsedRecord(
             record
                 .getParsedRecord()
-                .withContent(new JsonObject(new String(baos.toByteArray())).encode()));
+                .withContent(new JsonObject(baos.toString()).encode()));
         result = true;
       }
     } catch (Exception e) {

--- a/mod-source-record-manager-server/src/main/java/org/folio/services/afterprocessing/AdditionalFieldsUtil.java
+++ b/mod-source-record-manager-server/src/main/java/org/folio/services/afterprocessing/AdditionalFieldsUtil.java
@@ -46,6 +46,8 @@ public final class AdditionalFieldsUtil {
   private static LoadingCache<Object, org.marc4j.marc.Record> parsedRecordContentCache;
 
   static {
+    // this function is executed when creating a new item to be saved in the cache.
+    // In this case this is a MARC4J Record
     parsedRecordContentCacheLoader =
       new CacheLoader<>() {
         @Override
@@ -63,6 +65,8 @@ public final class AdditionalFieldsUtil {
 
     parsedRecordContentCache = CacheBuilder.newBuilder()
       .maximumSize(25)
+      // weak keys allows parsed content strings that are used as keys to be garbage collected, even it is still
+      // referenced by the cache.
       .weakKeys()
       .recordStats()
       .build(parsedRecordContentCacheLoader);
@@ -71,6 +75,9 @@ public final class AdditionalFieldsUtil {
   private AdditionalFieldsUtil() {
   }
 
+  /**
+   * Get cache stats
+   */
   static CacheStats getCacheStats() {
     return parsedRecordContentCache.stats();
   }
@@ -318,6 +325,10 @@ public final class AdditionalFieldsUtil {
     return result;
   }
 
+  /**
+   * Generate a {@link org.marc4j.marc.Record} from {@link Record} passed in.
+   * Will return null when there is no parsed content string present
+   */
   private static org.marc4j.marc.Record computeMarcRecord(Record record) {
     if (record != null
         && record.getParsedRecord() != null

--- a/mod-source-record-manager-server/src/main/java/org/folio/services/afterprocessing/AdditionalFieldsUtil.java
+++ b/mod-source-record-manager-server/src/main/java/org/folio/services/afterprocessing/AdditionalFieldsUtil.java
@@ -323,10 +323,14 @@ public final class AdditionalFieldsUtil {
         // use stream writer to recalculate leader
         marcStreamWriter.write(marcRecord);
         marcJsonWriter.write(marcRecord);
+        
+        String parsedContentString = new JsonObject(baos.toString()).encode();
+        // save parsed content string to cache then set it on the record
+        parsedRecordContentCache.put(parsedContentString, marcRecord);
         record.setParsedRecord(
-            record
-                .getParsedRecord()
-                .withContent(new JsonObject(baos.toString()).encode()));
+          record
+            .getParsedRecord()
+            .withContent(parsedContentString));
         result = true;
       }
     } catch (Exception e) {

--- a/mod-source-record-manager-server/src/main/java/org/folio/services/afterprocessing/AdditionalFieldsUtil.java
+++ b/mod-source-record-manager-server/src/main/java/org/folio/services/afterprocessing/AdditionalFieldsUtil.java
@@ -96,7 +96,7 @@ public final class AdditionalFieldsUtil {
         MarcWriter streamWriter = new MarcStreamWriter(new ByteArrayOutputStream());
         MarcJsonWriter jsonWriter = new MarcJsonWriter(os);
         MarcFactory factory = MarcFactory.newInstance();
-        org.marc4j.marc.Record marcRecord = parsedRecordContentCache.get(record.getParsedRecord().getContent());
+        org.marc4j.marc.Record marcRecord = computeMarcRecord(record);
         if (marcRecord != null) {
           VariableField variableField = getSingleFieldByIndicators(marcRecord.getVariableFields(field), INDICATOR, INDICATOR);
           DataField dataField;

--- a/mod-source-record-manager-server/src/main/java/org/folio/services/afterprocessing/AdditionalFieldsUtil.java
+++ b/mod-source-record-manager-server/src/main/java/org/folio/services/afterprocessing/AdditionalFieldsUtil.java
@@ -5,6 +5,7 @@ import com.google.common.cache.CacheLoader;
 import com.google.common.cache.CacheStats;
 import com.google.common.cache.LoadingCache;
 import io.vertx.core.json.JsonObject;
+import org.apache.commons.lang3.StringUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.apache.commons.collections4.CollectionUtils;
@@ -63,13 +64,14 @@ public final class AdditionalFieldsUtil {
     parsedRecordContentCache = CacheBuilder.newBuilder()
       .maximumSize(25)
       .weakKeys()
+      .recordStats()
       .build(parsedRecordContentCacheLoader);
   }
 
   private AdditionalFieldsUtil() {
   }
 
-  public static CacheStats getCacheStats() {
+  static CacheStats getCacheStats() {
     return parsedRecordContentCache.stats();
   }
 
@@ -319,10 +321,10 @@ public final class AdditionalFieldsUtil {
   private static org.marc4j.marc.Record computeMarcRecord(Record record) {
     if (record != null
         && record.getParsedRecord() != null
-        && record.getParsedRecord().getContent() != null) {
+        && !StringUtils.isBlank(record.getParsedRecord().getContent().toString())) {
       try {
         return parsedRecordContentCache.get(record.getParsedRecord().getContent());
-      } catch (ExecutionException e) {
+      } catch (Exception e) {
         LOGGER.error("Error during the transformation to marc record", e);
         return null;
       }

--- a/mod-source-record-manager-server/src/test/java/org/folio/services/afterprocessing/AdditionalFieldsUtilTest.java
+++ b/mod-source-record-manager-server/src/test/java/org/folio/services/afterprocessing/AdditionalFieldsUtilTest.java
@@ -1,5 +1,6 @@
 package org.folio.services.afterprocessing;
 
+import com.google.common.cache.CacheStats;
 import io.vertx.core.json.JsonArray;
 import io.vertx.core.json.JsonObject;
 import org.apache.commons.lang3.StringUtils;
@@ -25,6 +26,8 @@ import static org.folio.services.afterprocessing.AdditionalFieldsUtil.addFieldTo
 import static org.folio.services.afterprocessing.AdditionalFieldsUtil.getControlFieldValue;
 import static org.folio.services.afterprocessing.AdditionalFieldsUtil.isFieldExist;
 import static org.folio.services.afterprocessing.AdditionalFieldsUtil.removeField;
+import static org.folio.services.afterprocessing.AdditionalFieldsUtil.getCacheStats;
+import static org.folio.services.afterprocessing.AdditionalFieldsUtil.getValue;
 import static org.hamcrest.Matchers.lessThanOrEqualTo;
 
 @RunWith(BlockJUnit4ClassRunner.class)
@@ -284,5 +287,101 @@ public class AdditionalFieldsUtilTest {
     // then
     Assert.assertTrue(added);
     Assert.assertEquals(expectedParsedContent, parsedRecord.getContent());
+  }
+
+  @Test
+  public void caching() throws IOException {
+    // given
+    String parsedRecordContent = TestUtil.readFileFromPath(PARSED_RECORD_PATH);
+    ParsedRecord parsedRecord = new ParsedRecord();
+    parsedRecord.setContent(parsedRecordContent);
+    Record record = new Record().withId(UUID.randomUUID().toString()).withParsedRecord(parsedRecord);
+    String instanceId = UUID.randomUUID().toString();
+
+    // record with null parsed content
+    Assert.assertFalse(
+        isFieldExist(new Record().withId(UUID.randomUUID().toString()), "035", 'a', instanceId));
+    CacheStats cacheStats = getCacheStats();
+    Assert.assertEquals(0, cacheStats.requestCount());
+    Assert.assertEquals(0, cacheStats.hitCount());
+    Assert.assertEquals(0, cacheStats.missCount());
+    Assert.assertEquals(0, cacheStats.loadCount());
+    // record with empty parsed content
+    Assert.assertFalse(
+        isFieldExist(
+            new Record()
+                .withId(UUID.randomUUID().toString())
+                .withParsedRecord(new ParsedRecord().withContent("")),
+            "035",
+            'a',
+            instanceId));
+    cacheStats = getCacheStats();
+    Assert.assertEquals(0, cacheStats.requestCount());
+    Assert.assertEquals(0, cacheStats.hitCount());
+    Assert.assertEquals(0, cacheStats.missCount());
+    Assert.assertEquals(0, cacheStats.loadCount());
+    // record with bad parsed content
+    Assert.assertFalse(
+      isFieldExist(
+        new Record()
+          .withId(UUID.randomUUID().toString())
+          .withParsedRecord(new ParsedRecord().withContent("test")),
+        "035",
+        'a',
+        instanceId));
+    cacheStats = getCacheStats();
+    Assert.assertEquals(1, cacheStats.requestCount());
+    Assert.assertEquals(0, cacheStats.hitCount());
+    Assert.assertEquals(1, cacheStats.missCount());
+    Assert.assertEquals(1, cacheStats.loadCount());
+    // does field exists?
+    Assert.assertFalse(isFieldExist(record, "035", 'a', instanceId));
+    cacheStats = getCacheStats();
+    Assert.assertEquals(2, cacheStats.requestCount());
+    Assert.assertEquals(0, cacheStats.hitCount());
+    Assert.assertEquals(2, cacheStats.missCount());
+    Assert.assertEquals(2, cacheStats.loadCount());
+    // update field
+    addDataFieldToMarcRecord(record, "035", ' ', ' ', 'a', instanceId);
+    cacheStats = getCacheStats();
+    Assert.assertEquals(3, cacheStats.requestCount());
+    Assert.assertEquals(1, cacheStats.hitCount());
+    Assert.assertEquals(2, cacheStats.missCount());
+    Assert.assertEquals(2, cacheStats.loadCount());
+    // verify that field exists
+    Assert.assertTrue(isFieldExist(record, "035", 'a', instanceId));
+    cacheStats = getCacheStats();
+    Assert.assertEquals(4, cacheStats.requestCount());
+    Assert.assertEquals(1, cacheStats.hitCount());
+    Assert.assertEquals(3, cacheStats.missCount());
+    Assert.assertEquals(3, cacheStats.loadCount());
+    // verify that field exists again
+    Assert.assertTrue(isFieldExist(record, "035", 'a', instanceId));
+    cacheStats = getCacheStats();
+    Assert.assertEquals(5, cacheStats.requestCount());
+    Assert.assertEquals(2, cacheStats.hitCount());
+    Assert.assertEquals(3, cacheStats.missCount());
+    Assert.assertEquals(3, cacheStats.loadCount());
+    // get the field
+    Assert.assertEquals(instanceId, getValue(record, "035",  'a'));
+    cacheStats = getCacheStats();
+    Assert.assertEquals(6, cacheStats.requestCount());
+    Assert.assertEquals(3, cacheStats.hitCount());
+    Assert.assertEquals(3, cacheStats.missCount());
+    Assert.assertEquals(3, cacheStats.loadCount());
+    // get the control field
+    Assert.assertEquals(null, getControlFieldValue(record, "035"));
+    cacheStats = getCacheStats();
+    Assert.assertEquals(7, cacheStats.requestCount());
+    Assert.assertEquals(4, cacheStats.hitCount());
+    Assert.assertEquals(3, cacheStats.missCount());
+    Assert.assertEquals(3, cacheStats.loadCount());
+    // remove the field
+    Assert.assertTrue(removeField(record, "035"));
+    cacheStats = getCacheStats();
+    Assert.assertEquals(8, cacheStats.requestCount());
+    Assert.assertEquals(5, cacheStats.hitCount());
+    Assert.assertEquals(3, cacheStats.missCount());
+    Assert.assertEquals(3, cacheStats.loadCount());
   }
 }

--- a/mod-source-record-manager-server/src/test/java/org/folio/services/afterprocessing/AdditionalFieldsUtilTest.java
+++ b/mod-source-record-manager-server/src/test/java/org/folio/services/afterprocessing/AdditionalFieldsUtilTest.java
@@ -1,6 +1,6 @@
 package org.folio.services.afterprocessing;
 
-import com.google.common.cache.CacheStats;
+import com.github.benmanes.caffeine.cache.stats.CacheStats;
 import io.vertx.core.json.JsonArray;
 import io.vertx.core.json.JsonObject;
 import org.apache.commons.lang3.StringUtils;

--- a/mod-source-record-manager-server/src/test/java/org/folio/services/afterprocessing/AdditionalFieldsUtilTest.java
+++ b/mod-source-record-manager-server/src/test/java/org/folio/services/afterprocessing/AdditionalFieldsUtilTest.java
@@ -353,36 +353,36 @@ public class AdditionalFieldsUtilTest {
     Assert.assertTrue(isFieldExist(record, "035", 'a', instanceId));
     cacheStats = getCacheStats().minus(initialCacheStats);
     Assert.assertEquals(4, cacheStats.requestCount());
-    Assert.assertEquals(1, cacheStats.hitCount());
-    Assert.assertEquals(3, cacheStats.missCount());
-    Assert.assertEquals(3, cacheStats.loadCount());
+    Assert.assertEquals(2, cacheStats.hitCount());
+    Assert.assertEquals(2, cacheStats.missCount());
+    Assert.assertEquals(2, cacheStats.loadCount());
     // verify that field exists again
     Assert.assertTrue(isFieldExist(record, "035", 'a', instanceId));
     cacheStats = getCacheStats().minus(initialCacheStats);
     Assert.assertEquals(5, cacheStats.requestCount());
-    Assert.assertEquals(2, cacheStats.hitCount());
-    Assert.assertEquals(3, cacheStats.missCount());
-    Assert.assertEquals(3, cacheStats.loadCount());
+    Assert.assertEquals(3, cacheStats.hitCount());
+    Assert.assertEquals(2, cacheStats.missCount());
+    Assert.assertEquals(2, cacheStats.loadCount());
     // get the field
     Assert.assertEquals(instanceId, getValue(record, "035",  'a'));
     cacheStats = getCacheStats().minus(initialCacheStats);
     Assert.assertEquals(6, cacheStats.requestCount());
-    Assert.assertEquals(3, cacheStats.hitCount());
-    Assert.assertEquals(3, cacheStats.missCount());
-    Assert.assertEquals(3, cacheStats.loadCount());
+    Assert.assertEquals(4, cacheStats.hitCount());
+    Assert.assertEquals(2, cacheStats.missCount());
+    Assert.assertEquals(2, cacheStats.loadCount());
     // get the control field
     Assert.assertEquals(null, getControlFieldValue(record, "035"));
     cacheStats = getCacheStats().minus(initialCacheStats);
     Assert.assertEquals(7, cacheStats.requestCount());
-    Assert.assertEquals(4, cacheStats.hitCount());
-    Assert.assertEquals(3, cacheStats.missCount());
-    Assert.assertEquals(3, cacheStats.loadCount());
+    Assert.assertEquals(5, cacheStats.hitCount());
+    Assert.assertEquals(2, cacheStats.missCount());
+    Assert.assertEquals(2, cacheStats.loadCount());
     // remove the field
     Assert.assertTrue(removeField(record, "035"));
     cacheStats = getCacheStats().minus(initialCacheStats);
     Assert.assertEquals(8, cacheStats.requestCount());
-    Assert.assertEquals(5, cacheStats.hitCount());
-    Assert.assertEquals(3, cacheStats.missCount());
-    Assert.assertEquals(3, cacheStats.loadCount());
+    Assert.assertEquals(6, cacheStats.hitCount());
+    Assert.assertEquals(2, cacheStats.missCount());
+    Assert.assertEquals(2, cacheStats.loadCount());
   }
 }

--- a/mod-source-record-manager-server/src/test/java/org/folio/services/afterprocessing/AdditionalFieldsUtilTest.java
+++ b/mod-source-record-manager-server/src/test/java/org/folio/services/afterprocessing/AdditionalFieldsUtilTest.java
@@ -298,11 +298,12 @@ public class AdditionalFieldsUtilTest {
     Record record = new Record().withId(UUID.randomUUID().toString()).withParsedRecord(parsedRecord);
     String instanceId = UUID.randomUUID().toString();
 
+    CacheStats initialCacheStats = getCacheStats();
+
     // record with null parsed content
     Assert.assertFalse(
         isFieldExist(new Record().withId(UUID.randomUUID().toString()), "035", 'a', instanceId));
-    CacheStats cacheStats = getCacheStats();
-    Assert.assertEquals(0, cacheStats.requestCount());
+    CacheStats cacheStats = getCacheStats().minus(initialCacheStats);
     Assert.assertEquals(0, cacheStats.hitCount());
     Assert.assertEquals(0, cacheStats.missCount());
     Assert.assertEquals(0, cacheStats.loadCount());
@@ -315,7 +316,7 @@ public class AdditionalFieldsUtilTest {
             "035",
             'a',
             instanceId));
-    cacheStats = getCacheStats();
+    cacheStats = getCacheStats().minus(initialCacheStats);
     Assert.assertEquals(0, cacheStats.requestCount());
     Assert.assertEquals(0, cacheStats.hitCount());
     Assert.assertEquals(0, cacheStats.missCount());
@@ -329,56 +330,56 @@ public class AdditionalFieldsUtilTest {
         "035",
         'a',
         instanceId));
-    cacheStats = getCacheStats();
+    cacheStats = getCacheStats().minus(initialCacheStats);
     Assert.assertEquals(1, cacheStats.requestCount());
     Assert.assertEquals(0, cacheStats.hitCount());
     Assert.assertEquals(1, cacheStats.missCount());
     Assert.assertEquals(1, cacheStats.loadCount());
     // does field exists?
     Assert.assertFalse(isFieldExist(record, "035", 'a', instanceId));
-    cacheStats = getCacheStats();
+    cacheStats = getCacheStats().minus(initialCacheStats);
     Assert.assertEquals(2, cacheStats.requestCount());
     Assert.assertEquals(0, cacheStats.hitCount());
     Assert.assertEquals(2, cacheStats.missCount());
     Assert.assertEquals(2, cacheStats.loadCount());
     // update field
     addDataFieldToMarcRecord(record, "035", ' ', ' ', 'a', instanceId);
-    cacheStats = getCacheStats();
+    cacheStats = getCacheStats().minus(initialCacheStats);
     Assert.assertEquals(3, cacheStats.requestCount());
     Assert.assertEquals(1, cacheStats.hitCount());
     Assert.assertEquals(2, cacheStats.missCount());
     Assert.assertEquals(2, cacheStats.loadCount());
     // verify that field exists
     Assert.assertTrue(isFieldExist(record, "035", 'a', instanceId));
-    cacheStats = getCacheStats();
+    cacheStats = getCacheStats().minus(initialCacheStats);
     Assert.assertEquals(4, cacheStats.requestCount());
     Assert.assertEquals(1, cacheStats.hitCount());
     Assert.assertEquals(3, cacheStats.missCount());
     Assert.assertEquals(3, cacheStats.loadCount());
     // verify that field exists again
     Assert.assertTrue(isFieldExist(record, "035", 'a', instanceId));
-    cacheStats = getCacheStats();
+    cacheStats = getCacheStats().minus(initialCacheStats);
     Assert.assertEquals(5, cacheStats.requestCount());
     Assert.assertEquals(2, cacheStats.hitCount());
     Assert.assertEquals(3, cacheStats.missCount());
     Assert.assertEquals(3, cacheStats.loadCount());
     // get the field
     Assert.assertEquals(instanceId, getValue(record, "035",  'a'));
-    cacheStats = getCacheStats();
+    cacheStats = getCacheStats().minus(initialCacheStats);
     Assert.assertEquals(6, cacheStats.requestCount());
     Assert.assertEquals(3, cacheStats.hitCount());
     Assert.assertEquals(3, cacheStats.missCount());
     Assert.assertEquals(3, cacheStats.loadCount());
     // get the control field
     Assert.assertEquals(null, getControlFieldValue(record, "035"));
-    cacheStats = getCacheStats();
+    cacheStats = getCacheStats().minus(initialCacheStats);
     Assert.assertEquals(7, cacheStats.requestCount());
     Assert.assertEquals(4, cacheStats.hitCount());
     Assert.assertEquals(3, cacheStats.missCount());
     Assert.assertEquals(3, cacheStats.loadCount());
     // remove the field
     Assert.assertTrue(removeField(record, "035"));
-    cacheStats = getCacheStats();
+    cacheStats = getCacheStats().minus(initialCacheStats);
     Assert.assertEquals(8, cacheStats.requestCount());
     Assert.assertEquals(5, cacheStats.hitCount());
     Assert.assertEquals(3, cacheStats.missCount());


### PR DESCRIPTION
## Purpose
In the AdditionalFieldsUtil class, there are numerous methods used to modify/introspect MARC records. Each of these methods coverts the parsed content represented as a JSON string into a MARC4J reader to generate a MARC4J record. This conversion is compute intensive. The aim is to reduce the conversion from parsed content string to MARC4J record.

## Approach
Cache MARC4J records with the originating parsed content string as its key. This cache process is not perfect but works well since any change, such as updating a subfield, generate a brand new parsed content string. Using the whole parsed content string as a key reduces the possibility of the cache returning stale data. The immutability of the String class in Java is relied upon to make this work.

The cache is limited to 25 items for now. That is, only 25 MARC4J records will be cached. New MARC4J records will evict old MARC4J records to limit memory overruns. The life span of a parsed content string within SRM is short. Caching this way should reduce computation by over 50%.

## Learning
https://issues.folio.org/browse/MODSOURMAN-791
