### PR TITLE
MODQM-224 MARC bib record | Source does not reflect last person to update record when the update is via data import

### DIFF
--- a/mod-source-record-manager-server/src/main/java/org/folio/services/ChangeEngineServiceImpl.java
+++ b/mod-source-record-manager-server/src/main/java/org/folio/services/ChangeEngineServiceImpl.java
@@ -190,11 +190,9 @@ public class ChangeEngineServiceImpl implements ChangeEngineService {
 
   private Future<Boolean> updateRecords(List<Record> records, JobExecution jobExecution, OkapiConnectionParams params) {
     LOGGER.info("Records have not been saved in record-storage, because job contains action for Marc update");
-    records.forEach(parsedRecord -> parsedRecord.setMetadata(new Metadata().withCreatedByUserId(jobExecution.getUserId())
-      .withUpdatedByUserId(jobExecution.getUserId())
-      .withUpdatedByUsername(jobExecution.getRunBy().getFirstName())
-      .withCreatedByUsername(jobExecution.getRunBy().getFirstName())));
-
+    records.forEach(parsedRecord -> parsedRecord.setMetadata(new Metadata().withUpdatedByUserId(jobExecution.getUserId())
+      .withUpdatedByUsername((jobExecution.getRunBy() != null && jobExecution.getRunBy().getFirstName() != null)
+                             ? jobExecution.getRunBy().getFirstName():"SYSTEM")));
     return recordsPublishingService
       .sendEventsWithRecords(records, jobExecution.getId(), params, DI_MARC_FOR_UPDATE_RECEIVED.value());
   }
@@ -558,9 +556,8 @@ public class ChangeEngineServiceImpl implements ChangeEngineService {
       return Future.succeededFuture();
     }
     parsedRecords.forEach(parsedRecord -> parsedRecord.setMetadata(new Metadata().withCreatedByUserId(jobExecution.getUserId())
-      .withUpdatedByUserId(jobExecution.getUserId())
-      .withUpdatedByUsername(jobExecution.getRunBy().getFirstName())
-      .withCreatedByUsername(jobExecution.getRunBy().getFirstName())));
+      .withCreatedByUsername((jobExecution.getRunBy() != null && jobExecution.getRunBy().getFirstName() != null)
+                             ? jobExecution.getRunBy().getFirstName():"SYSTEM")));
     RecordCollection recordCollection = new RecordCollection()
       .withRecords(parsedRecords)
       .withTotalRecords(parsedRecords.size());

--- a/mod-source-record-manager-server/src/main/java/org/folio/services/ChangeEngineServiceImpl.java
+++ b/mod-source-record-manager-server/src/main/java/org/folio/services/ChangeEngineServiceImpl.java
@@ -13,6 +13,7 @@ import org.folio.rest.jaxrs.model.ExternalIdsHolder;
 import org.folio.rest.jaxrs.model.InitialRecord;
 import org.folio.rest.jaxrs.model.JobExecution;
 import org.folio.rest.jaxrs.model.JobExecutionSourceChunk;
+import org.folio.rest.jaxrs.model.Metadata;
 import org.folio.rest.jaxrs.model.ParsedRecord;
 import org.folio.rest.jaxrs.model.ProfileSnapshotWrapper;
 import org.folio.rest.jaxrs.model.RawRecord;
@@ -189,6 +190,9 @@ public class ChangeEngineServiceImpl implements ChangeEngineService {
 
   private Future<Boolean> updateRecords(List<Record> records, JobExecution jobExecution, OkapiConnectionParams params) {
     LOGGER.info("Records have not been saved in record-storage, because job contains action for Marc update");
+    records.forEach(record -> record.setMetadata(new Metadata().withCreatedByUserId(jobExecution.getUserId())
+      .withUpdatedByUserId(jobExecution.getUserId())));
+
     return recordsPublishingService
       .sendEventsWithRecords(records, jobExecution.getId(), params, DI_MARC_FOR_UPDATE_RECEIVED.value());
   }
@@ -551,7 +555,8 @@ public class ChangeEngineServiceImpl implements ChangeEngineService {
     if (CollectionUtils.isEmpty(parsedRecords)) {
       return Future.succeededFuture();
     }
-
+    parsedRecords.forEach(record -> record.setMetadata(new Metadata().withCreatedByUserId(jobExecution.getUserId())
+      .withUpdatedByUserId(jobExecution.getUserId())));
     RecordCollection recordCollection = new RecordCollection()
       .withRecords(parsedRecords)
       .withTotalRecords(parsedRecords.size());

--- a/mod-source-record-manager-server/src/main/java/org/folio/services/ChangeEngineServiceImpl.java
+++ b/mod-source-record-manager-server/src/main/java/org/folio/services/ChangeEngineServiceImpl.java
@@ -190,7 +190,7 @@ public class ChangeEngineServiceImpl implements ChangeEngineService {
 
   private Future<Boolean> updateRecords(List<Record> records, JobExecution jobExecution, OkapiConnectionParams params) {
     LOGGER.info("Records have not been saved in record-storage, because job contains action for Marc update");
-    records.forEach(record -> record.setMetadata(new Metadata().withCreatedByUserId(jobExecution.getUserId())
+    records.forEach(parsedRecord -> parsedRecord.setMetadata(new Metadata().withCreatedByUserId(jobExecution.getUserId())
       .withUpdatedByUserId(jobExecution.getUserId())));
 
     return recordsPublishingService
@@ -555,7 +555,7 @@ public class ChangeEngineServiceImpl implements ChangeEngineService {
     if (CollectionUtils.isEmpty(parsedRecords)) {
       return Future.succeededFuture();
     }
-    parsedRecords.forEach(record -> record.setMetadata(new Metadata().withCreatedByUserId(jobExecution.getUserId())
+    parsedRecords.forEach(parsedRecord -> parsedRecord.setMetadata(new Metadata().withCreatedByUserId(jobExecution.getUserId())
       .withUpdatedByUserId(jobExecution.getUserId())));
     RecordCollection recordCollection = new RecordCollection()
       .withRecords(parsedRecords)

--- a/mod-source-record-manager-server/src/main/java/org/folio/services/ChangeEngineServiceImpl.java
+++ b/mod-source-record-manager-server/src/main/java/org/folio/services/ChangeEngineServiceImpl.java
@@ -191,7 +191,9 @@ public class ChangeEngineServiceImpl implements ChangeEngineService {
   private Future<Boolean> updateRecords(List<Record> records, JobExecution jobExecution, OkapiConnectionParams params) {
     LOGGER.info("Records have not been saved in record-storage, because job contains action for Marc update");
     records.forEach(parsedRecord -> parsedRecord.setMetadata(new Metadata().withCreatedByUserId(jobExecution.getUserId())
-      .withUpdatedByUserId(jobExecution.getUserId())));
+      .withUpdatedByUserId(jobExecution.getUserId())
+      .withUpdatedByUsername(jobExecution.getRunBy().getFirstName())
+      .withCreatedByUsername(jobExecution.getRunBy().getFirstName())));
 
     return recordsPublishingService
       .sendEventsWithRecords(records, jobExecution.getId(), params, DI_MARC_FOR_UPDATE_RECEIVED.value());
@@ -556,7 +558,9 @@ public class ChangeEngineServiceImpl implements ChangeEngineService {
       return Future.succeededFuture();
     }
     parsedRecords.forEach(parsedRecord -> parsedRecord.setMetadata(new Metadata().withCreatedByUserId(jobExecution.getUserId())
-      .withUpdatedByUserId(jobExecution.getUserId())));
+      .withUpdatedByUserId(jobExecution.getUserId())
+      .withUpdatedByUsername(jobExecution.getRunBy().getFirstName())
+      .withCreatedByUsername(jobExecution.getRunBy().getFirstName())));
     RecordCollection recordCollection = new RecordCollection()
       .withRecords(parsedRecords)
       .withTotalRecords(parsedRecords.size());

--- a/mod-source-record-manager-server/src/main/java/org/folio/services/ChangeEngineServiceImpl.java
+++ b/mod-source-record-manager-server/src/main/java/org/folio/services/ChangeEngineServiceImpl.java
@@ -190,8 +190,7 @@ public class ChangeEngineServiceImpl implements ChangeEngineService {
 
   private Future<Boolean> updateRecords(List<Record> records, JobExecution jobExecution, OkapiConnectionParams params) {
     LOGGER.info("Records have not been saved in record-storage, because job contains action for Marc update");
-    records.forEach(parsedRecord -> parsedRecord.setMetadata(new Metadata().withUpdatedByUserId(jobExecution.getUserId())
-      .withUpdatedByUsername((jobExecution.getRunBy() != null) ? jobExecution.getRunBy().getFirstName():"SYSTEM")));
+    records.forEach(parsedRecord -> parsedRecord.setMetadata(new Metadata().withUpdatedByUserId(jobExecution.getUserId())));
     return recordsPublishingService
       .sendEventsWithRecords(records, jobExecution.getId(), params, DI_MARC_FOR_UPDATE_RECEIVED.value());
   }
@@ -554,8 +553,7 @@ public class ChangeEngineServiceImpl implements ChangeEngineService {
     if (CollectionUtils.isEmpty(parsedRecords)) {
       return Future.succeededFuture();
     }
-    parsedRecords.forEach(parsedRecord -> parsedRecord.setMetadata(new Metadata().withCreatedByUserId(jobExecution.getUserId())
-      .withCreatedByUsername((jobExecution.getRunBy() != null) ? jobExecution.getRunBy().getFirstName():"SYSTEM")));
+    parsedRecords.forEach(parsedRecord -> parsedRecord.setMetadata(new Metadata().withCreatedByUserId(jobExecution.getUserId())));
     RecordCollection recordCollection = new RecordCollection()
       .withRecords(parsedRecords)
       .withTotalRecords(parsedRecords.size());

--- a/mod-source-record-manager-server/src/main/java/org/folio/services/ChangeEngineServiceImpl.java
+++ b/mod-source-record-manager-server/src/main/java/org/folio/services/ChangeEngineServiceImpl.java
@@ -191,8 +191,7 @@ public class ChangeEngineServiceImpl implements ChangeEngineService {
   private Future<Boolean> updateRecords(List<Record> records, JobExecution jobExecution, OkapiConnectionParams params) {
     LOGGER.info("Records have not been saved in record-storage, because job contains action for Marc update");
     records.forEach(parsedRecord -> parsedRecord.setMetadata(new Metadata().withUpdatedByUserId(jobExecution.getUserId())
-      .withUpdatedByUsername((jobExecution.getRunBy() != null && jobExecution.getRunBy().getFirstName() != null)
-                             ? jobExecution.getRunBy().getFirstName():"SYSTEM")));
+      .withUpdatedByUsername((jobExecution.getRunBy() != null) ? jobExecution.getRunBy().getFirstName():"SYSTEM")));
     return recordsPublishingService
       .sendEventsWithRecords(records, jobExecution.getId(), params, DI_MARC_FOR_UPDATE_RECEIVED.value());
   }
@@ -556,8 +555,7 @@ public class ChangeEngineServiceImpl implements ChangeEngineService {
       return Future.succeededFuture();
     }
     parsedRecords.forEach(parsedRecord -> parsedRecord.setMetadata(new Metadata().withCreatedByUserId(jobExecution.getUserId())
-      .withCreatedByUsername((jobExecution.getRunBy() != null && jobExecution.getRunBy().getFirstName() != null)
-                             ? jobExecution.getRunBy().getFirstName():"SYSTEM")));
+      .withCreatedByUsername((jobExecution.getRunBy() != null) ? jobExecution.getRunBy().getFirstName():"SYSTEM")));
     RecordCollection recordCollection = new RecordCollection()
       .withRecords(parsedRecords)
       .withTotalRecords(parsedRecords.size());

--- a/mod-source-record-manager-server/src/test/java/org/folio/services/ChangeEngineServiceImplTest.java
+++ b/mod-source-record-manager-server/src/test/java/org/folio/services/ChangeEngineServiceImplTest.java
@@ -69,7 +69,6 @@ public class ChangeEngineServiceImplTest {
   private static final String MARC_BIB_REC_WITH_FF =
     "00861cam a2200193S1 45 0001000700000002000900007003000400016008004100020035002200061035001300083099001600096245005600112500011600168500019600284600003500480610003400515610003900549999007900588\u001E304162\u001E00320061\u001EPBL\u001E020613n                      000 0 eng u\u001E  \u001Fa(Sirsi)sc99900001\u001E  \u001Fa(Sirsi)1\u001E  \u001FaSC LVF M698\u001E00\u001FaMohler, Harold S. (Lehigh Collection Vertical File)\u001E  \u001FaMaterial on this topic is contained in the Lehigh Collection Vertical File. See Special Collections for access.\u001E  \u001FaContains press releases, versions of resumes, clippings, biographical information. L-in-Life program, and memorial service program -- Documents related Hershey Food Corporation. In two parts.\u001E10\u001FaMohler, Harold S.,\u001Fd1919-1988.\u001E20\u001FaLehigh University.\u001FbTrustees.\u001E20\u001FaLehigh University.\u001FbClass of 1948.\u001Eff\u001Fi29573076-a7ee-462a-8f9b-2659ab7df23c\u001Fs7ca42730-9ba6-4bc8-98d3-f068728504c9\u001E\u001D";
   private static final String TEST_USER_ID = "a4295ae8-ecef-4657-958a-0a45b12880db";
-  private static final String JOHN_NAME = "John";
 
   @Mock
   private JobExecutionSourceChunkDao jobExecutionSourceChunkDao;
@@ -127,7 +126,6 @@ public class ChangeEngineServiceImplTest {
 
     var actual = serviceFuture.result();
     assertThat(actual.get(0).getMetadata().getUpdatedByUserId(), equalTo(TEST_USER_ID));
-    assertThat(actual.get(0).getMetadata().getUpdatedByUsername(), equalTo(JOHN_NAME));
   }
 
   @Test
@@ -347,8 +345,7 @@ public class ChangeEngineServiceImplTest {
           List.of(new ProfileSnapshotWrapper().withContent(ProfileSnapshotWrapper.ContentType.ACTION_PROFILE)))
         ).withJobProfileInfo(new JobProfileInfo().withId(UUID.randomUUID().toString())
         .withName("test").withDataType(JobProfileInfo.DataType.MARC))
-      .withUserId(TEST_USER_ID)
-      .withRunBy(new RunBy().withFirstName(JOHN_NAME));
+      .withUserId(TEST_USER_ID);
   }
 
   private Future<List<Record>> executeWithKafkaMock(RawRecordsDto rawRecordsDto, JobExecution jobExecution,

--- a/mod-source-record-manager-server/src/test/java/org/folio/services/ChangeEngineServiceImplTest.java
+++ b/mod-source-record-manager-server/src/test/java/org/folio/services/ChangeEngineServiceImplTest.java
@@ -51,6 +51,7 @@ import org.folio.rest.jaxrs.model.ProfileSnapshotWrapper;
 import org.folio.rest.jaxrs.model.RawRecordsDto;
 import org.folio.rest.jaxrs.model.Record;
 import org.folio.rest.jaxrs.model.RecordsMetadata;
+import org.folio.rest.jaxrs.model.RunBy;
 import org.folio.services.afterprocessing.HrIdFieldService;
 import org.folio.services.util.EventHandlingUtil;
 
@@ -67,6 +68,9 @@ public class ChangeEngineServiceImplTest {
     "01119cam a2200349Li 4500001001300000003000600013005001700019008004100036020001800077020001500095035002100110037002200131040002700153043001200180050002700192082001600219090002200235100003300257245002700290264003800317300002300355336002600378337002800404338002700432651006400459945004300523960006200566961001600628980003900644981002300683999006300706\u001Eocn922152790\u001EOCoLC\u001E20150927051630.4\u001E150713s2015    enk           000 f eng d\u001E  \u001Fa9780241146064\u001E  \u001Fa0241146062\u001E  \u001Fa(OCoLC)922152790\u001E  \u001Fa12370236\u001Fbybp\u001F5NU\u001E  \u001FaYDXCP\u001Fbeng\u001Ferda\u001FcYDXCP\u001E  \u001Fae-uk-en\u001E 4\u001FaPR6052.A6488\u001FbN66 2015\u001E04\u001Fa823.914\u001F223\u001E 4\u001Fa823.914\u001FcB2557\u001Fb1\u001E1 \u001FaBarker, Pat,\u001Fd1943-\u001Feauthor.\u001E10\u001FaNoonday /\u001FcPat Barker.\u001E 1\u001FaLondon :\u001FbHamish Hamilton,\u001Fc2015.\u001E  \u001Fa258 pages ;\u001Fc24 cm\u001E  \u001Fatext\u001Fbtxt\u001F2rdacontent\u001E  \u001Faunmediated\u001Fbn\u001F2rdamedia\u001E  \u001Favolume\u001Fbnc\u001F2rdacarrier\u001E 0\u001FaLondon (England)\u001FxHistory\u001FyBombardment, 1940-1941\u001FvFiction.\u001E  \u001Ffh\u001Fg1\u001Fi0000000618391828\u001Flfhgen\u001Fr3\u001Fsv\u001Ft1\u001E  \u001Fap\u001Fda\u001Fgh\u001Fim\u001Fjn\u001Fka\u001Fla\u001Fmo\u001Ftfhgen\u001Fo1\u001Fs15.57\u001Fu7ART\u001Fvukapf\u001FzGBP\u001E  \u001FbGBP\u001Fm633761\u001E  \u001Fa160128\u001Fb1899\u001Fd156\u001Fe1713\u001Ff654270\u001Fg1\u001E  \u001Faukapf\u001Fb7ART\u001Fcfhgen\u001E  \u001Fdm\u001Fea\u001Ffx\u001Fgeng\u001FiTesting with subfield i\u001FsAnd with subfield s\u001E\u001D";
   private static final String MARC_BIB_REC_WITH_FF =
     "00861cam a2200193S1 45 0001000700000002000900007003000400016008004100020035002200061035001300083099001600096245005600112500011600168500019600284600003500480610003400515610003900549999007900588\u001E304162\u001E00320061\u001EPBL\u001E020613n                      000 0 eng u\u001E  \u001Fa(Sirsi)sc99900001\u001E  \u001Fa(Sirsi)1\u001E  \u001FaSC LVF M698\u001E00\u001FaMohler, Harold S. (Lehigh Collection Vertical File)\u001E  \u001FaMaterial on this topic is contained in the Lehigh Collection Vertical File. See Special Collections for access.\u001E  \u001FaContains press releases, versions of resumes, clippings, biographical information. L-in-Life program, and memorial service program -- Documents related Hershey Food Corporation. In two parts.\u001E10\u001FaMohler, Harold S.,\u001Fd1919-1988.\u001E20\u001FaLehigh University.\u001FbTrustees.\u001E20\u001FaLehigh University.\u001FbClass of 1948.\u001Eff\u001Fi29573076-a7ee-462a-8f9b-2659ab7df23c\u001Fs7ca42730-9ba6-4bc8-98d3-f068728504c9\u001E\u001D";
+  private static final String TEST_USER_ID = "a4295ae8-ecef-4657-958a-0a45b12880db";
+  private static final String JOHN_NAME = "John";
+
   @Mock
   private JobExecutionSourceChunkDao jobExecutionSourceChunkDao;
   @Mock
@@ -97,6 +101,24 @@ public class ChangeEngineServiceImplTest {
 
     when(mappingMetadataService.getMappingMetadataDto(anyString(), any(OkapiConnectionParams.class)))
       .thenReturn(Future.succeededFuture(new MappingMetadataDto()));
+  }
+
+  @Test
+  public void shouldPopulateWithUserId() {
+    RawRecordsDto rawRecordsDto = getTestRawRecordsDto(MARC_BIB_REC_WITHOUT_FF);
+    JobExecution jobExecution = getTestJobExecution();
+
+    when(marcRecordAnalyzer.process(any())).thenReturn(MarcRecordType.BIB);
+    when(jobExecutionSourceChunkDao.getById(any(), any()))
+      .thenReturn(Future.succeededFuture(Optional.of(new JobExecutionSourceChunk())));
+    when(jobExecutionSourceChunkDao.update(any(), any())).thenReturn(Future.succeededFuture(new JobExecutionSourceChunk()));
+
+    Future<List<Record>> serviceFuture = executeWithKafkaMock(rawRecordsDto, jobExecution, Future.succeededFuture(true));
+
+    var actual = serviceFuture.result();
+    assertThat(actual.get(0).getMetadata().getCreatedByUserId(), equalTo(TEST_USER_ID));
+    assertThat(actual.get(0).getMetadata().getUpdatedByUserId(), equalTo(TEST_USER_ID));
+    assertThat(actual.get(0).getMetadata().getUpdatedByUsername(), equalTo(JOHN_NAME));
   }
 
   @Test
@@ -316,7 +338,8 @@ public class ChangeEngineServiceImplTest {
           List.of(new ProfileSnapshotWrapper().withContent(ProfileSnapshotWrapper.ContentType.ACTION_PROFILE)))
         ).withJobProfileInfo(new JobProfileInfo().withId(UUID.randomUUID().toString())
         .withName("test").withDataType(JobProfileInfo.DataType.MARC))
-      .withUserId("id");
+      .withUserId(TEST_USER_ID)
+      .withRunBy(new RunBy().withFirstName(JOHN_NAME));
   }
 
   private Future<List<Record>> executeWithKafkaMock(RawRecordsDto rawRecordsDto, JobExecution jobExecution,

--- a/mod-source-record-manager-server/src/test/java/org/folio/services/ChangeEngineServiceImplTest.java
+++ b/mod-source-record-manager-server/src/test/java/org/folio/services/ChangeEngineServiceImplTest.java
@@ -310,9 +310,13 @@ public class ChangeEngineServiceImplTest {
 
   private JobExecution getTestJobExecution() {
     return new JobExecution().withId(UUID.randomUUID().toString())
-      .withJobProfileSnapshotWrapper(new ProfileSnapshotWrapper())
-      .withJobProfileInfo(new JobProfileInfo().withId(UUID.randomUUID().toString())
-        .withName("test").withDataType(JobProfileInfo.DataType.MARC));
+      .withJobProfileSnapshotWrapper(new ProfileSnapshotWrapper()
+        .withContent(ProfileSnapshotWrapper.ContentType.ACTION_PROFILE)
+        .withChildSnapshotWrappers(
+          List.of(new ProfileSnapshotWrapper().withContent(ProfileSnapshotWrapper.ContentType.ACTION_PROFILE)))
+        ).withJobProfileInfo(new JobProfileInfo().withId(UUID.randomUUID().toString())
+        .withName("test").withDataType(JobProfileInfo.DataType.MARC))
+      .withUserId("id");
   }
 
   private Future<List<Record>> executeWithKafkaMock(RawRecordsDto rawRecordsDto, JobExecution jobExecution,


### PR DESCRIPTION
## Purpose
MARC bib record | Source does not reflect last person to update record when the update is via data import

## Approach
set userId from jobExecution to records metadata

## Learning
[_MODQM-224_](https://issues.folio.org/browse/MODQM-224)
