### PR TITLE
MODSOURMAN-786 - To restrict update of JobExecution that is marked as "Deleted"

### DIFF
--- a/mod-source-record-manager-server/src/main/java/org/folio/dao/JobExecutionDaoImpl.java
+++ b/mod-source-record-manager-server/src/main/java/org/folio/dao/JobExecutionDaoImpl.java
@@ -195,7 +195,7 @@ public class JobExecutionDaoImpl implements JobExecutionDao {
         pgClientFactory.createInstance(tenantId).startTx(connection);
         return connection.future();
       }).compose(v -> {
-        String selectForUpdate = format("SELECT * FROM %s WHERE id = $1 LIMIT 1 FOR UPDATE", formatFullTableName(tenantId, TABLE_NAME));
+        String selectForUpdate = format("SELECT * FROM %s WHERE id = $1 AND is_deleted = false LIMIT 1 FOR UPDATE", formatFullTableName(tenantId, TABLE_NAME));
         Promise<RowSet<Row>> selectResult = Promise.promise();
         pgClientFactory.createInstance(tenantId).execute(connection.future(), selectForUpdate, Tuple.of(jobExecutionId), selectResult);
         return selectResult.future();


### PR DESCRIPTION
## Purpose
To restrict update of JobExecution that is marked as "Deleted"

## Approach
Update APIs requests check for the existing data and update the data with new information being sent.
In this PR, we have filtered out the deleted records, hence deleted records will not be returned and in turn, will not be updated.

#### TODOS and Open Questions
- [x] Test cases added
