### PR TITLE
MODINV-686 - Provided "source-storage.records.get" permission to get record during update instance action profile processing

### DIFF
--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -201,10 +201,10 @@
             "converter-storage.jobprofilesnapshots.get",
             "inventory-storage.alternative-title-types.collection.get",
             "inventory-storage.authorities.collection.get",
+            "inventory-storage.authorities.item.delete",
             "inventory-storage.authorities.item.get",
             "inventory-storage.authorities.item.post",
             "inventory-storage.authorities.item.put",
-            "inventory-storage.authorities.item.delete",
             "inventory-storage.authority-note-types.collection.get",
             "inventory-storage.call-number-types.collection.get",
             "inventory-storage.classification-types.collection.get",
@@ -250,12 +250,12 @@
             "inventory-storage.statistical-code-types.collection.get",
             "inventory-storage.statistical-codes.collection.get",
             "mapping-metadata.get",
+            "orders.po-lines.collection.get",
             "source-storage.records.get",
             "source-storage.snapshots.get",
             "source-storage.snapshots.put",
             "source-storage.verified.records",
-            "users.collection.get",
-            "orders.po-lines.collection.get"
+            "users.collection.get"
           ]
         },
         {

--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -250,6 +250,7 @@
             "inventory-storage.statistical-code-types.collection.get",
             "inventory-storage.statistical-codes.collection.get",
             "mapping-metadata.get",
+            "source-storage.records.get",
             "source-storage.snapshots.get",
             "source-storage.snapshots.put",
             "source-storage.verified.records",


### PR DESCRIPTION
## Purpose
to get record during update instance action profile processing


## Learning
[MODINV-686](https://issues.folio.org/browse/MODINV-686)