### PR TITLE
MODSOURMAN-798: Change cache invalidation policy for LP data

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -21,6 +21,7 @@
 * [MODSOURMAN-791](https://issues.folio.org/browse/MODSOURMAN-791) Reduce Conversion of Parsed Content Into A MARC4J Record
 * [MODSOURMAN-792](https://issues.folio.org/browse/MODSOURMAN-792) Initialize mapping parameters without race conditions
 * [MODSOURMAN-790](https://issues.folio.org/browse/MODSOURMAN-790) Implement endpoint to get job executions users.
+* [MODSOURMAN-798](https://issues.folio.org/browse/MODSOURMAN-798) Change cache invalidation policy for LP data.
 
 ## 2022-xx-xx v3.3.3-SNAPSHOT
 * [MODSOURMAN-746](https://issues.folio.org/browse/MODSOURMAN-746) Avoid creation of trigger for old job progress table which cases an error during jobProgress saving

--- a/mod-source-record-manager-server/src/main/java/org/folio/rest/impl/ChangeManagerImpl.java
+++ b/mod-source-record-manager-server/src/main/java/org/folio/rest/impl/ChangeManagerImpl.java
@@ -21,6 +21,7 @@ import org.folio.rest.jaxrs.resource.ChangeManager;
 import org.folio.rest.tools.utils.TenantTool;
 import org.folio.services.ChunkProcessingService;
 import org.folio.services.JobExecutionService;
+import org.folio.services.JobExecutionsCache;
 import org.folio.services.ParsedRecordService;
 import org.folio.spring.SpringContextUtil;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -43,6 +44,8 @@ public class ChangeManagerImpl implements ChangeManager {
   private ChunkProcessingService eventDrivenChunkProcessingService;
   @Autowired
   private ParsedRecordService parsedRecordService;
+  @Autowired
+  private JobExecutionsCache jobExecutionsCache;
 
   private String tenantId;
 
@@ -56,6 +59,7 @@ public class ChangeManagerImpl implements ChangeManager {
   public void deleteChangeManagerJobExecutions(DeleteJobExecutionsReq entity, Map<String, String> okapiHeaders, Handler<AsyncResult<Response>> asyncResultHandler, Context vertxContext) {
     vertxContext.runOnContext(c -> {
       try {
+        jobExecutionsCache.evictCache();
         jobExecutionService.softDeleteJobExecutionsByIds(entity.getIds(), tenantId)
           .map(DeleteChangeManagerJobExecutionsResponse::respond200WithApplicationJson)
           .map(Response.class::cast)

--- a/mod-source-record-manager-server/src/main/java/org/folio/services/JobExecutionsCache.java
+++ b/mod-source-record-manager-server/src/main/java/org/folio/services/JobExecutionsCache.java
@@ -85,6 +85,6 @@ public class JobExecutionsCache {
   }
 
   public void evictCache() {
-    cache = buildCache();
+    cache.synchronous().invalidateAll();
   }
 }


### PR DESCRIPTION
## Purpose
To unblock UI. For now, there is 30 sec delay after cache will be expired/evicted. That's why UI can "hide" removed jobs only after 30 seconds.


## Approach
To change it, there will be added cache eviction after the endpoint for delete JobExecution was called.

**NOTE:** This is temporary soultion. This cache will be removed at all in the future.

## Learning
https://issues.folio.org/browse/MODSOURMAN-798
