### PR TITLE
MODSOURMAN-796. Change logic to initialize job execution progress after reading file instead of processing the first chunk

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -21,6 +21,7 @@
 * [MODSOURMAN-791](https://issues.folio.org/browse/MODSOURMAN-791) Reduce Conversion of Parsed Content Into A MARC4J Record
 * [MODSOURMAN-792](https://issues.folio.org/browse/MODSOURMAN-792) Initialize mapping parameters without race conditions
 * [MODSOURMAN-790](https://issues.folio.org/browse/MODSOURMAN-790) Implement endpoint to get job executions users.
+* [MODSOURMAN-796](https://issues.folio.org/browse/MODSOURMAN-796) Change logic to initialize job execution progress after reading file instead of processing the first chunk
 
 ## 2022-xx-xx v3.3.3-SNAPSHOT
 * [MODSOURMAN-746](https://issues.folio.org/browse/MODSOURMAN-746) Avoid creation of trigger for old job progress table which cases an error during jobProgress saving

--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -201,10 +201,10 @@
             "converter-storage.jobprofilesnapshots.get",
             "inventory-storage.alternative-title-types.collection.get",
             "inventory-storage.authorities.collection.get",
+            "inventory-storage.authorities.item.delete",
             "inventory-storage.authorities.item.get",
             "inventory-storage.authorities.item.post",
             "inventory-storage.authorities.item.put",
-            "inventory-storage.authorities.item.delete",
             "inventory-storage.authority-note-types.collection.get",
             "inventory-storage.call-number-types.collection.get",
             "inventory-storage.classification-types.collection.get",
@@ -250,11 +250,12 @@
             "inventory-storage.statistical-code-types.collection.get",
             "inventory-storage.statistical-codes.collection.get",
             "mapping-metadata.get",
+            "orders.po-lines.collection.get",
+            "source-storage.records.get",
             "source-storage.snapshots.get",
             "source-storage.snapshots.put",
             "source-storage.verified.records",
-            "users.collection.get",
-            "orders.po-lines.collection.get"
+            "users.collection.get"
           ]
         },
         {

--- a/mod-source-record-manager-server/src/main/java/org/folio/services/flowcontrol/RawRecordsFlowControlServiceImpl.java
+++ b/mod-source-record-manager-server/src/main/java/org/folio/services/flowcontrol/RawRecordsFlowControlServiceImpl.java
@@ -59,7 +59,7 @@ public class RawRecordsFlowControlServiceImpl implements RawRecordsFlowControlSe
    * threshold can be missed during resetting that can cause that resume/pause cycle may not be as usual, because we are
    * starting from clear state after reset, but any events would not be missed and consumers never pause forever.
    */
-  @Scheduled(cron = "${di.flow.control.reset.state.cron:0 0/5 * * * ?}")
+  @Scheduled(fixedRateString = "${di.flow.control.reset.state.interval:PT5M}")
   public void resetState() {
     if (!enableFlowControl) {
       return;

--- a/mod-source-record-manager-server/src/main/java/org/folio/services/flowcontrol/RawRecordsFlowControlServiceImpl.java
+++ b/mod-source-record-manager-server/src/main/java/org/folio/services/flowcontrol/RawRecordsFlowControlServiceImpl.java
@@ -59,7 +59,7 @@ public class RawRecordsFlowControlServiceImpl implements RawRecordsFlowControlSe
    * threshold can be missed during resetting that can cause that resume/pause cycle may not be as usual, because we are
    * starting from clear state after reset, but any events would not be missed and consumers never pause forever.
    */
-  @Scheduled(fixedRateString = "${di.flow.control.reset.state.interval:PT5M}")
+  @Scheduled(initialDelayString = "PT1M", fixedRateString = "${di.flow.control.reset.state.interval:PT5M}")
   public void resetState() {
     if (!enableFlowControl) {
       return;

--- a/mod-source-record-manager-server/src/main/java/org/folio/verticle/DataImportInitConsumersVerticle.java
+++ b/mod-source-record-manager-server/src/main/java/org/folio/verticle/DataImportInitConsumersVerticle.java
@@ -1,0 +1,24 @@
+package org.folio.verticle;
+
+import org.folio.kafka.AsyncRecordHandler;
+import org.folio.verticle.consumers.DataImportInitKafkaHandler;
+import org.springframework.beans.factory.annotation.Autowired;
+import java.util.List;
+
+import static org.folio.rest.jaxrs.model.DataImportEventTypes.DI_INITIALIZATION_STARTED;
+
+public class DataImportInitConsumersVerticle extends AbstractConsumersVerticle {
+
+  @Autowired
+  private DataImportInitKafkaHandler initializationHandler;
+
+  @Override
+  public List<String> getEvents() {
+    return List.of(DI_INITIALIZATION_STARTED.value());
+  }
+
+  @Override
+  public AsyncRecordHandler<String, String> getHandler() {
+    return initializationHandler;
+  }
+}

--- a/mod-source-record-manager-server/src/main/java/org/folio/verticle/consumers/DataImportInitKafkaHandler.java
+++ b/mod-source-record-manager-server/src/main/java/org/folio/verticle/consumers/DataImportInitKafkaHandler.java
@@ -1,0 +1,69 @@
+package org.folio.verticle.consumers;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.vertx.core.Future;
+import io.vertx.core.Vertx;
+import io.vertx.core.json.Json;
+import io.vertx.kafka.client.consumer.KafkaConsumerRecord;
+import io.vertx.kafka.client.producer.KafkaHeader;
+import lombok.SneakyThrows;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.folio.dataimport.util.OkapiConnectionParams;
+import org.folio.kafka.AsyncRecordHandler;
+import org.folio.kafka.KafkaHeaderUtils;
+import org.folio.rest.jaxrs.model.DataImportInitConfig;
+import org.folio.rest.jaxrs.model.Event;
+import org.folio.rest.jaxrs.model.JobExecution;
+import org.folio.rest.jaxrs.model.StatusDto;
+import org.folio.services.JobExecutionService;
+import org.folio.services.progress.JobExecutionProgressService;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+
+@Component
+public class DataImportInitKafkaHandler implements AsyncRecordHandler<String, String> {
+  private static final Logger LOGGER = LogManager.getLogger();
+
+  private Vertx vertx;
+  private JobExecutionService jobExecutionService;
+  private JobExecutionProgressService jobExecutionProgressService;
+
+  public DataImportInitKafkaHandler(@Autowired Vertx vertx,
+                                    @Autowired JobExecutionProgressService jobExecutionProgressService,
+                                    @Autowired JobExecutionService jobExecutionService) {
+    this.vertx = vertx;
+    this.jobExecutionProgressService = jobExecutionProgressService;
+    this.jobExecutionService = jobExecutionService;
+  }
+
+  @SneakyThrows
+  @Override
+  public Future<String> handle(KafkaConsumerRecord<String, String> record) {
+    List<KafkaHeader> kafkaHeaders = record.headers();
+    OkapiConnectionParams okapiParams = new OkapiConnectionParams(KafkaHeaderUtils.kafkaHeadersToMap(kafkaHeaders), vertx);
+    Event event = Json.decodeValue(record.value(), Event.class);
+    DataImportInitConfig initConfig = new ObjectMapper().readValue(event.getEventPayload(), DataImportInitConfig.class);
+
+    return jobExecutionProgressService.initializeJobExecutionProgress(initConfig.getJobExecutionId(), initConfig.getTotalRecords(), okapiParams.getTenantId())
+      .compose(p -> checkAndUpdateToInProgressState(initConfig.getJobExecutionId(), okapiParams))
+      .compose(p -> Future.succeededFuture(record.key()));
+  }
+
+  private Future<JobExecution> checkAndUpdateToInProgressState(String jobExecutionId, OkapiConnectionParams params) {
+    return jobExecutionService.getJobExecutionById(jobExecutionId, params.getTenantId())
+      .compose(jobExecutionOptional -> {
+        if (jobExecutionOptional.isPresent()) {
+          JobExecution jobExecution = jobExecutionOptional.get();
+          if (jobExecution.getStatus() == JobExecution.Status.FILE_UPLOADED) {
+            LOGGER.info("Moving from file uploaded to in progress state for jobExecutionId: {}", jobExecutionId);
+            StatusDto statusDto = new StatusDto().withStatus(StatusDto.Status.PARSING_IN_PROGRESS);
+            return jobExecutionService.updateJobExecutionStatus(jobExecutionId, statusDto, params);
+          }
+        }
+        return Future.succeededFuture();
+      });
+  }
+}

--- a/mod-source-record-manager-server/src/test/java/org/folio/rest/impl/AbstractRestTest.java
+++ b/mod-source-record-manager-server/src/test/java/org/folio/rest/impl/AbstractRestTest.java
@@ -27,11 +27,14 @@ import io.vertx.core.json.JsonObject;
 import io.vertx.ext.unit.Async;
 import io.vertx.ext.unit.TestContext;
 import net.mguenther.kafka.junit.EmbeddedKafkaCluster;
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.apache.kafka.common.header.internals.RecordHeader;
 import org.folio.TestUtil;
 import org.folio.kafka.KafkaTopicNameHelper;
 import org.folio.rest.RestVerticle;
 import org.folio.rest.client.TenantClient;
 import org.folio.rest.jaxrs.model.ActionProfile;
+import org.folio.rest.jaxrs.model.Event;
 import org.folio.rest.jaxrs.model.File;
 import org.folio.rest.jaxrs.model.InitJobExecutionsRqDto;
 import org.folio.rest.jaxrs.model.InitJobExecutionsRsDto;
@@ -45,6 +48,7 @@ import org.folio.rest.persist.Criteria.Criterion;
 import org.folio.rest.persist.PostgresClient;
 import org.folio.rest.tools.utils.Envs;
 import org.folio.rest.tools.utils.NetworkUtils;
+import org.folio.rest.util.OkapiConnectionParams;
 import org.junit.AfterClass;
 import org.junit.Before;
 import org.junit.BeforeClass;
@@ -72,6 +76,7 @@ import static org.folio.kafka.KafkaTopicNameHelper.getDefaultNameSpace;
 import static org.folio.rest.jaxrs.model.ProfileSnapshotWrapper.ContentType.ACTION_PROFILE;
 import static org.folio.rest.jaxrs.model.ProfileSnapshotWrapper.ContentType.JOB_PROFILE;
 import static org.folio.services.util.EventHandlingUtil.constructModuleName;
+import static org.folio.rest.util.OkapiConnectionParams.OKAPI_TOKEN_HEADER;
 
 /**
  * Abstract test for the REST API testing needs.
@@ -436,4 +441,11 @@ public abstract class AbstractRestTest {
     throw new NotFoundException(String.format("Couldn't find bean %s", clazz.getName()));
   }
 
+  protected ConsumerRecord<String, String> buildConsumerRecord(String topic, Event event) {
+    ConsumerRecord<java.lang.String, java.lang.String> consumerRecord = new ConsumerRecord("folio", 0, 0, topic, Json.encode(event));
+    consumerRecord.headers().add(new RecordHeader(OkapiConnectionParams.OKAPI_TENANT_HEADER, TENANT_ID.getBytes(StandardCharsets.UTF_8)));
+    consumerRecord.headers().add(new RecordHeader(OKAPI_URL_HEADER, ("http://localhost:" + snapshotMockServer.port()).getBytes(StandardCharsets.UTF_8)));
+    consumerRecord.headers().add(new RecordHeader(OKAPI_TOKEN_HEADER, (TOKEN).getBytes(StandardCharsets.UTF_8)));
+    return consumerRecord;
+  }
 }

--- a/mod-source-record-manager-server/src/test/java/org/folio/verticle/consumers/DataImportInitConsumerVerticleTest.java
+++ b/mod-source-record-manager-server/src/test/java/org/folio/verticle/consumers/DataImportInitConsumerVerticleTest.java
@@ -17,7 +17,13 @@ import org.folio.dao.util.PostgresClientFactory;
 import org.folio.dataimport.util.OkapiConnectionParams;
 import org.folio.kafka.KafkaTopicNameHelper;
 import org.folio.rest.impl.AbstractRestTest;
-import org.folio.rest.jaxrs.model.*;
+import org.folio.rest.jaxrs.model.DataImportInitConfig;
+import org.folio.rest.jaxrs.model.Event;
+import org.folio.rest.jaxrs.model.File;
+import org.folio.rest.jaxrs.model.InitJobExecutionsRqDto;
+import org.folio.rest.jaxrs.model.JobExecution;
+import org.folio.rest.jaxrs.model.JobMonitoring;
+import org.folio.rest.jaxrs.model.StatusDto;
 import org.folio.services.JobExecutionServiceImpl;
 import org.folio.services.JobMonitoringServiceImpl;
 import org.folio.services.progress.JobExecutionProgressServiceImpl;
@@ -50,7 +56,6 @@ public class DataImportInitConsumerVerticleTest extends AbstractRestTest {
     .withFiles(Collections.singletonList(new File().withName("importBib1.bib")))
     .withSourceType(InitJobExecutionsRqDto.SourceType.FILES)
     .withUserId(okapiUserIdHeader);
-
 
   @Rule
   public RunTestOnContext rule = new RunTestOnContext();

--- a/mod-source-record-manager-server/src/test/java/org/folio/verticle/consumers/DataImportInitConsumerVerticleTest.java
+++ b/mod-source-record-manager-server/src/test/java/org/folio/verticle/consumers/DataImportInitConsumerVerticleTest.java
@@ -1,0 +1,199 @@
+package org.folio.verticle.consumers;
+
+import io.vertx.core.Future;
+import io.vertx.core.Vertx;
+import io.vertx.core.json.Json;
+import io.vertx.ext.unit.Async;
+import io.vertx.ext.unit.TestContext;
+import io.vertx.ext.unit.junit.RunTestOnContext;
+import io.vertx.ext.unit.junit.VertxUnitRunner;
+import io.vertx.kafka.client.consumer.KafkaConsumerRecord;
+import io.vertx.kafka.client.consumer.impl.KafkaConsumerRecordImpl;
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.folio.dao.JobExecutionDaoImpl;
+import org.folio.dao.JobExecutionProgressDaoImpl;
+import org.folio.dao.JobMonitoringDaoImpl;
+import org.folio.dao.util.PostgresClientFactory;
+import org.folio.dataimport.util.OkapiConnectionParams;
+import org.folio.kafka.KafkaTopicNameHelper;
+import org.folio.rest.impl.AbstractRestTest;
+import org.folio.rest.jaxrs.model.*;
+import org.folio.services.JobExecutionServiceImpl;
+import org.folio.services.JobMonitoringServiceImpl;
+import org.folio.services.progress.JobExecutionProgressServiceImpl;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.InjectMocks;
+import org.mockito.MockitoAnnotations;
+import org.mockito.Spy;
+import java.util.Collections;
+import java.util.HashMap;
+
+import static org.folio.dataimport.util.RestUtil.OKAPI_URL_HEADER;
+import static org.folio.kafka.KafkaTopicNameHelper.getDefaultNameSpace;
+import static org.folio.rest.jaxrs.model.DataImportEventTypes.DI_INITIALIZATION_STARTED;
+import static org.folio.rest.util.OkapiConnectionParams.OKAPI_TENANT_HEADER;
+import static org.folio.rest.util.OkapiConnectionParams.OKAPI_TOKEN_HEADER;
+import static org.junit.Assert.assertEquals;
+
+@RunWith(VertxUnitRunner.class)
+public class DataImportInitConsumerVerticleTest extends AbstractRestTest {
+  private static final Integer TOTAL_RECORDS = 10;
+  private static final String DEFAULT_NAMESPACE = "folio";
+
+  private Vertx vertx = Vertx.vertx();
+  private OkapiConnectionParams params;
+  private String jobExecutionId;
+  private InitJobExecutionsRqDto initJobExecutionsRqDto = new InitJobExecutionsRqDto()
+    .withFiles(Collections.singletonList(new File().withName("importBib1.bib")))
+    .withSourceType(InitJobExecutionsRqDto.SourceType.FILES)
+    .withUserId(okapiUserIdHeader);
+
+
+  @Rule
+  public RunTestOnContext rule = new RunTestOnContext();
+
+  @Spy
+  private PostgresClientFactory postgresClientFactory = new PostgresClientFactory(vertx);
+  @Spy
+  @InjectMocks
+  private JobExecutionDaoImpl jobExecutionDao;
+  @InjectMocks
+  @Spy
+  private JobExecutionProgressDaoImpl jobExecutionProgressDao;
+  @Spy
+  @InjectMocks
+  private JobMonitoringDaoImpl jobMonitoringDao;
+
+  @Spy
+  @InjectMocks
+  private JobExecutionProgressServiceImpl jobExecutionProgressService;
+  @Spy
+  @InjectMocks
+  private JobExecutionServiceImpl jobExecutionService;
+  @Spy
+  @InjectMocks
+  private JobMonitoringServiceImpl jobMonitoringService;
+
+  @InjectMocks
+  private DataImportInitKafkaHandler initKafkaHandler = new DataImportInitKafkaHandler(vertx, jobExecutionProgressService, jobExecutionService);
+
+  @Before
+  public void setUp() {
+    MockitoAnnotations.initMocks(this);
+
+    HashMap<String, String> headers = new HashMap<>();
+    headers.put(OKAPI_URL_HEADER, "http://localhost:" + snapshotMockServer.port());
+    headers.put(OKAPI_TENANT_HEADER, TENANT_ID);
+    headers.put(OKAPI_TOKEN_HEADER, "token");
+    params = new OkapiConnectionParams(headers, vertx);
+  }
+
+  @Test
+  public void shouldChangeStatusFromFileUploadedToParsingInProgress(TestContext context) {
+    // progress not yet initialized, current status is FILE_UPLOADED,
+    // so init handler should initialize progress and change status to PARSING_IN_PROGRESS
+    Async async = context.async();
+    Future<String> future = prepareJobWithStatus(StatusDto.Status.FILE_UPLOADED);
+
+    future.onComplete(ar -> {
+      context.assertTrue(ar.succeeded());
+
+      assertProgressAndMonitoringAndJobExecutionStatus(JobExecution.Status.PARSING_IN_PROGRESS, async);
+    });
+  }
+
+  @Test
+  public void shouldChangeStatusAndNotBreakAnythingIfProgressAlreadyInitialized(TestContext context) {
+    // if progress already initialized, but status not yet changed
+    // init handler should use already existed progress and change status to PARSING_IN_PROGRESS
+    Async async = context.async();
+    Future<String> future = initializeProgressAndPrepareJobWithStatus(StatusDto.Status.FILE_UPLOADED);
+
+    future.onComplete(ar -> {
+      context.assertTrue(ar.succeeded());
+
+      assertProgressAndMonitoringAndJobExecutionStatus(JobExecution.Status.PARSING_IN_PROGRESS, async);
+    });
+  }
+
+  @Test
+  public void shouldNotChangeStatusFromCommittedToParsingInProgress(TestContext context) {
+    // if progress already initialized and status already committed(for example when raw mark chunk consumer processed quicker),
+    // so init handler should use already existed progress and should remain status the same
+    // (it should change status only from FILE_UPLOADED to PARSING_IN_PROGRESS)
+    Async async = context.async();
+    Future<String> future = initializeProgressAndPrepareJobWithStatus(StatusDto.Status.COMMITTED);
+
+    future.onComplete(ar -> {
+      context.assertTrue(ar.succeeded());
+
+      assertProgressAndMonitoringAndJobExecutionStatus(JobExecution.Status.COMMITTED, async);
+    });
+  }
+
+  @Test
+  public void shouldBeIdempotentWhenStatusAlreadyInProgress(TestContext context) {
+    // if progress already initialized and status already in progress(for example when raw mark chunk consumer is processing)
+    // so init handler should use already existed progress and should remain status the same
+    // (it should change status only from FILE_UPLOADED to PARSING_IN_PROGRESS)
+    Async async = context.async();
+    Future<String> future = initializeProgressAndPrepareJobWithStatus(StatusDto.Status.PARSING_IN_PROGRESS);
+
+    future.onComplete(ar -> {
+      context.assertTrue(ar.succeeded());
+
+      assertProgressAndMonitoringAndJobExecutionStatus(JobExecution.Status.PARSING_IN_PROGRESS, async);
+    });
+  }
+
+  private Future<String> prepareJobWithStatus(StatusDto.Status status) {
+    return jobExecutionService.initializeJobExecutions(initJobExecutionsRqDto, params)
+      .compose(rsDto -> jobExecutionService.updateJobExecutionStatus(rsDto.getParentJobExecutionId(), new StatusDto().withStatus(status), params)
+        .compose(jobExecution -> {
+          this.jobExecutionId = jobExecution.getId();
+          return initKafkaHandler.handle(buildKafkaConsumerRecord(jobExecution.getId()));
+        }));
+  }
+
+  private Future<String> initializeProgressAndPrepareJobWithStatus(StatusDto.Status status) {
+    return jobExecutionService.initializeJobExecutions(initJobExecutionsRqDto, params)
+        .compose(rsDto -> jobExecutionService.updateJobExecutionStatus(rsDto.getParentJobExecutionId(), new StatusDto().withStatus(status), params)
+            .compose(jobExecution -> jobExecutionProgressService.initializeJobExecutionProgress(jobExecution.getId(), TOTAL_RECORDS, TENANT_ID)
+              .compose(progress -> {
+                this.jobExecutionId = progress.getJobExecutionId();
+                return initKafkaHandler.handle(buildKafkaConsumerRecord(progress.getJobExecutionId()));
+              })));
+  }
+
+  private void assertProgressAndMonitoringAndJobExecutionStatus(JobExecution.Status statusToCheck, Async async) {
+    jobExecutionProgressService.getByJobExecutionId(jobExecutionId, TENANT_ID).onSuccess(progress -> {
+      assertEquals(jobExecutionId, progress.getJobExecutionId());
+      assertEquals(TOTAL_RECORDS, progress.getTotal());
+
+      jobExecutionService.getJobExecutionById(jobExecutionId, TENANT_ID).onSuccess(jobExecutionOptional -> {
+        JobExecution jobExecution = jobExecutionOptional.get();
+        assertEquals(statusToCheck, jobExecution.getStatus());
+
+        jobMonitoringService.getByJobExecutionId(jobExecution.getId(), TENANT_ID).onSuccess(jobMonitoringOptional -> {
+          JobMonitoring jobMonitoring = jobMonitoringOptional.get();
+          assertEquals(jobExecutionId, jobMonitoring.getJobExecutionId());
+          async.complete();
+        });
+      });
+    });
+  }
+
+  private KafkaConsumerRecord<String, String> buildKafkaConsumerRecord(String jobExecutionId) {
+    DataImportInitConfig initConfig = new DataImportInitConfig();
+    initConfig.setJobExecutionId(jobExecutionId);
+    initConfig.setTotalRecords(TOTAL_RECORDS);
+
+    String topic = KafkaTopicNameHelper.formatTopicName(DEFAULT_NAMESPACE, getDefaultNameSpace(), TENANT_ID, DI_INITIALIZATION_STARTED.value());
+    Event event = new Event().withEventPayload(Json.encode(initConfig));
+    ConsumerRecord<String, String> consumerRecord = buildConsumerRecord(topic, event);
+    return new KafkaConsumerRecordImpl<>(consumerRecord);
+  }
+}

--- a/mod-source-record-manager-server/src/test/java/org/folio/verticle/consumers/DataImportJournalConsumerVerticleMockTest.java
+++ b/mod-source-record-manager-server/src/test/java/org/folio/verticle/consumers/DataImportJournalConsumerVerticleMockTest.java
@@ -365,14 +365,4 @@ public class DataImportJournalConsumerVerticleMockTest extends AbstractRestTest 
     ConsumerRecord<String, String> consumerRecord = buildConsumerRecord(topic, event);
     return new KafkaConsumerRecordImpl<>(consumerRecord);
   }
-
-  private ConsumerRecord<String, String> buildConsumerRecord(String topic, Event event) {
-    ConsumerRecord<java.lang.String, java.lang.String> consumerRecord =
-      new ConsumerRecord(ENV_KEY, 0, 0, topic, Json.encode(event));
-    consumerRecord.headers().add(new RecordHeader(OKAPI_TENANT_HEADER, TENANT_ID.getBytes(StandardCharsets.UTF_8)));
-    consumerRecord.headers().add(new RecordHeader(OKAPI_URL_HEADER, ("http://localhost:" + snapshotMockServer.port()).getBytes(StandardCharsets.UTF_8)));
-    consumerRecord.headers().add(new RecordHeader(OKAPI_TOKEN_HEADER, (TOKEN).getBytes(StandardCharsets.UTF_8)));
-    return consumerRecord;
-  }
-
 }

--- a/mod-source-record-manager-server/src/test/java/org/folio/verticle/consumers/DataImportJournalConsumerVerticleTest.java
+++ b/mod-source-record-manager-server/src/test/java/org/folio/verticle/consumers/DataImportJournalConsumerVerticleTest.java
@@ -31,13 +31,11 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 
 import java.io.IOException;
-import java.nio.charset.StandardCharsets;
 import java.util.HashMap;
 import java.util.List;
 import java.util.UUID;
 import java.util.concurrent.ExecutionException;
 
-import static org.folio.dataimport.util.RestUtil.OKAPI_URL_HEADER;
 import static org.folio.kafka.KafkaTopicNameHelper.getDefaultNameSpace;
 import static org.folio.rest.jaxrs.model.DataImportEventTypes.*;
 import static org.folio.rest.jaxrs.model.EntityType.INSTANCE;
@@ -45,8 +43,7 @@ import static org.folio.rest.jaxrs.model.JournalRecord.EntityType.HOLDINGS;
 import static org.folio.rest.jaxrs.model.JournalRecord.EntityType.ITEM;
 import static org.folio.rest.jaxrs.model.JournalRecord.EntityType.MARC_BIBLIOGRAPHIC;
 import static org.folio.rest.jaxrs.model.ProfileSnapshotWrapper.ContentType.ACTION_PROFILE;
-import static org.folio.rest.util.OkapiConnectionParams.OKAPI_TENANT_HEADER;
-import static org.folio.rest.util.OkapiConnectionParams.OKAPI_TOKEN_HEADER;
+
 
 @RunWith(VertxUnitRunner.class)
 public class DataImportJournalConsumerVerticleTest extends AbstractRestTest {
@@ -287,13 +284,4 @@ public class DataImportJournalConsumerVerticleTest extends AbstractRestTest {
     ConsumerRecord<String, String> consumerRecord = buildConsumerRecord(topic, event);
     return new KafkaConsumerRecordImpl<>(consumerRecord);
   }
-
-  private ConsumerRecord<String, String> buildConsumerRecord(String topic, Event event) {
-    ConsumerRecord<java.lang.String, java.lang.String> consumerRecord = new ConsumerRecord("folio", 0, 0, topic, Json.encode(event));
-    consumerRecord.headers().add(new RecordHeader(OKAPI_TENANT_HEADER, TENANT_ID.getBytes(StandardCharsets.UTF_8)));
-    consumerRecord.headers().add(new RecordHeader(OKAPI_URL_HEADER, ("http://localhost:" + snapshotMockServer.port()).getBytes(StandardCharsets.UTF_8)));
-    consumerRecord.headers().add(new RecordHeader(OKAPI_TOKEN_HEADER, (TOKEN).getBytes(StandardCharsets.UTF_8)));
-    return consumerRecord;
-  }
-
 }

--- a/mod-source-record-manager-server/src/test/java/org/folio/verticle/consumers/ImportInvoiceJournalConsumerVerticleMockTest.java
+++ b/mod-source-record-manager-server/src/test/java/org/folio/verticle/consumers/ImportInvoiceJournalConsumerVerticleMockTest.java
@@ -325,14 +325,4 @@ public class ImportInvoiceJournalConsumerVerticleMockTest extends AbstractRestTe
     ConsumerRecord<String, String> consumerRecord = buildConsumerRecord(topic, event);
     return new KafkaConsumerRecordImpl<>(consumerRecord);
   }
-
-  private ConsumerRecord<String, String> buildConsumerRecord(String topic, Event event) {
-    ConsumerRecord<java.lang.String, java.lang.String> consumerRecord =
-      new ConsumerRecord(ENV_KEY, 0, 0, topic, Json.encode(event));
-    consumerRecord.headers().add(new RecordHeader(OKAPI_TENANT_HEADER, TENANT_ID.getBytes(StandardCharsets.UTF_8)));
-    consumerRecord.headers().add(new RecordHeader(OKAPI_URL_HEADER, ("http://localhost:" + snapshotMockServer.port()).getBytes(StandardCharsets.UTF_8)));
-    consumerRecord.headers().add(new RecordHeader(OKAPI_TOKEN_HEADER, (TOKEN).getBytes(StandardCharsets.UTF_8)));
-    return consumerRecord;
-  }
-
 }

--- a/mod-source-record-manager-server/src/test/java/org/folio/verticle/consumers/ImportInvoiceJournalConsumerVerticleTest.java
+++ b/mod-source-record-manager-server/src/test/java/org/folio/verticle/consumers/ImportInvoiceJournalConsumerVerticleTest.java
@@ -10,7 +10,6 @@ import io.vertx.ext.unit.junit.VertxUnitRunner;
 import io.vertx.kafka.client.consumer.KafkaConsumerRecord;
 import io.vertx.kafka.client.consumer.impl.KafkaConsumerRecordImpl;
 import org.apache.kafka.clients.consumer.ConsumerRecord;
-import org.apache.kafka.common.header.internals.RecordHeader;
 import org.folio.DataImportEventPayload;
 import org.folio.ParsedRecord;
 import org.folio.Record;
@@ -32,7 +31,6 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 
 import java.io.IOException;
-import java.nio.charset.StandardCharsets;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Optional;
@@ -40,13 +38,11 @@ import java.util.UUID;
 
 import static org.folio.DataImportEventTypes.DI_ERROR;
 import static org.folio.DataImportEventTypes.DI_INVOICE_CREATED;
-import static org.folio.dataimport.util.RestUtil.OKAPI_URL_HEADER;
 import static org.folio.kafka.KafkaTopicNameHelper.getDefaultNameSpace;
 import static org.folio.rest.jaxrs.model.EntityType.EDIFACT_INVOICE;
 import static org.folio.rest.jaxrs.model.EntityType.INVOICE;
 import static org.folio.rest.jaxrs.model.ProfileSnapshotWrapper.ContentType.JOB_PROFILE;
-import static org.folio.rest.util.OkapiConnectionParams.OKAPI_TENANT_HEADER;
-import static org.folio.rest.util.OkapiConnectionParams.OKAPI_TOKEN_HEADER;
+
 import static org.folio.services.journal.InvoiceUtil.FIELD_DESCRIPTION;
 import static org.folio.services.journal.InvoiceUtil.FIELD_FOLIO_INVOICE_NO;
 import static org.folio.services.journal.InvoiceUtil.FIELD_ID;
@@ -181,13 +177,4 @@ public class ImportInvoiceJournalConsumerVerticleTest extends AbstractRestTest {
     ConsumerRecord<String, String> consumerRecord = buildConsumerRecord(topic, event);
     return new KafkaConsumerRecordImpl<>(consumerRecord);
   }
-
-  private ConsumerRecord<String, String> buildConsumerRecord(String topic, Event event) {
-    ConsumerRecord<java.lang.String, java.lang.String> consumerRecord = new ConsumerRecord("folio", 0, 0, topic, Json.encode(event));
-    consumerRecord.headers().add(new RecordHeader(OKAPI_TENANT_HEADER, TENANT_ID.getBytes(StandardCharsets.UTF_8)));
-    consumerRecord.headers().add(new RecordHeader(OKAPI_URL_HEADER, ("http://localhost:" + snapshotMockServer.port()).getBytes(StandardCharsets.UTF_8)));
-    consumerRecord.headers().add(new RecordHeader(OKAPI_TOKEN_HEADER, (TOKEN).getBytes(StandardCharsets.UTF_8)));
-    return consumerRecord;
-  }
-
 }

--- a/ramls/change-manager.raml
+++ b/ramls/change-manager.raml
@@ -27,6 +27,7 @@ types:
   userInfo: !include raml-storage/schemas/common/userInfo.json
   journalRecord: !include raml-storage/schemas/mod-source-record-manager/journalRecord.json
   dataImportEventTypes: !include raml-storage/schemas/common/dataImportEventTypes.json
+  dataImportInitConfig: !include raml-storage/schemas/common/dataImportInitConfig.json
   jobExecutionProgress: !include raml-storage/schemas/mod-source-record-manager/jobExecutionProgress.json
   dataImportEventPayload: !include raml-storage/schemas/common/dataImportEventPayload.json
   sourceRecordState: !include sourceRecordState.json


### PR DESCRIPTION
## Purpose
Due to flow control changes,  offsets of topic DI_RAW_RECORDS_CHUNK_READ consumed by batches. If next import triggers - it will not appear in Running section on UI, because job execution progress initialized after reading first chunk of DI_RAW_RECORDS_CHUNK_READ topic, so in order to see new import on UI - need to wait until all chunks of previous imports processed.

## Approach

- Introduce new event DI_INITIALIZATION_STARTED (Corresponding PR: https://github.com/folio-org/data-import-raml-storage/pull/263)
- Produce this new event from mod-data-import after finding out how many records input file contains (Corresponding PR: https://github.com/folio-org/mod-data-import/pull/217)
- Initialize job execution progress and update job execution status to be visible in Running section on UI before receiving the first chunk of DI_RAW_RECORDS_CHUNK_READ , this operation should be idempotent(current PR). 

## Learning
https://issues.folio.org/browse/MODSOURMAN-796