### PR TITLE
MODSOURMAN-780 - Improvement for the endpoint returning summary for work accomplished in import

### DIFF
--- a/mod-source-record-manager-server/src/main/java/org/folio/dao/JournalRecordDaoImpl.java
+++ b/mod-source-record-manager-server/src/main/java/org/folio/dao/JournalRecordDaoImpl.java
@@ -412,10 +412,19 @@ public class JournalRecordDaoImpl implements JournalRecordDao {
 
   private EntityProcessingSummary mapToEntityProcessingSummary(Row row, String totalCreatedColumn, String totalUpdatedColumn,
                                                               String totalDiscardedColumn, String totalErrorsColumn) {
+    Integer totalCreated = row.getInteger(totalCreatedColumn);
+    Integer totalUpdated = row.getInteger(totalUpdatedColumn);
+    Integer totalDiscarded = row.getInteger(totalDiscardedColumn);
+    Integer totalErrors = row.getInteger(totalErrorsColumn);
+
+    if (0 == totalCreated && 0 == totalUpdated && 0 == totalDiscarded && 0 == totalErrors) {
+      return null;
+    }
+
     return new EntityProcessingSummary()
-      .withTotalCreatedEntities(row.getInteger(totalCreatedColumn))
-      .withTotalUpdatedEntities(row.getInteger(totalUpdatedColumn))
-      .withTotalDiscardedEntities(row.getInteger(totalDiscardedColumn))
-      .withTotalErrors(row.getInteger(totalErrorsColumn));
+      .withTotalCreatedEntities(totalCreated)
+      .withTotalUpdatedEntities(totalUpdated)
+      .withTotalDiscardedEntities(totalDiscarded)
+      .withTotalErrors(totalErrors);
   }
 }

--- a/mod-source-record-manager-server/src/test/java/org/folio/rest/impl/metadataProvider/MetadataProviderJobExecutionAPITest.java
+++ b/mod-source-record-manager-server/src/test/java/org/folio/rest/impl/metadataProvider/MetadataProviderJobExecutionAPITest.java
@@ -74,6 +74,7 @@ import static org.hamcrest.Matchers.lessThanOrEqualTo;
 import static org.hamcrest.Matchers.not;
 import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.notNullValue;
+import static org.hamcrest.Matchers.nullValue;
 
 /**
  * REST tests for MetadataProvider to manager JobExecution entities
@@ -723,11 +724,10 @@ public class MetadataProviderJobExecutionAPITest extends AbstractRestTest {
         .body("itemSummary.totalUpdatedEntities", is(0))
         .body("itemSummary.totalDiscardedEntities", is(0))
         .body("itemSummary.totalErrors", is(0))
-        .body("authoritySummary.totalCreatedEntities", is(0))
-        .body("authoritySummary.totalUpdatedEntities", is(0))
-        .body("authoritySummary.totalDiscardedEntities", is(0))
-        .body("authoritySummary.totalErrors", is(0))
-        .body("totalErrors", is(0));
+        .body("authoritySummary", nullValue())
+        .body("orderSummary", nullValue())
+        .body("invoiceSummary", nullValue())
+        .body("totalErrors", is(0)).extract().response().prettyPrint();
 
       async.complete();
     }));
@@ -817,6 +817,11 @@ public class MetadataProviderJobExecutionAPITest extends AbstractRestTest {
         .body("instanceSummary.totalUpdatedEntities", is(0))
         .body("instanceSummary.totalDiscardedEntities", is(1))
         .body("instanceSummary.totalErrors", is(0))
+        .body("holdingSummary", nullValue())
+        .body("itemSummary", nullValue())
+        .body("authoritySummary", nullValue())
+        .body("orderSummary", nullValue())
+        .body("invoiceSummary", nullValue())
         .body("totalErrors", is(0));
 
       async.complete();
@@ -915,7 +920,12 @@ public class MetadataProviderJobExecutionAPITest extends AbstractRestTest {
         .body("invoiceSummary.totalUpdatedEntities", is(0))
         .body("invoiceSummary.totalDiscardedEntities", is(0))
         .body("invoiceSummary.totalErrors", is(0))
-        .body("totalErrors", is(0));
+        .body("totalErrors", is(0))
+        .body("instanceSummary", nullValue())
+        .body("holdingSummary", nullValue())
+        .body("itemSummary", nullValue())
+        .body("authoritySummary", nullValue())
+        .body("orderSummary", nullValue());
 
       async.complete();
     }));


### PR DESCRIPTION
## Purpose
for ui needs (scenario 1) it is necessary to distinguish summary data for entity types that were not acted upon import to fill in columns for them with '-' character instead of '0'


## Approach
return null as a summary for the type of entities that were not involved in particular import process (if summary contains only 0 values a null should be returned as entity type summary)


## Learning
[UIDATIMP-1163](https://issues.folio.org/browse/UIDATIMP-1163) (scenario 1)