### PR TITLE
MODSOURMAN-775: Logs show incorrectly formatted request id.

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -27,6 +27,7 @@
 * [MODSOURMAN-802](https://issues.folio.org/browse/MODSOURMAN-802) Block sending "Cancel" signal to finished task.
 * [MODSOURMAN-808](https://issues.folio.org/browse/MODSOURMAN-808) Drop deprecated job_execution(s!) table.
 * [MODSOURMAN-710](https://issues.folio.org/browse/MODSOURMAN-710) Improve performance of sql query for retrieving log data for json screen
+* [MODSOURMAN-775](https://issues.folio.org/browse/MODSOURMAN-775) Logs show incorrectly formatted request id.
 
 ## 2022-xx-xx v3.3.3-SNAPSHOT
 * [MODSOURMAN-746](https://issues.folio.org/browse/MODSOURMAN-746) Avoid creation of trigger for old job progress table which cases an error during jobProgress saving

--- a/mod-source-record-manager-server/src/main/resources/log4j2.properties
+++ b/mod-source-record-manager-server/src/main/resources/log4j2.properties
@@ -1,10 +1,19 @@
 status = warn
 name = PropertiesConfig
 
+packages = org.folio.okapi.common.logging
+
+filters = threshold
+
+filter.threshold.type = ThresholdFilter
+filter.threshold.level = info
+
+appenders = console
+
 appender.console.type = Console
 appender.console.name = STDOUT
 appender.console.layout.type = PatternLayout
-appender.console.layout.pattern = %d{HH:mm:ss.SSS} [%t] %-5p %-20.20C{1} [%reqId] %m%n
+appender.console.layout.pattern = %d{HH:mm:ss.SSS} [%t] [$${FolioLoggingContext:requestid}] %-5p %-20.20C{1} %m%n
 
 logger.folio_services.name = org.folio.services
 logger.folio_services.level = debug

--- a/mod-source-record-manager-server/src/main/resources/log4j2.properties
+++ b/mod-source-record-manager-server/src/main/resources/log4j2.properties
@@ -3,11 +3,6 @@ name = PropertiesConfig
 
 packages = org.folio.okapi.common.logging
 
-filters = threshold
-
-filter.threshold.type = ThresholdFilter
-filter.threshold.level = info
-
 appenders = console
 
 appender.console.type = Console


### PR DESCRIPTION
## Purpose
Improve logging. Added FOLIO-approach for retrieving properties for logging.

## Approach
Retreiving properties from FolioLoggingContext.

#### TODOS and Open Questions

- It seems like these properties are available only for REST-requests.
- We disabled logging for REST-requests. (Just errors)

## Learning
https://issues.folio.org/browse/MODSOURMAN-775
