### PR TITLE
MODSOURMAN-812 RMB v34 upgrade - Morning Glory 2022 R2 module release

### DIFF
--- a/mod-source-record-manager-server/src/test/java/org/folio/verticle/consumers/QuickMarcUpdateKafkaHandlerTest.java
+++ b/mod-source-record-manager-server/src/test/java/org/folio/verticle/consumers/QuickMarcUpdateKafkaHandlerTest.java
@@ -67,7 +67,7 @@ public class QuickMarcUpdateKafkaHandlerTest {
   public void shouldUpdateRecordStateAndSendEventOnHandleQmInventoryInstanceUpdated() {
     var recordId = UUID.randomUUID().toString();
     var recordDtoId = UUID.randomUUID().toString();
-    var kafkaHeaders = List.of(KafkaHeader.header(OKAPI_HEADER_TENANT, TENANT_ID));
+    var kafkaHeaders = List.of(KafkaHeader.header(OKAPI_HEADER_TENANT.toLowerCase(), TENANT_ID));
 
     Map<String, String> eventPayload = new HashMap<>();
     eventPayload.put("RECORD_ID", recordId);
@@ -104,7 +104,7 @@ public class QuickMarcUpdateKafkaHandlerTest {
     var errorMessage = "random error";
     var recordId = UUID.randomUUID().toString();
     var recordDtoId = UUID.randomUUID().toString();
-    var kafkaHeaders = List.of(KafkaHeader.header(OKAPI_HEADER_TENANT, TENANT_ID));
+    var kafkaHeaders = List.of(KafkaHeader.header(OKAPI_HEADER_TENANT.toLowerCase(), TENANT_ID));
 
     Map<String, String> eventPayload = new HashMap<>();
     eventPayload.put("RECORD_ID", recordId);
@@ -140,7 +140,7 @@ public class QuickMarcUpdateKafkaHandlerTest {
   @Test
   public void shouldReturnFailedFutureWhenHandleEncodedEventPayload() {
     var recordId = UUID.randomUUID().toString();
-    var kafkaHeaders = List.of(KafkaHeader.header(OKAPI_HEADER_TENANT, TENANT_ID));
+    var kafkaHeaders = List.of(KafkaHeader.header(OKAPI_HEADER_TENANT.toLowerCase(), TENANT_ID));
 
     Map<String, String> eventPayload = new HashMap<>();
     eventPayload.put("RECORD_ID", recordId);

--- a/mod-source-record-manager-server/src/test/java/org/folio/verticle/consumers/StoredRecordChunksKafkaHandlerTest.java
+++ b/mod-source-record-manager-server/src/test/java/org/folio/verticle/consumers/StoredRecordChunksKafkaHandlerTest.java
@@ -98,7 +98,7 @@ public class StoredRecordChunksKafkaHandlerTest {
       .withEventPayload(Json.encode(recordsBatch));
 
     when(kafkaRecord.value()).thenReturn(Json.encode(event));
-    when(kafkaRecord.headers()).thenReturn(List.of(KafkaHeader.header(OKAPI_HEADER_TENANT, TENANT_ID)));
+    when(kafkaRecord.headers()).thenReturn(List.of(KafkaHeader.header(OKAPI_HEADER_TENANT.toLowerCase(), TENANT_ID)));
     when(eventProcessedService.collectData(STORED_RECORD_CHUNKS_KAFKA_HANDLER_UUID, event.getId(), TENANT_ID))
       .thenReturn(Future.failedFuture(new DuplicateEventException("Constraint Violation Occurs")));
 
@@ -142,7 +142,7 @@ public class StoredRecordChunksKafkaHandlerTest {
       .withEventPayload(Json.encode(savedRecordsBatch));
 
     when(kafkaRecord.value()).thenReturn(Json.encode(event));
-    when(kafkaRecord.headers()).thenReturn(List.of(KafkaHeader.header(OKAPI_HEADER_TENANT, TENANT_ID)));
+    when(kafkaRecord.headers()).thenReturn(List.of(KafkaHeader.header(OKAPI_HEADER_TENANT.toLowerCase(), TENANT_ID)));
     when(eventProcessedService.collectData(STORED_RECORD_CHUNKS_KAFKA_HANDLER_UUID, event.getId(), TENANT_ID)).thenReturn(Future.succeededFuture());
 
     // when
@@ -165,7 +165,7 @@ public class StoredRecordChunksKafkaHandlerTest {
       .withEventPayload(Json.encode(savedRecordsBatch));
 
     when(kafkaRecord.value()).thenReturn(Json.encode(event));
-    when(kafkaRecord.headers()).thenReturn(List.of(KafkaHeader.header(OKAPI_HEADER_TENANT, TENANT_ID)));
+    when(kafkaRecord.headers()).thenReturn(List.of(KafkaHeader.header(OKAPI_HEADER_TENANT.toLowerCase(), TENANT_ID)));
     when(eventProcessedService.collectData(STORED_RECORD_CHUNKS_KAFKA_HANDLER_UUID, event.getId(), TENANT_ID)).thenReturn(Future.succeededFuture());
     when(mappingRuleCache.get(new MappingRuleCacheKey(TENANT_ID, EntityType.EDIFACT))).thenReturn(Future.failedFuture(new Exception()));
 
@@ -189,7 +189,7 @@ public class StoredRecordChunksKafkaHandlerTest {
       .withEventPayload(Json.encode(savedRecordsBatch));
 
     when(kafkaRecord.value()).thenReturn(Json.encode(event));
-    when(kafkaRecord.headers()).thenReturn(List.of(KafkaHeader.header(OKAPI_HEADER_TENANT, TENANT_ID)));
+    when(kafkaRecord.headers()).thenReturn(List.of(KafkaHeader.header(OKAPI_HEADER_TENANT.toLowerCase(), TENANT_ID)));
     when(eventProcessedService.collectData(STORED_RECORD_CHUNKS_KAFKA_HANDLER_UUID, event.getId(), TENANT_ID)).thenReturn(Future.succeededFuture());
     when(mappingRuleCache.get(new MappingRuleCacheKey(TENANT_ID, EntityType.EDIFACT))).thenReturn(Future.failedFuture(new Exception()));
     when(recordsPublishingService
@@ -217,7 +217,7 @@ public class StoredRecordChunksKafkaHandlerTest {
       .withEventPayload(Json.encode(savedRecordsBatch));
 
     when(kafkaRecord.value()).thenReturn(Json.encode(event));
-    when(kafkaRecord.headers()).thenReturn(List.of(KafkaHeader.header(OKAPI_HEADER_TENANT, TENANT_ID)));
+    when(kafkaRecord.headers()).thenReturn(List.of(KafkaHeader.header(OKAPI_HEADER_TENANT.toLowerCase(), TENANT_ID)));
     when(eventProcessedService.collectData(STORED_RECORD_CHUNKS_KAFKA_HANDLER_UUID, event.getId(), TENANT_ID)).thenReturn(Future.succeededFuture());
     when(mappingRuleCache.get(new MappingRuleCacheKey(TENANT_ID, entityType))).thenReturn(Future.succeededFuture(Optional.of(mappingRules)));
     when(recordsPublishingService

--- a/pom.xml
+++ b/pom.xml
@@ -19,7 +19,7 @@
   </modules>
 
   <properties>
-    <raml-module-builder.version>34.0.0</raml-module-builder.version>
+    <raml-module-builder.version>34.1.0</raml-module-builder.version>
     <vertx.version>4.3.1</vertx.version>
     <junit.version>4.13.2</junit.version>
     <rest-assured.version>4.3.1</rest-assured.version>

--- a/pom.xml
+++ b/pom.xml
@@ -19,8 +19,8 @@
   </modules>
 
   <properties>
-    <raml-module-builder.version>33.2.7</raml-module-builder.version>
-    <vertx.version>4.2.6</vertx.version>
+    <raml-module-builder.version>34.0.0</raml-module-builder.version>
+    <vertx.version>4.3.1</vertx.version>
     <junit.version>4.13.2</junit.version>
     <rest-assured.version>4.3.1</rest-assured.version>
     <wiremock.version>2.27.2</wiremock.version>

--- a/pom.xml
+++ b/pom.xml
@@ -19,7 +19,7 @@
   </modules>
 
   <properties>
-    <raml-module-builder.version>34.1.0</raml-module-builder.version>
+    <raml-module-builder.version>34.0.0</raml-module-builder.version>
     <vertx.version>4.3.1</vertx.version>
     <junit.version>4.13.2</junit.version>
     <rest-assured.version>4.3.1</rest-assured.version>


### PR DESCRIPTION
## Approach
I've converted OKAPI_HEADER_TENANT in tests bellow to lower case because these [changes](https://github.com/folio-org/raml-module-builder/commit/94a085e6a71e16c71cc661fbbd59577b7ca752ca#diff-91377a3321186e8203264c2555b10f7989fad363da8ab2a3270e5ae5afad7046R37) affected to tests after upgrading rmb to 34.0.0 version.
