### PR TITLE
MODSOURMAN-818 - Improve endpoints to get job executions profiles and users

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,6 @@
+## 2022-xx-xx v3.4.1-SNAPSHOT
+* [MODSOURMAN-818](https://issues.folio.org/browse/MODSOURMAN-818) Improve endpoints to get job executions profiles and users
+
 ## 2022-xx-xx v3.4.0-SNAPSHOT
 * [MODSOURMAN-691](https://issues.folio.org/browse/MODSOURMAN-691) Support Delete MARC Authority Action
 * [MODSOURMAN-707](https://issues.folio.org/browse/MODSOURMAN-707) Suppress Delete Authority job logs from Data Import log UI

--- a/mod-source-record-manager-server/src/main/java/org/folio/dao/util/JobExecutionDBConstants.java
+++ b/mod-source-record-manager-server/src/main/java/org/folio/dao/util/JobExecutionDBConstants.java
@@ -75,7 +75,7 @@ public final class JobExecutionDBConstants {
   public static final String GET_RELATED_JOB_PROFILES_SQL =
     "WITH unique_profiles AS (SELECT DISTINCT job_profile_id, job_profile_name, job_profile_data_type, job_profile_hidden " +
     "FROM %s " +
-    "WHERE job_profile_id IS NOT NULL AND job_profile_hidden = false), " +
+    "WHERE job_profile_id IS NOT NULL AND job_profile_hidden = false AND is_deleted = false), " +
     "total AS (SELECT count(*) AS total_count FROM unique_profiles) " +
     "SELECT j.*, p.* " +
     "FROM unique_profiles j " +
@@ -83,7 +83,7 @@ public final class JobExecutionDBConstants {
     "LIMIT $1 OFFSET $2";
 
   public static final String GET_UNIQUE_USERS = "WITH unique_users AS (SELECT DISTINCT user_id, " +
-    "job_user_first_name, job_user_last_name FROM %s  WHERE job_profile_hidden = false)," +
+    "job_user_first_name, job_user_last_name FROM %s WHERE job_profile_hidden = false AND is_deleted = false)," +
     "total AS (SELECT count(*) AS total_count FROM unique_users)" +
     "SELECT j.*, p.* FROM unique_users j LEFT JOIN total p ON true LIMIT $1 OFFSET $2";
 

--- a/mod-source-record-manager-server/src/test/java/org/folio/rest/impl/metadataProvider/MetadataProviderJobExecutionAPITest.java
+++ b/mod-source-record-manager-server/src/test/java/org/folio/rest/impl/metadataProvider/MetadataProviderJobExecutionAPITest.java
@@ -14,6 +14,7 @@ import org.folio.dao.JournalRecordDaoImpl;
 import org.folio.dao.util.PostgresClientFactory;
 import org.folio.rest.impl.AbstractRestTest;
 import org.folio.rest.impl.changeManager.ChangeManagerAPITest;
+import org.folio.rest.jaxrs.model.DeleteJobExecutionsReq;
 import org.folio.rest.jaxrs.model.DeleteJobExecutionsResp;
 import org.folio.rest.jaxrs.model.EntityType;
 import org.folio.rest.jaxrs.model.InitJobExecutionsRsDto;
@@ -1097,7 +1098,7 @@ public class MetadataProviderJobExecutionAPITest extends AbstractRestTest {
   }
 
   @Test
-  public void shouldNotReturnDeletedJobExecutionRecords(TestContext context) {
+  public void shouldNotReturnDeletedJobExecutionRecords() {
     JobExecution createdJobExecution = constructAndPostInitJobExecutionRqDto(1).getJobExecutions().get(0);
 
     putJobExecution(createdJobExecution);
@@ -1194,6 +1195,48 @@ public class MetadataProviderJobExecutionAPITest extends AbstractRestTest {
   }
 
   @Test
+  public void shouldNotReturnJobProfilesForJobExecutionsMarkedAsDeleted() {
+    String nonExpectedJobProfileId = UUID.randomUUID().toString();
+    List<JobExecution> childJobs = constructAndPostInitJobExecutionRqDto(4).getJobExecutions().stream()
+      .filter(jobExecution -> jobExecution.getSubordinationType().equals(CHILD))
+      .collect(Collectors.toList());
+
+    for (int i = 0; i < childJobs.size(); i++) {
+      String id = (i % 2 == 0) ? nonExpectedJobProfileId : UUID.randomUUID().toString();
+      childJobs.get(i).withJobProfileInfo(new JobProfileInfo()
+        .withId(id)
+        .withName("test")
+        .withDataType(MARC));
+      putJobExecution(childJobs.get(i));
+    }
+
+    List<String> jobIdsToMarkAsDeleted = childJobs.stream()
+      .filter(job -> job.getJobProfileInfo().getId().equals(nonExpectedJobProfileId))
+      .map(JobExecution::getId)
+      .collect(Collectors.toList());
+
+    // Marks job executions as deleted which contain nonExpectedJobProfileId in the jobProfileInfo
+    RestAssured.given()
+      .spec(spec)
+      .body(new DeleteJobExecutionsReq().withIds(jobIdsToMarkAsDeleted))
+      .delete(JOB_EXECUTION_PATH)
+      .then()
+      .statusCode(HttpStatus.SC_OK)
+      .body("jobExecutionDetails*.isDeleted", everyItem(is(true)));
+
+    int expectedProfilesNumber = childJobs.size() / 2;
+    RestAssured.given()
+      .spec(spec)
+      .get(GET_JOB_EXECUTION_JOB_PROFILES_PATH)
+      .then()
+      .log().all()
+      .statusCode(HttpStatus.SC_OK)
+      .body("jobProfilesInfo.size()", is(expectedProfilesNumber))
+      .body("jobProfilesInfo*.id", everyItem(not(is(nonExpectedJobProfileId))))
+      .body("totalRecords", is(expectedProfilesNumber));
+  }
+
+  @Test
   public void shouldReturnEmptyUsersInfoCollection() {
     RestAssured.given()
       .spec(spec)
@@ -1272,4 +1315,42 @@ public class MetadataProviderJobExecutionAPITest extends AbstractRestTest {
       .body("jobExecutionUsersInfo[0].jobUserLastName", is("ADMINISTRATOR"))
       .body("totalRecords", is(1));
   }
+
+  @Test
+  public void shouldNotReturnUsersForJobExecutionsMarkedAsDeleted() {
+    String nonExpectedUserId = UUID.randomUUID().toString();
+    // Creates 1 parent job and 3 child job executions
+    List<JobExecution> jobExecutions = constructAndPostInitJobExecutionRqDto(3).getJobExecutions();
+
+    for (int i = 0; i < jobExecutions.size(); i++) {
+      String userId = (i % 2 == 0) ? nonExpectedUserId : UUID.randomUUID().toString();
+      putJobExecution(jobExecutions.get(i).withUserId(userId));
+    }
+
+    List<String> jobIdsToMarkAsDeleted = jobExecutions.stream()
+      .filter(job -> job.getUserId().equals(nonExpectedUserId))
+      .map(JobExecution::getId)
+      .collect(Collectors.toList());
+
+    // Marks job executions as deleted which contain nonExpectedUserId
+    RestAssured.given()
+      .spec(spec)
+      .body(new DeleteJobExecutionsReq().withIds(jobIdsToMarkAsDeleted))
+      .delete(JOB_EXECUTION_PATH)
+      .then()
+      .statusCode(HttpStatus.SC_OK)
+      .body("jobExecutionDetails*.isDeleted", everyItem(is(true)));
+
+    int expectedProfilesNumber = jobExecutions.size() / 2;
+    RestAssured.given()
+      .spec(spec)
+      .when()
+      .get(GET_UNIQUE_USERS_INFO)
+      .then()
+      .statusCode(HttpStatus.SC_OK)
+      .body("jobExecutionUsersInfo.size()", is(expectedProfilesNumber))
+      .body("jobExecutionUsersInfo*.id", everyItem(not(is(nonExpectedUserId))))
+      .body("totalRecords", is(expectedProfilesNumber));
+  }
+
 }


### PR DESCRIPTION
## Purpose
to avoid returning profiles and users for filters on the "view all" page, that mentioned only in job executions marked as deleted

## Approach
* filter job profiles and users by job executions that are not marked as deleted (where column "is_deleted" = false)
* add tests

## Learning
[MODSOURMAN-818](https://issues.folio.org/browse/MODSOURMAN-818)