### PR TITLE
MODSOURCE-521 Populate 035 fields for exceptional cases of Update action

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -35,7 +35,6 @@
 * [MODSOURMAN-775](https://issues.folio.org/browse/MODSOURMAN-775) Logs show incorrectly formatted request id.
 * [MODSOURMAN-810](https://issues.folio.org/browse/MODSOURMAN-810) Improve summary endpoint by parameter "entityType"
 * [MODSOURMAN-811](https://issues.folio.org/browse/MODSOURMAN-811) Ensure proper work of flow control in multi-instances and multi-partitions envs
-* [MODSOURCE-509](https://issues.folio.org/browse/MODSOURCE-509) Data Import Updates should add 035 field if it's not HRID or it is already exists. Removed HridFieldService
 * [MODSOURMAN-813](https://issues.folio.org/browse/MODSOURMAN-813) Remove JobExecutionCache to improve progress bar on distributed envs
 * [MODSOURMAN-814](https://issues.folio.org/browse/MODSOURMAN-814) Adjust totalRecords field for filtered jobLogEntries
 * [MODSOURMAN-814](https://issues.folio.org/browse/MODSOURMAN-814) Send DI_MARC_FOR_UPDATE_RECEIVED event if job profile contains action for instance update

--- a/mod-source-record-manager-server/src/main/java/org/folio/services/ChangeEngineServiceImpl.java
+++ b/mod-source-record-manager-server/src/main/java/org/folio/services/ChangeEngineServiceImpl.java
@@ -80,6 +80,7 @@ import org.folio.rest.jaxrs.model.Record.RecordType;
 import org.folio.rest.jaxrs.model.RecordCollection;
 import org.folio.rest.jaxrs.model.RecordsMetadata;
 import org.folio.rest.jaxrs.model.StatusDto;
+import org.folio.services.afterprocessing.HrIdFieldService;
 import org.folio.services.parsers.ParsedResult;
 import org.folio.services.parsers.RecordParserBuilder;
 import org.folio.services.util.RecordConversionUtil;
@@ -105,6 +106,7 @@ public class ChangeEngineServiceImpl implements ChangeEngineService {
   private final JobExecutionSourceChunkDao jobExecutionSourceChunkDao;
   private final JobExecutionService jobExecutionService;
   private final RecordAnalyzer marcRecordAnalyzer;
+  private final HrIdFieldService hrIdFieldService;
   private final RecordsPublishingService recordsPublishingService;
   private final MappingMetadataService mappingMetadataService;
   private final KafkaConfig kafkaConfig;
@@ -118,12 +120,14 @@ public class ChangeEngineServiceImpl implements ChangeEngineService {
   public ChangeEngineServiceImpl(@Autowired JobExecutionSourceChunkDao jobExecutionSourceChunkDao,
                                  @Autowired JobExecutionService jobExecutionService,
                                  @Autowired MarcRecordAnalyzer marcRecordAnalyzer,
+                                 @Autowired HrIdFieldService hrIdFieldService,
                                  @Autowired RecordsPublishingService recordsPublishingService,
                                  @Autowired MappingMetadataService mappingMetadataService,
                                  @Autowired KafkaConfig kafkaConfig) {
     this.jobExecutionSourceChunkDao = jobExecutionSourceChunkDao;
     this.jobExecutionService = jobExecutionService;
     this.marcRecordAnalyzer = marcRecordAnalyzer;
+    this.hrIdFieldService = hrIdFieldService;
     this.recordsPublishingService = recordsPublishingService;
     this.mappingMetadataService = mappingMetadataService;
     this.kafkaConfig = kafkaConfig;
@@ -526,6 +530,7 @@ public class ChangeEngineServiceImpl implements ChangeEngineService {
     if (!CollectionUtils.isEmpty(records)) {
       Record.RecordType recordType = records.get(0).getRecordType();
       if (MARC_BIB.equals(recordType) || MARC_HOLDING.equals(recordType)) {
+        hrIdFieldService.move001valueTo035Field(records);
         for (Record record : records) {
           addFieldToMarcRecord(record, TAG_999, SUBFIELD_S, record.getMatchedId());
         }

--- a/mod-source-record-manager-server/src/main/java/org/folio/services/ChangeEngineServiceImpl.java
+++ b/mod-source-record-manager-server/src/main/java/org/folio/services/ChangeEngineServiceImpl.java
@@ -147,6 +147,7 @@ public class ChangeEngineServiceImpl implements ChangeEngineService {
         fillParsedRecordsWithAdditionalFields(parsedRecords);
 
         if (updateMarcActionExists(jobExecution) || updateInstanceActionExists(jobExecution)) {
+          hrIdFieldService.move001valueTo035Field(parsedRecords);
           updateRecords(parsedRecords, jobExecution, params)
             .onSuccess(ar -> promise.complete(parsedRecords))
             .onFailure(promise::fail);
@@ -530,7 +531,6 @@ public class ChangeEngineServiceImpl implements ChangeEngineService {
     if (!CollectionUtils.isEmpty(records)) {
       Record.RecordType recordType = records.get(0).getRecordType();
       if (MARC_BIB.equals(recordType) || MARC_HOLDING.equals(recordType)) {
-        hrIdFieldService.move001valueTo035Field(records);
         for (Record record : records) {
           addFieldToMarcRecord(record, TAG_999, SUBFIELD_S, record.getMatchedId());
         }

--- a/mod-source-record-manager-server/src/main/java/org/folio/services/afterprocessing/HrIdFieldService.java
+++ b/mod-source-record-manager-server/src/main/java/org/folio/services/afterprocessing/HrIdFieldService.java
@@ -1,0 +1,16 @@
+package org.folio.services.afterprocessing;
+
+import org.folio.rest.jaxrs.model.Record;
+
+import java.util.List;
+
+public interface HrIdFieldService {
+
+  /**
+   * Method move 001 field to 035
+   *
+   * @param records - list of MARC records
+   */
+  void move001valueTo035Field(List<Record> records);
+
+}

--- a/mod-source-record-manager-server/src/main/java/org/folio/services/afterprocessing/HrIdFieldServiceImpl.java
+++ b/mod-source-record-manager-server/src/main/java/org/folio/services/afterprocessing/HrIdFieldServiceImpl.java
@@ -1,0 +1,44 @@
+package org.folio.services.afterprocessing;
+
+import org.folio.rest.jaxrs.model.Record;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+import java.util.Objects;
+
+import static org.apache.commons.lang3.StringUtils.isBlank;
+import static org.folio.services.afterprocessing.AdditionalFieldsUtil.addDataFieldToMarcRecord;
+import static org.folio.services.afterprocessing.AdditionalFieldsUtil.getValue;
+import static org.folio.services.afterprocessing.AdditionalFieldsUtil.isFieldExist;
+
+@Service
+public class HrIdFieldServiceImpl implements HrIdFieldService {
+
+  private static final String TAG_001 = "001";
+  private static final String TAG_003 = "003";
+  private static final String TAG_035 = "035";
+  private static final char SUBFIELD_FOR_035 = 'a';
+  private static final char INDICATOR_FOR_035 = ' ';
+
+  @Override
+  public void move001valueTo035Field(List<Record> records) {
+    records.stream().parallel().forEach(record -> {
+      String valueFrom035 = getValue(record, TAG_035, SUBFIELD_FOR_035);
+      if (Objects.isNull(valueFrom035)) {
+        String valueFrom001 = getValue(record, TAG_001, ' ');
+        String valueFor035 = mergeFieldsFor035(getValue(record, TAG_003, ' '), valueFrom001);
+        if (valueFrom001 != null && !isFieldExist(record, TAG_035, SUBFIELD_FOR_035, valueFor035)) {
+          addDataFieldToMarcRecord(record, TAG_035, INDICATOR_FOR_035, INDICATOR_FOR_035, SUBFIELD_FOR_035, valueFor035);
+        }
+      }
+    });
+  }
+
+  private String mergeFieldsFor035(String valueFrom003, String valueFrom001) {
+    if (isBlank(valueFrom003)) {
+      return valueFrom001;
+    }
+    return "(" + valueFrom003 + ")" + valueFrom001;
+  }
+
+}

--- a/mod-source-record-manager-server/src/main/java/org/folio/services/afterprocessing/HrIdFieldServiceImpl.java
+++ b/mod-source-record-manager-server/src/main/java/org/folio/services/afterprocessing/HrIdFieldServiceImpl.java
@@ -23,13 +23,10 @@ public class HrIdFieldServiceImpl implements HrIdFieldService {
   @Override
   public void move001valueTo035Field(List<Record> records) {
     records.stream().parallel().forEach(record -> {
-      String valueFrom035 = getValue(record, TAG_035, SUBFIELD_FOR_035);
-      if (Objects.isNull(valueFrom035)) {
-        String valueFrom001 = getValue(record, TAG_001, ' ');
-        String valueFor035 = mergeFieldsFor035(getValue(record, TAG_003, ' '), valueFrom001);
-        if (valueFrom001 != null && !isFieldExist(record, TAG_035, SUBFIELD_FOR_035, valueFor035)) {
-          addDataFieldToMarcRecord(record, TAG_035, INDICATOR_FOR_035, INDICATOR_FOR_035, SUBFIELD_FOR_035, valueFor035);
-        }
+      String valueFrom001 = getValue(record, TAG_001, ' ');
+      String valueFor035 = mergeFieldsFor035(getValue(record, TAG_003, ' '), valueFrom001);
+      if (valueFrom001 != null && !isFieldExist(record, TAG_035, SUBFIELD_FOR_035, valueFor035)) {
+        addDataFieldToMarcRecord(record, TAG_035, INDICATOR_FOR_035, INDICATOR_FOR_035, SUBFIELD_FOR_035, valueFor035);
       }
     });
   }

--- a/mod-source-record-manager-server/src/test/java/org/folio/services/ChangeEngineServiceImplTest.java
+++ b/mod-source-record-manager-server/src/test/java/org/folio/services/ChangeEngineServiceImplTest.java
@@ -51,6 +51,7 @@ import org.folio.rest.jaxrs.model.ProfileSnapshotWrapper;
 import org.folio.rest.jaxrs.model.RawRecordsDto;
 import org.folio.rest.jaxrs.model.Record;
 import org.folio.rest.jaxrs.model.RecordsMetadata;
+import org.folio.services.afterprocessing.HrIdFieldService;
 import org.folio.services.util.EventHandlingUtil;
 
 @RunWith(MockitoJUnitRunner.class)
@@ -72,6 +73,8 @@ public class ChangeEngineServiceImplTest {
   private JobExecutionService jobExecutionService;
   @Mock
   private MarcRecordAnalyzer marcRecordAnalyzer;
+  @Mock
+  private HrIdFieldService hrIdFieldService;
   @Mock
   private RecordsPublishingService recordsPublishingService;
   @Mock

--- a/mod-source-record-manager-server/src/test/java/org/folio/services/EventDrivenChunkProcessingServiceImplTest.java
+++ b/mod-source-record-manager-server/src/test/java/org/folio/services/EventDrivenChunkProcessingServiceImplTest.java
@@ -35,6 +35,7 @@ import org.folio.rest.jaxrs.model.JobProfileInfo.DataType;
 import org.folio.rest.jaxrs.model.RawRecordsDto;
 import org.folio.rest.jaxrs.model.RecordsMetadata;
 import org.folio.rest.jaxrs.model.StatusDto;
+import org.folio.services.afterprocessing.HrIdFieldServiceImpl;
 import org.folio.services.mappers.processor.MappingParametersProvider;
 import org.folio.services.progress.JobExecutionProgressServiceImpl;
 import org.junit.After;
@@ -128,6 +129,8 @@ public class EventDrivenChunkProcessingServiceImplTest extends AbstractRestTest 
   @InjectMocks
   private JobMonitoringDaoImpl jobMonitoringDao;
   @Spy
+  private HrIdFieldServiceImpl hrIdFieldService;
+  @Spy
   @InjectMocks
   private JournalRecordDaoImpl journalRecordDao;
   @Spy
@@ -183,7 +186,7 @@ public class EventDrivenChunkProcessingServiceImplTest extends AbstractRestTest 
     mappingParametersProvider = when(mock(MappingParametersProvider.class).get(anyString(), any(OkapiConnectionParams.class))).thenReturn(Future.succeededFuture(new MappingParameters())).getMock();
 
     mappingMetadataService = new MappingMetadataServiceImpl(mappingParametersProvider, mappingRuleService, mappingRulesSnapshotDao, mappingParamsSnapshotDao);
-    changeEngineService = new ChangeEngineServiceImpl(jobExecutionSourceChunkDao, jobExecutionService, marcRecordAnalyzer, recordsPublishingService, mappingMetadataService, kafkaConfig);
+    changeEngineService = new ChangeEngineServiceImpl(jobExecutionSourceChunkDao, jobExecutionService, marcRecordAnalyzer, hrIdFieldService, recordsPublishingService, mappingMetadataService, kafkaConfig);
     ReflectionTestUtils.setField(changeEngineService, "maxDistributionNum", 10);
     ReflectionTestUtils.setField(changeEngineService, "batchSize", 100);
     chunkProcessingService = new EventDrivenChunkProcessingServiceImpl(jobExecutionSourceChunkDao, jobExecutionService, changeEngineService, jobExecutionProgressService);

--- a/mod-source-record-manager-server/src/test/java/org/folio/services/HrIdFieldServiceTest.java
+++ b/mod-source-record-manager-server/src/test/java/org/folio/services/HrIdFieldServiceTest.java
@@ -1,0 +1,82 @@
+package org.folio.services;
+
+import java.util.UUID;
+
+import org.assertj.core.util.Lists;
+import org.folio.rest.jaxrs.model.ExternalIdsHolder;
+import org.folio.rest.jaxrs.model.ParsedRecord;
+import org.folio.rest.jaxrs.model.Record;
+import org.folio.services.afterprocessing.HrIdFieldService;
+import org.folio.services.afterprocessing.HrIdFieldServiceImpl;
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import io.vertx.ext.unit.junit.VertxUnitRunner;
+
+@RunWith(VertxUnitRunner.class)
+public class HrIdFieldServiceTest {
+
+  @Test
+  public void shouldAdd035FieldIf001FieldExists(){
+    // given
+    String parsedContent = "{\"leader\":\"00115nam  22000731a 4500\",\"fields\":[{\"001\":\"in001\"},{\"507\":{\"subfields\":[{\"a\":\"data\"}],\"ind1\":\" \",\"ind2\":\" \"}},{\"500\":{\"subfields\":[{\"a\":\"data\"}],\"ind1\":\" \",\"ind2\":\" \"}}]}";
+    String expectedParsedContent = "{\"leader\":\"00108nam  22000731a 4500\",\"fields\":[{\"001\":\"in001\"},{\"035\":{\"subfields\":[{\"a\":\"in001\"}],\"ind1\":\" \",\"ind2\":\" \"}},{\"507\":{\"subfields\":[{\"a\":\"data\"}],\"ind1\":\" \",\"ind2\":\" \"}},{\"500\":{\"subfields\":[{\"a\":\"data\"}],\"ind1\":\" \",\"ind2\":\" \"}}]}";
+    ParsedRecord parsedRecord = new ParsedRecord();
+    parsedRecord.setContent(parsedContent);
+
+    Record record = new Record().withId(UUID.randomUUID().toString())
+      .withParsedRecord(parsedRecord)
+      .withGeneration(0)
+      .withState(Record.State.ACTUAL)
+      .withExternalIdsHolder(new ExternalIdsHolder().withInstanceId("001").withInstanceHrid("in001"));
+
+    // when
+    HrIdFieldService hrIdFieldService = new HrIdFieldServiceImpl();
+    hrIdFieldService.move001valueTo035Field(Lists.newArrayList(record));
+    // then
+    Assert.assertEquals(expectedParsedContent, record.getParsedRecord().getContent());
+  }
+
+  @Test
+  public void shouldNotAdd035FieldIf001FieldNotExists(){
+    // given
+    String parsedContent = "{\"leader\":\"00115nam  22000731a 4500\",\"fields\":[{\"003\":\"in001\"},{\"507\":{\"subfields\":[{\"a\":\"data\"}],\"ind1\":\" \",\"ind2\":\" \"}},{\"500\":{\"subfields\":[{\"a\":\"data\"}],\"ind1\":\" \",\"ind2\":\" \"}}]}";
+    String expectedParsedContent = "{\"leader\":\"00115nam  22000731a 4500\",\"fields\":[{\"003\":\"in001\"},{\"507\":{\"subfields\":[{\"a\":\"data\"}],\"ind1\":\" \",\"ind2\":\" \"}},{\"500\":{\"subfields\":[{\"a\":\"data\"}],\"ind1\":\" \",\"ind2\":\" \"}}]}";
+    ParsedRecord parsedRecord = new ParsedRecord();
+    parsedRecord.setContent(parsedContent);
+
+    Record record = new Record().withId(UUID.randomUUID().toString())
+      .withParsedRecord(parsedRecord)
+      .withGeneration(0)
+      .withState(Record.State.ACTUAL)
+      .withExternalIdsHolder(new ExternalIdsHolder().withInstanceId("001").withInstanceHrid("in001"));
+
+    // when
+    HrIdFieldService hrIdFieldService = new HrIdFieldServiceImpl();
+    hrIdFieldService.move001valueTo035Field(Lists.newArrayList(record));
+    // then
+    Assert.assertEquals(expectedParsedContent, record.getParsedRecord().getContent());
+  }
+
+  @Test
+  public void shouldNotAdd035FieldIf035FieldExists(){
+    // given
+    String parsedContent = "{\"leader\":\"00115nam  22000731a 4500\",\"fields\":[{\"001\":\"in001\"},{\"003\":\"in001\"},{\"035\":{\"subfields\":[{\"a\":\"(test)data\"}],\"ind1\":\" \",\"ind2\":\" \"}},{\"507\":{\"subfields\":[{\"a\":\"data\"}],\"ind1\":\" \",\"ind2\":\" \"}},{\"500\":{\"subfields\":[{\"a\":\"data\"}],\"ind1\":\" \",\"ind2\":\" \"}}]}";
+    String expectedParsedContent = "{\"leader\":\"00115nam  22000731a 4500\",\"fields\":[{\"001\":\"in001\"},{\"003\":\"in001\"},{\"035\":{\"subfields\":[{\"a\":\"(test)data\"}],\"ind1\":\" \",\"ind2\":\" \"}},{\"507\":{\"subfields\":[{\"a\":\"data\"}],\"ind1\":\" \",\"ind2\":\" \"}},{\"500\":{\"subfields\":[{\"a\":\"data\"}],\"ind1\":\" \",\"ind2\":\" \"}}]}";
+    ParsedRecord parsedRecord = new ParsedRecord();
+    parsedRecord.setContent(parsedContent);
+
+    Record record = new Record().withId(UUID.randomUUID().toString())
+      .withParsedRecord(parsedRecord)
+      .withGeneration(0)
+      .withState(Record.State.ACTUAL)
+      .withExternalIdsHolder(new ExternalIdsHolder().withInstanceId("001").withInstanceHrid("in001"));
+
+    // when
+    HrIdFieldService hrIdFieldService = new HrIdFieldServiceImpl();
+    hrIdFieldService.move001valueTo035Field(Lists.newArrayList(record));
+    // then
+    Assert.assertEquals(expectedParsedContent, record.getParsedRecord().getContent());
+  }
+}

--- a/mod-source-record-manager-server/src/test/java/org/folio/services/HrIdFieldServiceTest.java
+++ b/mod-source-record-manager-server/src/test/java/org/folio/services/HrIdFieldServiceTest.java
@@ -60,10 +60,10 @@ public class HrIdFieldServiceTest {
   }
 
   @Test
-  public void shouldNotAdd035FieldIf035FieldExists(){
+  public void shouldAdd035FieldIf035FieldExists(){
     // given
-    String parsedContent = "{\"leader\":\"00115nam  22000731a 4500\",\"fields\":[{\"001\":\"in001\"},{\"003\":\"in001\"},{\"035\":{\"subfields\":[{\"a\":\"(test)data\"}],\"ind1\":\" \",\"ind2\":\" \"}},{\"507\":{\"subfields\":[{\"a\":\"data\"}],\"ind1\":\" \",\"ind2\":\" \"}},{\"500\":{\"subfields\":[{\"a\":\"data\"}],\"ind1\":\" \",\"ind2\":\" \"}}]}";
-    String expectedParsedContent = "{\"leader\":\"00115nam  22000731a 4500\",\"fields\":[{\"001\":\"in001\"},{\"003\":\"in001\"},{\"035\":{\"subfields\":[{\"a\":\"(test)data\"}],\"ind1\":\" \",\"ind2\":\" \"}},{\"507\":{\"subfields\":[{\"a\":\"data\"}],\"ind1\":\" \",\"ind2\":\" \"}},{\"500\":{\"subfields\":[{\"a\":\"data\"}],\"ind1\":\" \",\"ind2\":\" \"}}]}";
+    String parsedContent = "{\"leader\":\"00115nam  22000731a 4500\",\"fields\":[{\"001\":\"12345\"},{\"035\":{\"subfields\":[{\"a\":\"(test)data\"}],\"ind1\":\" \",\"ind2\":\" \"}},{\"507\":{\"subfields\":[{\"a\":\"data\"}],\"ind1\":\" \",\"ind2\":\" \"}},{\"500\":{\"subfields\":[{\"a\":\"data\"}],\"ind1\":\" \",\"ind2\":\" \"}}]}";
+    String expectedParsedContent = "{\"leader\":\"00135nam  22000851a 4500\",\"fields\":[{\"001\":\"12345\"},{\"035\":{\"subfields\":[{\"a\":\"(test)data\"}],\"ind1\":\" \",\"ind2\":\" \"}},{\"035\":{\"subfields\":[{\"a\":\"12345\"}],\"ind1\":\" \",\"ind2\":\" \"}},{\"507\":{\"subfields\":[{\"a\":\"data\"}],\"ind1\":\" \",\"ind2\":\" \"}},{\"500\":{\"subfields\":[{\"a\":\"data\"}],\"ind1\":\" \",\"ind2\":\" \"}}]}";
     ParsedRecord parsedRecord = new ParsedRecord();
     parsedRecord.setContent(parsedContent);
 

--- a/mod-source-record-manager-server/src/test/java/org/folio/services/RecordProcessedEventHandlingServiceImplTest.java
+++ b/mod-source-record-manager-server/src/test/java/org/folio/services/RecordProcessedEventHandlingServiceImplTest.java
@@ -71,6 +71,7 @@ import org.folio.kafka.KafkaConfig;
 import org.folio.processing.mapping.defaultmapper.processor.parameters.MappingParameters;
 import org.folio.rest.impl.AbstractRestTest;
 import org.folio.rest.jaxrs.model.JobProfileInfo.DataType;
+import org.folio.services.afterprocessing.HrIdFieldServiceImpl;
 import org.folio.services.journal.JournalServiceImpl;
 import org.folio.services.mappers.processor.MappingParametersProvider;
 import org.folio.services.progress.JobExecutionProgressServiceImpl;
@@ -115,6 +116,8 @@ public class RecordProcessedEventHandlingServiceImplTest extends AbstractRestTes
   @Spy
   @InjectMocks
   private JobExecutionProgressServiceImpl jobExecutionProgressService;
+  @Spy
+  private HrIdFieldServiceImpl hrIdFieldService;
   @Spy
   @InjectMocks
   private JournalRecordDaoImpl journalRecordDao;
@@ -191,7 +194,7 @@ public class RecordProcessedEventHandlingServiceImplTest extends AbstractRestTes
     mappingRuleDao = when(mock(MappingRuleDaoImpl.class).get(any(), anyString())).thenReturn(Future.succeededFuture(Optional.of(new JsonObject(rules)))).getMock();
     mappingParametersProvider = when(mock(MappingParametersProvider.class).get(anyString(), any(OkapiConnectionParams.class))).thenReturn(Future.succeededFuture(new MappingParameters())).getMock();
     mappingMetadataService = new MappingMetadataServiceImpl(mappingParametersProvider, mappingRuleService, mappingRulesSnapshotDao, mappingParamsSnapshotDao);
-    changeEngineService = new ChangeEngineServiceImpl(jobExecutionSourceChunkDao, jobExecutionService, marcRecordAnalyzer , recordsPublishingService, mappingMetadataService, kafkaConfig);
+    changeEngineService = new ChangeEngineServiceImpl(jobExecutionSourceChunkDao, jobExecutionService, marcRecordAnalyzer, hrIdFieldService , recordsPublishingService, mappingMetadataService, kafkaConfig);
     ReflectionTestUtils.setField(changeEngineService, "maxDistributionNum", 10);
     ReflectionTestUtils.setField(changeEngineService, "batchSize", 100);
     chunkProcessingService = new EventDrivenChunkProcessingServiceImpl(jobExecutionSourceChunkDao, jobExecutionService, changeEngineService, jobExecutionProgressService);


### PR DESCRIPTION
Data Import Updates should add 035 field from 001/003, but only for exceptional Update scenarions (in such cases records are not prior saved in SRS, where 035 fields are handled)
035 fields should also be added if other 035 fields exist in the record

## Approach
Removing the creation of field 035 on the fly was erroneous because it caused an error: "MODSOURCE-521
Matching on created 035 does not work in Lotus or MG"
Remove the limitation on number of 035 fields
Construct 035 from 001 and 003 only for exceptional Update scenarios