### PR TITLE
MODSOURMAN-846 Optimize data access for job execution progress update

### DIFF
--- a/mod-source-record-manager-server/src/main/java/org/folio/dao/JobExecutionProgressDao.java
+++ b/mod-source-record-manager-server/src/main/java/org/folio/dao/JobExecutionProgressDao.java
@@ -51,4 +51,16 @@ public interface JobExecutionProgressDao {
    * @return future with updated jobExecutionProgress
    */
   Future<JobExecutionProgress> updateByJobExecutionId(String jobExecutionId, UnaryOperator<JobExecutionProgress> progressMutator, String tenantId);
+
+  /**
+   * Updates jobExecutionProgress entity by jobExecutionId in database by adding delta to existing success and error
+   * counts.
+   *
+   * @param jobExecutionId  jobExecution id
+   * @param successCountDelta number of successful executions
+   * @param errorCountDelta number of failed executions
+   * @param tenantId        tenant id
+   * @return future with updated jobExecutionProgress
+   */
+  Future<JobExecutionProgress> updateCompletionCounts(String jobExecutionId, int successCountDelta, int errorCountDelta, String tenantId);
 }

--- a/mod-source-record-manager-server/src/main/java/org/folio/services/progress/JobExecutionProgressService.java
+++ b/mod-source-record-manager-server/src/main/java/org/folio/services/progress/JobExecutionProgressService.java
@@ -39,4 +39,20 @@ public interface JobExecutionProgressService {
    * @return future with updated jobExecutionProgress
    */
   Future<JobExecutionProgress> updateJobExecutionProgress(String jobExecutionId, UnaryOperator<JobExecutionProgress> progressMutator, String tenantId);
+
+  /**
+   * Updates jobExecutionProgress entity by adding deltas to the number of success and error counts.
+   * <p>
+   * EXAMPLE:
+   *  a success count of 5 and an error count of 0 means that the success count will be increased by 5 and the
+   *  error count will remain unchanged in jobExecutionProgress entity.
+   *
+   *
+   * @param jobExecutionId  jobExecution id
+   * @param successCountDelta number of successful executions
+   * @param errorCountDelta number of failed executions
+   * @param tenantId        tenant id
+   * @return future with updated jobExecutionProgress
+   */
+  Future<JobExecutionProgress> updateCompletionCounts(String jobExecutionId, int successCountDelta, int errorCountDelta, String tenantId);
 }

--- a/mod-source-record-manager-server/src/main/java/org/folio/services/progress/JobExecutionProgressServiceImpl.java
+++ b/mod-source-record-manager-server/src/main/java/org/folio/services/progress/JobExecutionProgressServiceImpl.java
@@ -44,4 +44,12 @@ public class JobExecutionProgressServiceImpl implements JobExecutionProgressServ
     jobMonitoringService.updateByJobExecutionId(jobExecutionId, new Date(), false, tenantId);
     return jobExecutionProgressDao.updateByJobExecutionId(jobExecutionId, progressMutator, tenantId);
   }
+
+  @Override
+  public Future<JobExecutionProgress> updateCompletionCounts(String jobExecutionId, int successCountDelta, int errorCountDelta, String tenantId) {
+    jobMonitoringService.updateByJobExecutionId(jobExecutionId, new Date(), false, tenantId);
+    return jobExecutionProgressDao.updateCompletionCounts(jobExecutionId, successCountDelta, errorCountDelta, tenantId);
+  }
+
+
 }

--- a/mod-source-record-manager-server/src/test/java/org/folio/services/RecordProcessedEventHandlingServiceImplTest.java
+++ b/mod-source-record-manager-server/src/test/java/org/folio/services/RecordProcessedEventHandlingServiceImplTest.java
@@ -198,7 +198,7 @@ public class RecordProcessedEventHandlingServiceImplTest extends AbstractRestTes
     ReflectionTestUtils.setField(changeEngineService, "maxDistributionNum", 10);
     ReflectionTestUtils.setField(changeEngineService, "batchSize", 100);
     chunkProcessingService = new EventDrivenChunkProcessingServiceImpl(jobExecutionSourceChunkDao, jobExecutionService, changeEngineService, jobExecutionProgressService);
-    recordProcessedEventHandlingService = new RecordProcessedEventHandlingServiceImpl(jobExecutionProgressService, jobExecutionService, journalService, jobMonitoringService);
+    recordProcessedEventHandlingService = new RecordProcessedEventHandlingServiceImpl(jobExecutionProgressService, jobExecutionService, jobMonitoringService);
     HashMap<String, String> headers = new HashMap<>();
     headers.put(OKAPI_URL_HEADER, "http://localhost:" + snapshotMockServer.port());
     headers.put(OKAPI_TENANT_HEADER, TENANT_ID);


### PR DESCRIPTION
## Purpose
Optimize data access pattern when updating job execution progress.

## Approach
In the previous approach, a SELECT FOR UPDATE statement is sent followed by an UPDATE statement. This means two database calls are used to update job execution progress. This was done because the SRM instance was manipulating the counts in memory so a lock on the row was needed. In the new approach, a single update statement is used to update job execution progress by adding deltas.


## Learning
https://issues.folio.org/browse/MODSOURMAN-846
