### PR TITLE
MODSOURMAN-852: Clarification of condition for the 035 field creation

### DIFF
--- a/mod-source-record-manager-server/src/main/java/org/folio/services/afterprocessing/HrIdFieldServiceImpl.java
+++ b/mod-source-record-manager-server/src/main/java/org/folio/services/afterprocessing/HrIdFieldServiceImpl.java
@@ -4,9 +4,9 @@ import org.folio.rest.jaxrs.model.Record;
 import org.springframework.stereotype.Service;
 
 import java.util.List;
-import java.util.Objects;
 
 import static org.apache.commons.lang3.StringUtils.isBlank;
+import static org.folio.services.afterprocessing.AdditionalFieldsUtil.TAG_999;
 import static org.folio.services.afterprocessing.AdditionalFieldsUtil.addDataFieldToMarcRecord;
 import static org.folio.services.afterprocessing.AdditionalFieldsUtil.getValue;
 import static org.folio.services.afterprocessing.AdditionalFieldsUtil.isFieldExist;
@@ -24,8 +24,10 @@ public class HrIdFieldServiceImpl implements HrIdFieldService {
   public void move001valueTo035Field(List<Record> records) {
     records.stream().parallel().forEach(record -> {
       String valueFrom001 = getValue(record, TAG_001, ' ');
+      String valueFrom999i = getValue(record, TAG_999, 'i');
       String valueFor035 = mergeFieldsFor035(getValue(record, TAG_003, ' '), valueFrom001);
-      if (valueFrom001 != null && !isFieldExist(record, TAG_035, SUBFIELD_FOR_035, valueFor035)) {
+      if (valueFrom001 != null && !isFieldExist(record, TAG_035, SUBFIELD_FOR_035, valueFor035)
+        && valueFrom999i == null) {
         addDataFieldToMarcRecord(record, TAG_035, INDICATOR_FOR_035, INDICATOR_FOR_035, SUBFIELD_FOR_035, valueFor035);
       }
     });

--- a/mod-source-record-manager-server/src/test/java/org/folio/services/HrIdFieldServiceTest.java
+++ b/mod-source-record-manager-server/src/test/java/org/folio/services/HrIdFieldServiceTest.java
@@ -79,4 +79,25 @@ public class HrIdFieldServiceTest {
     // then
     Assert.assertEquals(expectedParsedContent, record.getParsedRecord().getContent());
   }
+
+  @Test
+  public void shouldNotAdd035FieldIf999iFieldExists(){
+    // given
+    String parsedContent = "{\"leader\":\"00115nam  22000731a 4500\",\"fields\":[{\"001\":\"12345\"},{\"035\":{\"subfields\":[{\"a\":\"(test)data\"}],\"ind1\":\" \",\"ind2\":\" \"}},{\"507\":{\"subfields\":[{\"a\":\"data\"}],\"ind1\":\" \",\"ind2\":\" \"}},{\"500\":{\"subfields\":[{\"a\":\"data\"}],\"ind1\":\" \",\"ind2\":\" \"},{\"999\":{\"ind1\":\"f\",\"ind2\":\"f\",\"subfields\":[{\"s\":\"d5b8b9de-5730-40af-a7f0-525983e231d9\"},{\"i\":\"da466e87-5a8d-428f-891a-78964fff7538\"}]}}}]}";
+    String expectedParsedContent = "{\"leader\":\"00115nam  22000731a 4500\",\"fields\":[{\"001\":\"12345\"},{\"035\":{\"subfields\":[{\"a\":\"(test)data\"}],\"ind1\":\" \",\"ind2\":\" \"}},{\"507\":{\"subfields\":[{\"a\":\"data\"}],\"ind1\":\" \",\"ind2\":\" \"}},{\"500\":{\"subfields\":[{\"a\":\"data\"}],\"ind1\":\" \",\"ind2\":\" \"},{\"999\":{\"ind1\":\"f\",\"ind2\":\"f\",\"subfields\":[{\"s\":\"d5b8b9de-5730-40af-a7f0-525983e231d9\"},{\"i\":\"da466e87-5a8d-428f-891a-78964fff7538\"}]}}}]}";
+    ParsedRecord parsedRecord = new ParsedRecord();
+    parsedRecord.setContent(parsedContent);
+
+    Record record = new Record().withId(UUID.randomUUID().toString())
+      .withParsedRecord(parsedRecord)
+      .withGeneration(0)
+      .withState(Record.State.ACTUAL)
+      .withExternalIdsHolder(new ExternalIdsHolder().withInstanceId("001").withInstanceHrid("in001"));
+
+    // when
+    HrIdFieldService hrIdFieldService = new HrIdFieldServiceImpl();
+    hrIdFieldService.move001valueTo035Field(Lists.newArrayList(record));
+    // then
+    Assert.assertEquals(expectedParsedContent, record.getParsedRecord().getContent());
+  }
 }


### PR DESCRIPTION
## Purpose
SRM creates an extra 035 with hrId.

## Approach
Clarification of condition for the 035 field creation: when the MARC BIB record contains the 999i subfield this means that the current record exists in DB and we don't need to generate the 035 field because of a high probability the field 001 contains hrId.

## Learning
[MODSOURCE-528](https://issues.folio.org/browse/MODSOURCE-528)
