### PR TITLE
MODSOURMAN-858 Extend bib mapping rules to map contributor's authority ID

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,6 @@
+## 2022-xx-xx v3.5.0-SNAPSHOT
+* [MODSOURMAN-858](https://issues.folio.org/browse/MODSOURMAN-858) Mapping bib's $9 into contributors.authorityId field
+
 ## 2022-xx-xx v3.4.1-SNAPSHOT
 * [MODSOURMAN-818](https://issues.folio.org/browse/MODSOURMAN-818) Improve endpoints to get job executions profiles and users
 * [MODSOURMAN-836](https://issues.folio.org/browse/MODSOURMAN-836) Return job users and profiles only for jobs with COMMITTED, ERROR, CANCELED statuses

--- a/mod-source-record-manager-server/src/main/resources/rules/marc_bib_rules.json
+++ b/mod-source-record-manager-server/src/main/resources/rules/marc_bib_rules.json
@@ -1081,6 +1081,14 @@
     {
       "entity": [
         {
+          "target": "contributors.authorityId",
+          "description": "Authority ID that controlling the contributor",
+          "applyRulesOnConcatenatedData": true,
+          "subfield": [
+            "9"
+          ]
+        },
+        {
           "target": "contributors.contributorNameTypeId",
           "description": "Type for Personal Name",
           "applyRulesOnConcatenatedData": true,
@@ -1183,6 +1191,14 @@
     {
       "entity": [
         {
+          "target": "contributors.authorityId",
+          "description": "Authority ID that controlling the contributor",
+          "applyRulesOnConcatenatedData": true,
+          "subfield": [
+            "9"
+          ]
+        },
+        {
           "target": "contributors.contributorNameTypeId",
           "description": "Type for Corporate Name",
           "applyRulesOnConcatenatedData": true,
@@ -1282,6 +1298,14 @@
   "111": [
     {
       "entity": [
+        {
+          "target": "contributors.authorityId",
+          "description": "Authority ID that controlling the contributor",
+          "applyRulesOnConcatenatedData": true,
+          "subfield": [
+            "9"
+          ]
+        },
         {
           "target": "contributors.contributorNameTypeId",
           "description": "Type for Meeting Name",
@@ -6142,6 +6166,14 @@
     {
       "entity": [
         {
+          "target": "contributors.authorityId",
+          "description": "Authority ID that controlling the contributor",
+          "applyRulesOnConcatenatedData": true,
+          "subfield": [
+            "9"
+          ]
+        },
+        {
           "target": "contributors.contributorNameTypeId",
           "description": "Type for Personal Name",
           "applyRulesOnConcatenatedData": true,
@@ -6244,6 +6276,14 @@
     {
       "entity": [
         {
+          "target": "contributors.authorityId",
+          "description": "Authority ID that controlling the contributor",
+          "applyRulesOnConcatenatedData": true,
+          "subfield": [
+            "9"
+          ]
+        },
+        {
           "target": "contributors.contributorNameTypeId",
           "description": "Type for Corporate Name",
           "applyRulesOnConcatenatedData": true,
@@ -6343,6 +6383,14 @@
   "711": [
     {
       "entity": [
+        {
+          "target": "contributors.authorityId",
+          "description": "Authority ID that controlling the contributor",
+          "applyRulesOnConcatenatedData": true,
+          "subfield": [
+            "9"
+          ]
+        },
         {
           "target": "contributors.contributorNameTypeId",
           "description": "Type for Meeting Name",

--- a/mod-source-record-manager-server/src/test/java/org/folio/mapping/DefaultRulesMappingTest.java
+++ b/mod-source-record-manager-server/src/test/java/org/folio/mapping/DefaultRulesMappingTest.java
@@ -24,8 +24,8 @@ public class DefaultRulesMappingTest {
     JsonObject mappingRules = readJson(DEFAULT_RULES_PATH + "marc_bib_rules.json");
 
 
-    var actualAuthority = mapper.mapRecord(parsedRecord, new MappingParameters(), mappingRules);
-    Assert.assertEquals(expectedMappedAuthority.encode(), JsonObject.mapFrom(actualAuthority).put("id", "0").encode());
+    var actualInstance = mapper.mapRecord(parsedRecord, new MappingParameters(), mappingRules);
+    Assert.assertEquals(expectedMappedAuthority.encode(), JsonObject.mapFrom(actualInstance).put("id", "0").encode());
   }
 
   @Test
@@ -36,8 +36,8 @@ public class DefaultRulesMappingTest {
     JsonObject mappingRules = readJson(DEFAULT_RULES_PATH + "marc_holdings_rules.json");
 
 
-    var actualAuthority = mapper.mapRecord(parsedRecord, new MappingParameters(), mappingRules);
-    Assert.assertEquals(expectedMappedAuthority.encode(), JsonObject.mapFrom(actualAuthority).put("id", "0").encode());
+    var actualHoldings = mapper.mapRecord(parsedRecord, new MappingParameters(), mappingRules);
+    Assert.assertEquals(expectedMappedAuthority.encode(), JsonObject.mapFrom(actualHoldings).put("id", "0").encode());
   }
 
   @Test

--- a/mod-source-record-manager-server/src/test/resources/org/folio/mapping/mappedBibRecord.json
+++ b/mod-source-record-manager-server/src/test/resources/org/folio/mapping/mappedBibRecord.json
@@ -72,11 +72,13 @@
     {
       "name": "Research Publications, inc",
       "contributorNameTypeId": "fe19bae4-da28-472b-be90-d442e2428ead",
+      "authorityId": "af96e194-9081-41f5-9d91-d06d86eccdb8",
       "primary": false
     },
     {
       "name": "ESTC (Project)",
       "contributorNameTypeId": "fe19bae4-da28-472b-be90-d442e2428ead",
+      "authorityId": "af96e194-9081-41f5-9d91-d06d86eccdb8",
       "primary": false
     },
     {

--- a/mod-source-record-manager-server/src/test/resources/org/folio/mapping/parsedBibRecord.json
+++ b/mod-source-record-manager-server/src/test/resources/org/folio/mapping/parsedBibRecord.json
@@ -531,6 +531,9 @@
         "subfields": [
           {
             "a": "Research Publications, inc."
+          },
+          {
+            "9": "af96e194-9081-41f5-9d91-d06d86eccdb8"
           }
         ]
       }
@@ -542,6 +545,9 @@
         "subfields": [
           {
             "a": "ESTC (Project)"
+          },
+          {
+            "9": "af96e194-9081-41f5-9d91-d06d86eccdb8"
           }
         ]
       }


### PR DESCRIPTION
## Purpose
It's needed to have information if a contributor is controlled by authority

## Approach
Extend bib mapping rules to map contributor's authority ID from $9 subfield

#### TODOS and Open Questions
- [ ] Add to release notes info that rules should be updated