### PR TITLE
MODSOURMAN-833: Schema differences between MG Bugfest and clean MG deployment: mod-source-record-manager.

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,7 @@
 ## 2022-xx-xx v3.5.0-SNAPSHOT
 * [MODSOURMAN-858](https://issues.folio.org/browse/MODSOURMAN-858) Mapping bib's $9 into contributors.authorityId field
 * [MODSOURMAN-838](https://issues.folio.org/browse/MODSOURMAN-838) Search by LCCN "010 $a" subfield value with "\" at the end don't retrieve results
+* [MODSOURMAN-833](https://issues.folio.org/browse/MODSOURMAN-833) Schema differences between MG Bugfest and clean MG deployment: mod-source-record-manager
 
 ## 2022-xx-xx v3.4.1-SNAPSHOT
 * [MODSOURMAN-818](https://issues.folio.org/browse/MODSOURMAN-818) Improve endpoints to get job executions profiles and users

--- a/mod-source-record-manager-server/src/main/resources/templates/db_scripts/schema.json
+++ b/mod-source-record-manager-server/src/main/resources/templates/db_scripts/schema.json
@@ -219,7 +219,7 @@
     },
     {
       "run": "after",
-      "snippet": "update_source_chunks_table_structure_if_needed.sql",
+      "snippetPath": "update_source_chunks_table_structure_if_needed.sql",
       "fromModuleVersion": "mod-source-record-manager-3.4.3"
     }
   ]

--- a/mod-source-record-manager-server/src/main/resources/templates/db_scripts/schema.json
+++ b/mod-source-record-manager-server/src/main/resources/templates/db_scripts/schema.json
@@ -216,6 +216,11 @@
       "run": "after",
       "snippet": "CREATE OR REPLACE FUNCTION save_event_and_decrease_flow_control_counter(handlerId uuid, eventId uuid) RETURNS integer AS $$ DECLARE counterValue integer; BEGIN INSERT INTO events_processed(handler_id, event_id) VALUES(handlerId, eventId); UPDATE flow_control_events_counter SET events_to_process = events_to_process - 1; SELECT events_to_process FROM flow_control_events_counter INTO counterValue; RETURN counterValue; END; $$ LANGUAGE plpgsql;",
       "fromModuleVersion": "mod-source-record-manager-3.4.0"
+    },
+    {
+      "run": "after",
+      "snippet": "update_source_chunks_table_structure_if_needed.sql",
+      "fromModuleVersion": "mod-source-record-manager-3.4.3"
     }
   ]
 }

--- a/mod-source-record-manager-server/src/main/resources/templates/db_scripts/update_source_chunks_table_structure_if_needed.sql
+++ b/mod-source-record-manager-server/src/main/resources/templates/db_scripts/update_source_chunks_table_structure_if_needed.sql
@@ -1,0 +1,28 @@
+-- This actions should be run if there is non-clean deployment to return structure for source_chunks table(this issue was caused via changing creation this table not via rmb)
+
+-- Add NOT NULL constraint
+ALTER TABLE IF EXISTS job_execution_source_chunks ALTER COLUMN jobexecutionid SET NOT NULL;
+
+-- Add triggers/functions
+CREATE TRIGGER set_id_in_jsonb
+BEFORE INSERT OR UPDATE
+ON job_execution_source_chunks
+FOR EACH ROW
+EXECUTE PROCEDURE set_id_in_jsonb();
+
+CREATE FUNCTION update_job_execution_source_chunks_references () RETURNS trigger AS
+$$
+BEGIN
+NEW.jobExecutionId = (NEW.jsonb->>'jobExecutionId');
+RETURN NEW;
+END;
+$$
+LANGUAGE 'plpgsql' COST 100;
+
+ALTER FUNCTION update_job_execution_source_chunks_references () OWNER TO folio;
+
+CREATE TRIGGER update_job_execution_source_chunks_references
+BEFORE INSERT OR UPDATE
+ON job_execution_source_chunks
+FOR EACH ROW
+EXECUTE PROCEDURE update_job_execution_source_chunks_references();

--- a/mod-source-record-manager-server/src/main/resources/templates/db_scripts/update_source_chunks_table_structure_if_needed.sql
+++ b/mod-source-record-manager-server/src/main/resources/templates/db_scripts/update_source_chunks_table_structure_if_needed.sql
@@ -19,8 +19,6 @@ END;
 $$
 LANGUAGE 'plpgsql' COST 100;
 
-ALTER FUNCTION update_job_execution_source_chunks_references () OWNER TO folio;
-
 CREATE TRIGGER update_job_execution_source_chunks_references
 BEFORE INSERT OR UPDATE
 ON job_execution_source_chunks


### PR DESCRIPTION

## Purpose
Update the source-chunks table to make it consistent between clean deployment and non-clean. It was caused because we changed the creation of this table - now, it will create not via RMB.

## Approach
Added trigger and functions.


## Learning
JIRA: https://issues.folio.org/browse/MODSOURMAN-833
