### PR TITLE
MODSOURMAN-866 Assign each authority record to an Authority Source file list

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -12,6 +12,7 @@
 * [MODSOURMAN-823](https://issues.folio.org/browse/MODSOURMAN-823) View all logs: broken alphabetical sorting via the "Job profile" column
 * [MODSOURMAN-840](https://issues.folio.org/browse/MODSOURMAN-840) Importing MARC records with 999 ff fields using Create jobs without match profiles causes data problems.
 * [MODSOURMAN-845](https://issues.folio.org/browse/MODSOURMAN-845) Importing MARC Authority and Holdings records with 999 marc fields, with default Create job profiles, causes data problems.
+* [MODSOURMAN-866](https://issues.folio.org/browse/MODSOURMAN-866) Assign each authority record to an Authority Source file list
 
 ## 2022-07-05 v3.4.0
 * [MODSOURMAN-691](https://issues.folio.org/browse/MODSOURMAN-691) Support Delete MARC Authority Action

--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -73,6 +73,10 @@
     {
       "id": "authority-note-types",
       "version": "1.0"
+    },
+    {
+      "id": "authority-source-files",
+      "version": "1.0"
     }
   ],
   "provides": [
@@ -206,6 +210,7 @@
             "inventory-storage.authorities.item.post",
             "inventory-storage.authorities.item.put",
             "inventory-storage.authority-note-types.collection.get",
+            "inventory-storage.authority-source-files.collection.get",
             "inventory-storage.call-number-types.collection.get",
             "inventory-storage.classification-types.collection.get",
             "inventory-storage.contributor-name-types.collection.get",
@@ -308,6 +313,7 @@
             "inventory-storage.authorities.item.put",
             "inventory-storage.authorities.item.delete",
             "inventory-storage.authority-note-types.collection.get",
+            "inventory-storage.authority-source-files.collection.get",
             "inventory-storage.call-number-types.collection.get",
             "inventory-storage.classification-types.collection.get",
             "inventory-storage.contributor-name-types.collection.get",

--- a/mod-source-record-manager-server/src/main/java/org/folio/services/mappers/processor/MappingParametersProvider.java
+++ b/mod-source-record-manager-server/src/main/java/org/folio/services/mappers/processor/MappingParametersProvider.java
@@ -9,7 +9,9 @@ import org.apache.commons.lang.StringUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.folio.AuthorityNoteType;
+import org.folio.AuthoritySourceFile;
 import org.folio.Authoritynotetypes;
+import org.folio.Authoritysourcefiles;
 import org.folio.okapi.common.GenericCompositeFuture;
 
 import io.vertx.core.Future;
@@ -122,6 +124,7 @@ public class MappingParametersProvider {
   private static final String ITEM_NOTE_TYPES_RESPONSE_PARAM = "itemNoteTypes";
   private static final String FIELD_PROTECTION_SETTINGS_RESPONSE_PARAM = "marcFieldProtectionSettings";
   private static final String AUTHORITY_NOTE_TYPES_RESPONSE_PARAM = "authorityNoteTypes";
+  private static final String AUTHORITY_SOURCE_FILES_RESPONSE_PARAM = "authoritySourceFiles";
 
   private static final String CONFIGS_VALUE_RESPONSE = "configs";
   private static final String VALUE_RESPONSE = "value";
@@ -178,6 +181,7 @@ public class MappingParametersProvider {
     Future<List<Loantype>> loanTypesFuture = getLoanTypes(okapiParams);
     Future<List<ItemNoteType>> itemNoteTypesFuture = getItemNoteTypes(okapiParams);
     Future<List<AuthorityNoteType>> authorityNoteTypesFuture = getAuthorityNoteTypes(okapiParams);
+    Future<List<AuthoritySourceFile>> authoritySourceFilesFuture = getAuthoritySourceFiles(okapiParams);
     Future<List<MarcFieldProtectionSetting>> marcFieldProtectionSettingsFuture = getMarcFieldProtectionSettings(okapiParams);
     Future<String> tenantConfigurationFuture = getTenantConfiguration(okapiParams);
 
@@ -186,7 +190,7 @@ public class MappingParametersProvider {
         contributorTypesFuture, contributorNameTypesFuture, electronicAccessRelationshipsFuture, instanceNoteTypesFuture, alternativeTitleTypesFuture,
         issuanceModesFuture, instanceStatusesFuture, natureOfContentTermsFuture, instanceRelationshipTypesFuture, holdingsTypesFuture, holdingsNoteTypesFuture,
         illPoliciesFuture, callNumberTypesFuture, statisticalCodesFuture, statisticalCodeTypesFuture, locationsFuture, materialTypesFuture, itemDamagedStatusesFuture,
-        loanTypesFuture, itemNoteTypesFuture, authorityNoteTypesFuture, marcFieldProtectionSettingsFuture, tenantConfigurationFuture))
+        loanTypesFuture, itemNoteTypesFuture, authorityNoteTypesFuture, authoritySourceFilesFuture, marcFieldProtectionSettingsFuture, tenantConfigurationFuture))
       .map(ar ->
         mappingParams
           .withInitializedState(true)
@@ -216,6 +220,7 @@ public class MappingParametersProvider {
           .withLoanTypes(loanTypesFuture.result())
           .withItemNoteTypes(itemNoteTypesFuture.result())
           .withAuthorityNoteTypes(authorityNoteTypesFuture.result())
+          .withAuthoritySourceFiles(authoritySourceFilesFuture.result())
           .withMarcFieldProtectionSettings(marcFieldProtectionSettingsFuture.result())
           .withTenantConfiguration(tenantConfigurationFuture.result())
       ).onFailure(e -> LOGGER.error("Something happened while initializing mapping parameters", e));
@@ -691,6 +696,26 @@ public class MappingParametersProvider {
       if (response != null && response.containsKey(AUTHORITY_NOTE_TYPES_RESPONSE_PARAM)) {
         var authorityNoteTypes = response.mapTo(Authoritynotetypes.class).getAuthorityNoteTypes();
         promise.complete(authorityNoteTypes);
+      } else {
+        promise.complete(Collections.emptyList());
+      }
+    });
+    return promise.future();
+  }
+
+  private Future<List<AuthoritySourceFile>> getAuthoritySourceFiles(OkapiConnectionParams params) {
+    var promise = Promise.<List<AuthoritySourceFile>>promise();
+    var authoritySourceFilesUrl = "/authority-source-files?limit=" + settingsLimit;
+
+    RestUtil.doRequest(params, authoritySourceFilesUrl, HttpMethod.GET, null).onComplete(ar -> {
+      if (!RestUtil.validateAsyncResult(ar, promise)) {
+        return;
+      }
+
+      var response = ar.result().getJson();
+      if (response != null && response.containsKey(AUTHORITY_SOURCE_FILES_RESPONSE_PARAM)) {
+        var authoritySourceFiles = response.mapTo(Authoritysourcefiles.class).getAuthoritySourceFiles();
+        promise.complete(authoritySourceFiles);
       } else {
         promise.complete(Collections.emptyList());
       }

--- a/mod-source-record-manager-server/src/test/java/org/folio/rest/impl/AbstractRestTest.java
+++ b/mod-source-record-manager-server/src/test/java/org/folio/rest/impl/AbstractRestTest.java
@@ -126,6 +126,7 @@ public abstract class AbstractRestTest {
   protected static final String LOAN_TYPES_URL = "/loan-types?limit=1000";
   protected static final String ITEM_NOTE_TYPES_URL = "/item-note-types?limit=1000";
   protected static final String AUTHORITY_NOTE_TYPES_URL = "/authority-note-types?limit=1000";
+  protected static final String AUTHORITY_SOURCE_FILES_URL = "/authority-source-files?limit=1000";
   protected static final String FIELD_PROTECTION_SETTINGS_URL = "/field-protection-settings/marc?limit=1000";
   protected static final String TENANT_CONFIGURATIONS_SETTINGS_URL = "/configurations/entries?query=" + URLEncoder.encode("(module==ORG and configName==localeSettings)", StandardCharsets.UTF_8);;
 
@@ -418,6 +419,7 @@ public abstract class AbstractRestTest {
     WireMock.stubFor(get(LOAN_TYPES_URL).willReturn(okJson(new JsonObject().put("loantypes", new JsonArray()).toString())));
     WireMock.stubFor(get(ITEM_NOTE_TYPES_URL).willReturn(okJson(new JsonObject().put("itemNoteTypes", new JsonArray()).toString())));
     WireMock.stubFor(get(AUTHORITY_NOTE_TYPES_URL).willReturn(okJson(new JsonObject().put("authorityNoteTypes", new JsonArray()).toString())));
+    WireMock.stubFor(get(AUTHORITY_SOURCE_FILES_URL).willReturn(okJson(new JsonObject().put("authoritySourceFiles", new JsonArray()).toString())));
     WireMock.stubFor(get(FIELD_PROTECTION_SETTINGS_URL).willReturn(okJson(new JsonObject().put("marcFieldProtectionSettings", new JsonArray()).toString())));
     WireMock.stubFor(get(TENANT_CONFIGURATIONS_SETTINGS_URL).willReturn(okJson(new JsonObject().put("configs", new JsonArray()).toString())));
 

--- a/mod-source-record-manager-server/src/test/java/org/folio/rest/impl/changeManager/ChangeManagerAPITest.java
+++ b/mod-source-record-manager-server/src/test/java/org/folio/rest/impl/changeManager/ChangeManagerAPITest.java
@@ -1164,6 +1164,7 @@ public class ChangeManagerAPITest extends AbstractRestTest {
     verify(1, getRequestedFor(urlEqualTo(LOAN_TYPES_URL)));
     verify(1, getRequestedFor(urlEqualTo(ITEM_NOTE_TYPES_URL)));
     verify(1, getRequestedFor(urlEqualTo(AUTHORITY_NOTE_TYPES_URL)));
+    verify(1, getRequestedFor(urlEqualTo(AUTHORITY_SOURCE_FILES_URL)));
     verify(1, getRequestedFor(urlEqualTo(FIELD_PROTECTION_SETTINGS_URL)));
     verify(1, getRequestedFor(urlEqualTo(TENANT_CONFIGURATIONS_SETTINGS_URL)));
     async.complete();
@@ -1204,6 +1205,7 @@ public class ChangeManagerAPITest extends AbstractRestTest {
     WireMock.stubFor(get(LOAN_TYPES_URL).willReturn(serverError()));
     WireMock.stubFor(get(ITEM_NOTE_TYPES_URL).willReturn(serverError()));
     WireMock.stubFor(get(AUTHORITY_NOTE_TYPES_URL).willReturn(serverError()));
+    WireMock.stubFor(get(AUTHORITY_SOURCE_FILES_URL).willReturn(serverError()));
     WireMock.stubFor(get(FIELD_PROTECTION_SETTINGS_URL).willReturn(serverError()));
     WireMock.stubFor(get(TENANT_CONFIGURATIONS_SETTINGS_URL).willReturn(serverError()));
 

--- a/mod-source-record-manager-server/src/test/java/org/folio/services/mappers/processor/MappingParametersProviderTest.java
+++ b/mod-source-record-manager-server/src/test/java/org/folio/services/mappers/processor/MappingParametersProviderTest.java
@@ -60,6 +60,7 @@ public class MappingParametersProviderTest {
   protected static final String LOAN_TYPES_URL = "/loan-types?limit=0";
   protected static final String ITEM_NOTE_TYPES_URL = "/item-note-types?limit=0";
   protected static final String AUTHORITY_NOTE_TYPES_URL = "/authority-note-types?limit=0";
+  protected static final String AUTHORITY_SOURCE_FILES_URL = "/authority-source-files?limit=0";
   protected static final String FIELD_PROTECTION_SETTINGS_URL =
     "/field-protection-settings/marc?limit=0";
   protected static final String TENANT_CONFIGURATIONS_SETTINGS_URL =
@@ -190,6 +191,10 @@ public class MappingParametersProviderTest {
         .willReturn(
           okJson(new JsonObject().put("authorityNoteTypes", new JsonArray()).toString())));
     WireMock.stubFor(
+      get(AUTHORITY_SOURCE_FILES_URL)
+        .willReturn(
+          okJson(new JsonObject().put("authoritySourceFiles", new JsonArray()).toString())));
+    WireMock.stubFor(
       get(FIELD_PROTECTION_SETTINGS_URL)
         .willReturn(
           okJson(
@@ -251,7 +256,7 @@ public class MappingParametersProviderTest {
   public void cacheKeyEquality() {
     OkapiConnectionParams otherParams = new OkapiConnectionParams(Collections.emptyMap(), rule.vertx());
     Assert.assertNotEquals(okapiConnectionParams, otherParams);
-    
+
     MappingParametersProvider.MappingParameterKey key1 =
       new MappingParametersProvider.MappingParameterKey("key",
         otherParams);


### PR DESCRIPTION
## Purpose
Populate Authority Source Files from mod-inventory-storage in MappingParametersProvider.
[MODSOURMAN-866](https://issues.folio.org/browse/MODSOURMAN-866)
## Approach
- getAuthoritySourceFiles method added to MappingParametersProvider
- Permissions added to ModuleDescriptor
- Tests updated