### PR TITLE
MODSOURMAN-868 Allow sorting of JobExecutions by started_date

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,19 +1,26 @@
 ## 2022-xx-xx v3.5.0-SNAPSHOT
 * [MODSOURMAN-858](https://issues.folio.org/browse/MODSOURMAN-858) Mapping bib's $9 into contributors.authorityId field
 * [MODSOURMAN-838](https://issues.folio.org/browse/MODSOURMAN-838) Search by LCCN "010 $a" subfield value with "\" at the end don't retrieve results
-* [MODSOURMAN-833](https://issues.folio.org/browse/MODSOURMAN-833) Schema differences between MG Bugfest and clean MG deployment: mod-source-record-manager
+* [MODSOURMAN-868](https://issues.folio.org/browse/MODSOURMAN-868) Allow sorting of JobExecutions by 'started_date'
+
+## 2022-09-06 v3.4.4
 * [MODSOURMAN-870](https://issues.folio.org/browse/MODSOURMAN-870) Error while updating module after fix for schema differences between MG Bugfest and clean MG deployment
 
-## 2022-09-xx v3.4.3-SNAPSHOT
+## 2022-09-05 v3.4.3
+* [MODSOURMAN-854](https://issues.folio.org/browse/MODSOURMAN-854) Importing MARC Authority and Holdings records with 999 marc fields, with default Create job profiles, causes data problems.
+* [MODSOURMAN-833](https://issues.folio.org/browse/MODSOURMAN-833) Schema differences between MG Bugfest and clean MG deployment: mod-source-record-manager
 * [MODSOURMAN-859](https://issues.folio.org/browse/MODSOURMAN-859) DI stops processing the following files after using an incorrect type of JobProfile
 
-## 2022-xx-xx v3.4.1-SNAPSHOT
+## 2022-08-25 v3.4.2
+* [MODSOURMAN-840](https://issues.folio.org/browse/MODSOURMAN-840) Importing MARC records with 999 ff fields using Create jobs without match profiles causes data problems.
+* [MODSOURMAN-852](https://issues.folio.org/browse/MODSOURMAN-852) Fail job for unsupported profile (match MARC BIB to Instance and update MARC BIB)
+* [MODSOURCE-521](https://issues.folio.org/browse/MODSOURCE-521) Populate 035 fields for exceptional cases of Update action
+
+## 2022-08-03 v3.4.1
 * [MODSOURMAN-818](https://issues.folio.org/browse/MODSOURMAN-818) Improve endpoints to get job executions profiles and users
 * [MODSOURMAN-836](https://issues.folio.org/browse/MODSOURMAN-836) Return job users and profiles only for jobs with COMMITTED, ERROR, CANCELED statuses
 * [MODSOURMAN-823](https://issues.folio.org/browse/MODSOURMAN-823) View all logs: broken alphabetical sorting via the "Job profile" column
 * [MODSOURMAN-840](https://issues.folio.org/browse/MODSOURMAN-840) Importing MARC records with 999 ff fields using Create jobs without match profiles causes data problems.
-* [MODSOURMAN-845](https://issues.folio.org/browse/MODSOURMAN-845) Importing MARC Authority and Holdings records with 999 marc fields, with default Create job profiles, causes data problems.
-* [MODSOURMAN-866](https://issues.folio.org/browse/MODSOURMAN-866) Assign each authority record to an Authority Source file list
 
 ## 2022-07-05 v3.4.0
 * [MODSOURMAN-691](https://issues.folio.org/browse/MODSOURMAN-691) Support Delete MARC Authority Action

--- a/mod-source-record-manager-server/src/main/java/org/folio/rest/impl/MetadataProviderImpl.java
+++ b/mod-source-record-manager-server/src/main/java/org/folio/rest/impl/MetadataProviderImpl.java
@@ -41,7 +41,7 @@ public class MetadataProviderImpl implements MetadataProvider {
   private static final String INVALID_SORT_PARAMS_MSG = "The specified parameter for sorting jobExecutions is invalid: '%s'. Valid sortable fields are: %s. Valid sorting order values are: asc, desc.";
   public static final Set<String> SORT_ORDER_VALUES = Set.of("asc", "desc");
   private static final Set<String> JOB_EXECUTION_SORTABLE_FIELDS =
-    Set.of("completed_date", "progress_total", "status", "hrid", "file_name", "job_profile_name", "job_user_first_name", "job_user_last_name");
+    Set.of("completed_date", "started_date", "progress_total", "status", "hrid", "file_name", "job_profile_name", "job_user_first_name", "job_user_last_name");
 
   @Autowired
   private JobExecutionService jobExecutionService;

--- a/mod-source-record-manager-server/src/main/resources/templates/db_scripts/create_index_on_job_execution_started_date.sql
+++ b/mod-source-record-manager-server/src/main/resources/templates/db_scripts/create_index_on_job_execution_started_date.sql
@@ -1,0 +1,2 @@
+-- create job_execution_started_date_idx index
+CREATE INDEX IF NOT EXISTS job_execution_started_date_idx ON job_execution USING BTREE (started_date);

--- a/mod-source-record-manager-server/src/main/resources/templates/db_scripts/schema.json
+++ b/mod-source-record-manager-server/src/main/resources/templates/db_scripts/schema.json
@@ -221,6 +221,11 @@
       "run": "after",
       "snippetPath": "update_source_chunks_table_structure_if_needed.sql",
       "fromModuleVersion": "mod-source-record-manager-3.4.3"
+    },
+    {
+      "run": "after",
+      "snippetPath": "create_index_on_job_execution_started_date.sql",
+      "fromModuleVersion": "mod-source-record-manager-3.5.0"
     }
   ]
 }


### PR DESCRIPTION
## Purpose
Started date for jobs was added on Landing page, sorting should also be possible

## Approach
Extend enum of sortable fields for jobExecutions