### PR TITLE
MODSOURMAN-827 - Updated mapping rules of 590 field for "staff only"

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -3,6 +3,7 @@
 * [MODSOURMAN-838](https://issues.folio.org/browse/MODSOURMAN-838) Search by LCCN "010 $a" subfield value with "\" at the end don't retrieve results
 * [MODSOURMAN-868](https://issues.folio.org/browse/MODSOURMAN-868) Allow sorting of JobExecutions by 'started_date'
 * [MODSOURMAN-874](https://issues.folio.org/browse/MODSOURMAN-874) Data import: fails the creation of a Holding through a match on the 999 ff field.
+* [MODSOURMAN-827](https://issues.folio.org/browse/MODSOURMAN-827) Updated instance mapping rules for 590 field to mark notes as staff only
 
 ## 2022-09-06 v3.4.4
 * [MODSOURMAN-870](https://issues.folio.org/browse/MODSOURMAN-870) Error while updating module after fix for schema differences between MG Bugfest and clean MG deployment

--- a/mod-source-record-manager-server/src/main/resources/rules/marc_bib_rules.json
+++ b/mod-source-record-manager-server/src/main/resources/rules/marc_bib_rules.json
@@ -5649,14 +5649,17 @@
         },
         {
           "target": "notes.staffOnly",
-          "description": "If true, determines that the note should not be visible for others than staff",
+          "description": "If the 1st indicator equals 0, determines that the note should not be visible for others than staff",
           "subfield": [
             "a"
           ],
           "rules": [
             {
-              "conditions": [],
-              "value": "false"
+              "conditions": [
+                {
+                  "type": "set_note_staff_only_via_indicator"
+                }
+              ]
             }
           ]
         }


### PR DESCRIPTION
## Purpose
to update the default mapping rule of the 590 field to mapp a note as stuff only, if ind1 = 0


## Learning
[MODSOURMAN-827](https://issues.folio.org/browse/MODSOURMAN-827)