### PR TITLE
WITH cte AS (SELECT count(*) AS total_count FROM diku_mod_source_record_manager.job_execution WHERE subordination_type <> 'PARENT_MULTIPLE' AND TRUE AND status IN ('COMMITTED', 'ERROR', 'CANCELLED') AND NOT job_profile_hidden AND NOT is_deleted) SELECT j.*, cte.*, p.total_records_count total, p.succeeded_records_count + p.error_records_count currently_processed FROM diku_mod_source_record_manager.job_execution j LEFT JOIN diku_mod_source_record_manager.job_execution_progress p ON  j.id = p.job_execution_id LEFT JOIN cte ON true WHERE subordination_type <> 'PARENT_MULTIPLE' AND TRUE AND status IN ('COMMITTED', 'ERROR', 'CANCELLED') AND NOT job_profile_hidden AND NOT is_deleted ORDER BY status desc LIMIT $1 OFFSET $2

### DIFF
--- a/mod-source-record-manager-server/src/main/java/org/folio/rest/impl/MetadataProviderImpl.java
+++ b/mod-source-record-manager-server/src/main/java/org/folio/rest/impl/MetadataProviderImpl.java
@@ -217,6 +217,10 @@ public class MetadataProviderImpl implements MetadataProvider {
       if (!JOB_EXECUTION_SORTABLE_FIELDS.contains(sortField) || !SORT_ORDER_VALUES.contains(sortOrder)) {
         throw new BadRequestException(format(INVALID_SORT_PARAMS_MSG, sortFieldQuery, JOB_EXECUTION_SORTABLE_FIELDS));
       }
+
+      if (sortField.equals("progress_total")) {
+        sortField = "COALESCE(p.total_records_count, progress_total)";
+      }
       fields.add(new SortField(sortField, sortOrder));
     }
     return fields;


### PR DESCRIPTION
## Purpose
Fix sorting in the Records columns

Jira: https://issues.folio.org/browse/MODSOURMAN-822
