### PR TITLE
MODSOURMAN-889: folio-di-support 1.6.0 fixing Spring4Shell

### DIFF
--- a/mod-source-record-manager-server/pom.xml
+++ b/mod-source-record-manager-server/pom.xml
@@ -153,7 +153,7 @@
     <dependency>
       <groupId>org.folio</groupId>
       <artifactId>folio-di-support</artifactId>
-      <version>1.4.1</version>
+      <version>1.6.0</version>
       <type>jar</type>
     </dependency>
     <dependency>


### PR DESCRIPTION
Upgrade folio-di-support from 1.4.1 to 1.6.0.

This indirectly upgrades spring-beans from 5.2.8.RELEASE to 5.3.20 fixing Spring4Shell Remote Code Execution vulnerability, for details see https://issues.folio.org/browse/FOLIO-3466 and
https://nvd.nist.gov/vuln/detail/CVE-2022-22965 .
The Spring upgrade also fixes these vulnerabilities:
https://nvd.nist.gov/vuln/detail/CVE-2021-22060
https://nvd.nist.gov/vuln/detail/CVE-2021-22096
https://nvd.nist.gov/vuln/detail/CVE-2022-22968
https://nvd.nist.gov/vuln/detail/CVE-2022-22950
https://nvd.nist.gov/vuln/detail/CVE-2022-22970

## Learning
For each flower release each module should upgrade all dependencies.
