### PR TITLE
MODSOURMAN-837:MARC bib - FOLIO instance mapping | Update default mapping to change how Relator term is populated on instance record

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,6 @@
 ## 2022-xx-xx v3.5.0-SNAPSHOT
 * [MODSOURMAN-873](https://issues.folio.org/browse/MODSOURMAN-873) Add MARC 720 field to default MARC Bib-Instance mapping and adjust relator term mapping
+* [MODSOURMAN-837](https://issues.folio.org/browse/MODSOURMAN-837) MARC bib - FOLIO instance mapping | Update default mapping to change how Relator term is populated on instance record
 
 ## 2022-xx-xx v3.5.0-SNAPSHOT
 * [MODSOURMAN-858](https://issues.folio.org/browse/MODSOURMAN-858) Mapping bib's $9 into contributors.authorityId field

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,4 +1,7 @@
 ## 2022-xx-xx v3.5.0-SNAPSHOT
+* [MODSOURMAN-873](https://issues.folio.org/browse/MODSOURMAN-873) Add MARC 720 field to default MARC Bib-Instance mapping and adjust relator term mapping
+
+## 2022-xx-xx v3.5.0-SNAPSHOT
 * [MODSOURMAN-858](https://issues.folio.org/browse/MODSOURMAN-858) Mapping bib's $9 into contributors.authorityId field
 * [MODSOURMAN-838](https://issues.folio.org/browse/MODSOURMAN-838) Search by LCCN "010 $a" subfield value with "\" at the end don't retrieve results
 * [MODSOURMAN-868](https://issues.folio.org/browse/MODSOURMAN-868) Allow sorting of JobExecutions by 'started_date'

--- a/RuleProcessorApi.md
+++ b/RuleProcessorApi.md
@@ -664,6 +664,133 @@ Indicator value of record field "ind2" is "1" but it also matched because the ru
 the rule will be proceeded.
 
 This mechanism executes in Processor, in data-import-processing-core, while parsing these rules.
+
+####  Alternative mapping with specific subfield and target
+If there is a need to use an alternative target and subfield if the result of the running function is empty, there can be used "alternativeMapping" rule:
+which process a record field:
+
+```json
+Alternative rules:
+"alternativeMapping": {
+"target": "contributors.contributorTypeText",
+"subfield": [
+"e"
+],
+"ignoreSubsequentSubfields": true
+},
+"applyRulesOnConcatenatedData": true
+},
+```
+##### Note: 
+For the function "set_contributor_type_id_by_code_or_name" there should be set additional parameters: "contributorCodeSubfield" and "contributorNameSubfield" for searching from subfield "4" as code for Contributors and from subfield "e" as name for Contributors.
+```json
+  Rule:
+"710": [
+{
+"entity": [
+{
+"target": "contributors.authorityId",
+"description": "Authority ID that controlling the contributor",
+"applyRulesOnConcatenatedData": true,
+"subfield": [
+"9"
+]
+},
+{
+"target": "contributors.contributorNameTypeId",
+"description": "Type for Corporate Name",
+"applyRulesOnConcatenatedData": true,
+"subfield": [
+],
+"rules": [
+{
+"conditions": [
+{
+"type": "set_contributor_name_type_id",
+"parameter": {
+"name": "Corporate name"
+}
+}
+]
+}
+]
+},
+{
+"rules": [
+{
+"conditions": [
+{
+"type": "set_contributor_type_id_by_code_or_name",
+"parameter": {
+"contributorCodeSubfield": "4",
+"contributorNameSubfield": "e"
+}
+}
+]
+}
+],
+"target": "contributors.contributorTypeId",
+"subfield": [
+"4",
+"e"
+],
+"description": "Type of contributor",
+"alternativeMapping": {
+"target": "contributors.contributorTypeText",
+"subfield": [
+"e"
+],
+"ignoreSubsequentSubfields": true
+},
+"applyRulesOnConcatenatedData": true
+},
+{
+"target": "contributors.primary",
+"description": "Primary contributor",
+"applyRulesOnConcatenatedData": true,
+"subfield": [
+],
+"rules": [
+{
+"conditions": [],
+"value": "false"
+}
+]
+},
+{
+"target": "contributors.name",
+"description": "Corporate Name",
+"subfield": [
+"a",
+"b",
+"c",
+"d",
+"f",
+"g",
+"k",
+"l",
+"n",
+"p",
+"t",
+"u"
+],
+"applyRulesOnConcatenatedData": true,
+"rules": [
+{
+"conditions": [
+{
+"type": "trim_period, trim"
+}
+]
+}
+]
+}
+]
+}
+],
+```
+
+
 #
 ### REST API
 When the source-record-manager starts up, it performs initialization for default mapping rules for given tenant.

--- a/mod-source-record-manager-server/pom.xml
+++ b/mod-source-record-manager-server/pom.xml
@@ -201,7 +201,7 @@
     <dependency>
       <groupId>org.folio</groupId>
       <artifactId>data-import-processing-core</artifactId>
-      <version>3.5.0-SNAPSHOT</version>
+      <version>3.6.0-SNAPSHOT</version>
     </dependency>
     <dependency>
       <groupId>org.folio</groupId>

--- a/mod-source-record-manager-server/src/main/resources/rules/marc_bib_rules.json
+++ b/mod-source-record-manager-server/src/main/resources/rules/marc_bib_rules.json
@@ -1108,38 +1108,33 @@
           ]
         },
         {
-          "target": "contributors.contributorTypeId",
-          "description": "Type of contributor",
-          "applyRulesOnConcatenatedData": true,
-          "subfield": [
-            "4"
-          ],
           "rules": [
             {
               "conditions": [
                 {
-                  "type": "set_contributor_type_id"
+                  "type": "set_contributor_type_id_by_code_or_name",
+                  "parameter": {
+                    "contributorCodeSubfield": "4",
+                    "contributorNameSubfield": "e"
+                  }
                 }
               ]
             }
-          ]
-        },
-        {
-          "target": "contributors.contributorTypeText",
-          "description": "Contributor type free text",
-          "applyRulesOnConcatenatedData": true,
+          ],
+          "target": "contributors.contributorTypeId",
           "subfield": [
+            "4",
             "e"
           ],
-          "rules": [
-            {
-              "conditions": [
-                {
-                  "type": "set_contributor_type_text"
-                }
-              ]
-            }
-          ]
+          "description": "Type of contributor",
+          "alternativeMapping": {
+            "target": "contributors.contributorTypeText",
+            "subfield": [
+              "e"
+            ],
+            "ignoreSubsequentSubfields": true
+          },
+          "applyRulesOnConcatenatedData": true
         },
         {
           "target": "contributors.primary",
@@ -1218,38 +1213,33 @@
           ]
         },
         {
-          "target": "contributors.contributorTypeText",
-          "description": "Contributor type free text",
-          "applyRulesOnConcatenatedData": true,
+          "rules": [
+            {
+              "conditions": [
+                {
+                  "type": "set_contributor_type_id_by_code_or_name",
+                  "parameter": {
+                    "contributorCodeSubfield": "4",
+                    "contributorNameSubfield": "e"
+                  }
+                }
+              ]
+            }
+          ],
+          "target": "contributors.contributorTypeId",
           "subfield": [
+            "4",
             "e"
           ],
-          "rules": [
-            {
-              "conditions": [
-                {
-                  "type": "set_contributor_type_text"
-                }
-              ]
-            }
-          ]
-        },
-        {
-          "target": "contributors.contributorTypeId",
           "description": "Type of contributor",
-          "applyRulesOnConcatenatedData": true,
-          "subfield": [
-            "4"
-          ],
-          "rules": [
-            {
-              "conditions": [
-                {
-                  "type": "set_contributor_type_id"
-                }
-              ]
-            }
-          ]
+          "alternativeMapping": {
+            "target": "contributors.contributorTypeText",
+            "subfield": [
+              "e"
+            ],
+            "ignoreSubsequentSubfields": true
+          },
+          "applyRulesOnConcatenatedData": true
         },
         {
           "target": "contributors.primary",
@@ -1326,38 +1316,33 @@
           ]
         },
         {
-          "target": "contributors.contributorTypeId",
-          "description": "Type of contributor",
-          "applyRulesOnConcatenatedData": true,
-          "subfield": [
-            "4"
-          ],
           "rules": [
             {
               "conditions": [
                 {
-                  "type": "set_contributor_type_id"
+                  "type": "set_contributor_type_id_by_code_or_name",
+                  "parameter": {
+                    "contributorCodeSubfield": "4",
+                    "contributorNameSubfield": "j"
+                  }
                 }
               ]
             }
-          ]
-        },
-        {
-          "target": "contributors.contributorTypeText",
-          "description": "Contributor type free text",
-          "applyRulesOnConcatenatedData": true,
+          ],
+          "target": "contributors.contributorTypeId",
           "subfield": [
+            "4",
             "j"
           ],
-          "rules": [
-            {
-              "conditions": [
-                {
-                  "type": "set_contributor_type_text"
-                }
-              ]
-            }
-          ]
+          "description": "Type of contributor",
+          "alternativeMapping": {
+            "target": "contributors.contributorTypeText",
+            "subfield": [
+              "j"
+            ],
+            "ignoreSubsequentSubfields": true
+          },
+          "applyRulesOnConcatenatedData": true
         },
         {
           "target": "contributors.primary",
@@ -6196,39 +6181,34 @@
           ]
         },
         {
-          "target": "contributors.contributorTypeId",
-          "description": "Type of contributor",
-          "applyRulesOnConcatenatedData": true,
-          "subfield": [
-            "4"
-          ],
           "rules": [
             {
               "conditions": [
                 {
-                  "type": "set_contributor_type_id"
+                  "type": "set_contributor_type_id_by_code_or_name",
+                  "parameter": {
+                    "contributorCodeSubfield": "4",
+                    "contributorNameSubfield": "e"
+                  }
                 }
               ]
             }
-          ]
-        },
-        {
-          "target": "contributors.contributorTypeText",
-          "description": "Contributor type free text",
-          "applyRulesOnConcatenatedData": true,
+          ],
+          "target": "contributors.contributorTypeId",
           "subfield": [
+            "4",
             "e"
           ],
-          "rules": [
-            {
-              "conditions": [
-                {
-                  "type": "set_contributor_type_text"
-                }
-              ]
-            }
-          ]
-        },
+          "description": "Type of contributor",
+          "alternativeMapping": {
+            "target": "contributors.contributorTypeText",
+            "subfield": [
+              "e"
+            ],
+            "ignoreSubsequentSubfields": true
+          },
+          "applyRulesOnConcatenatedData": true
+        },d
         {
           "target": "contributors.primary",
           "description": "Primary contributor",
@@ -6306,38 +6286,33 @@
           ]
         },
         {
-          "target": "contributors.contributorTypeId",
-          "description": "Type of contributor",
-          "applyRulesOnConcatenatedData": true,
-          "subfield": [
-            "4"
-          ],
           "rules": [
             {
               "conditions": [
                 {
-                  "type": "set_contributor_type_id"
+                  "type": "set_contributor_type_id_by_code_or_name",
+                  "parameter": {
+                    "contributorCodeSubfield": "4",
+                    "contributorNameSubfield": "e"
+                  }
                 }
               ]
             }
-          ]
-        },
-        {
-          "target": "contributors.contributorTypeText",
-          "description": "Contributor type free text",
-          "applyRulesOnConcatenatedData": true,
+          ],
+          "target": "contributors.contributorTypeId",
           "subfield": [
+            "4",
             "e"
           ],
-          "rules": [
-            {
-              "conditions": [
-                {
-                  "type": "set_contributor_type_text"
-                }
-              ]
-            }
-          ]
+          "description": "Type of contributor",
+          "alternativeMapping": {
+            "target": "contributors.contributorTypeText",
+            "subfield": [
+              "e"
+            ],
+            "ignoreSubsequentSubfields": true
+          },
+          "applyRulesOnConcatenatedData": true
         },
         {
           "target": "contributors.primary",
@@ -6414,38 +6389,33 @@
           ]
         },
         {
-          "target": "contributors.contributorTypeId",
-          "description": "Type of contributor",
-          "applyRulesOnConcatenatedData": true,
-          "subfield": [
-            "4"
-          ],
           "rules": [
             {
               "conditions": [
                 {
-                  "type": "set_contributor_type_id"
+                  "type": "set_contributor_type_id_by_code_or_name",
+                  "parameter": {
+                    "contributorCodeSubfield": "4",
+                    "contributorNameSubfield": "j"
+                  }
                 }
               ]
             }
-          ]
-        },
-        {
-          "target": "contributors.contributorTypeText",
-          "description": "Contributor type free text",
-          "applyRulesOnConcatenatedData": true,
+          ],
+          "target": "contributors.contributorTypeId",
           "subfield": [
+            "4",
             "j"
           ],
-          "rules": [
-            {
-              "conditions": [
-                {
-                  "type": "set_contributor_type_text"
-                }
-              ]
-            }
-          ]
+          "description": "Type of contributor",
+          "alternativeMapping": {
+            "target": "contributors.contributorTypeText",
+            "subfield": [
+              "j"
+            ],
+            "ignoreSubsequentSubfields": true
+          },
+          "applyRulesOnConcatenatedData": true
         },
         {
           "target": "contributors.primary",

--- a/mod-source-record-manager-server/src/main/resources/rules/marc_bib_rules.json
+++ b/mod-source-record-manager-server/src/main/resources/rules/marc_bib_rules.json
@@ -6208,7 +6208,7 @@
             "ignoreSubsequentSubfields": true
           },
           "applyRulesOnConcatenatedData": true
-        },d
+        },
         {
           "target": "contributors.primary",
           "description": "Primary contributor",

--- a/mod-source-record-manager-server/src/main/resources/rules/marc_bib_rules.json
+++ b/mod-source-record-manager-server/src/main/resources/rules/marc_bib_rules.json
@@ -6488,6 +6488,269 @@
       ]
     }
   ],
+  "720": [
+    {
+      "indicators": {
+        "ind1": "1",
+        "ind2": "*"
+      },
+      "entity": [
+        {
+          "target": "contributors.contributorNameTypeId",
+          "description": "Type for Personal Name",
+          "applyRulesOnConcatenatedData": true,
+          "subfield": [],
+          "rules": [
+            {
+              "conditions": [
+                {
+                  "type": "set_contributor_name_type_id",
+                  "parameter": {
+                    "name": "Personal name"
+                  }
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "target": "contributors.contributorTypeId",
+          "description": "Type of contributor",
+          "applyRulesOnConcatenatedData": true,
+          "ignoreSubsequentSubfields": true,
+          "subfield": [
+            "4",
+            "e"
+          ],
+          "rules": [
+            {
+              "conditions": [
+                {
+                  "type": "set_contributor_type_id_by_code_or_name",
+                  "parameter": {
+                    "contributorCodeSubfield": "4",
+                    "contributorNameSubfield": "e"
+                  }
+                }
+              ]
+            }
+          ],
+          "alternativeMapping": {
+            "target": "contributors.contributorTypeText",
+            "description": "Contributor type free text",
+            "ignoreSubsequentSubfields": true,
+            "subfield": [
+              "e"
+            ]
+          }
+        },
+        {
+          "target": "contributors.primary",
+          "description": "Primary contributor",
+          "applyRulesOnConcatenatedData": true,
+          "subfield": [
+          ],
+          "rules": [
+            {
+              "conditions": [],
+              "value": "false"
+            }
+          ]
+        },
+        {
+          "target": "contributors.name",
+          "description": "Personal Name",
+          "applyRulesOnConcatenatedData": true,
+          "subfield": [
+            "a"
+          ],
+          "rules": [
+            {
+              "conditions": [
+                {
+                  "type": "trim_period, trim"
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "indicators": {
+        "ind1": " ",
+        "ind2": "*"
+      },
+      "entity": [
+        {
+          "target": "contributors.contributorNameTypeId",
+          "description": "Type for Personal Name",
+          "applyRulesOnConcatenatedData": true,
+          "subfield": [],
+          "rules": [
+            {
+              "conditions": [
+                {
+                  "type": "set_contributor_name_type_id",
+                  "parameter": {
+                    "name": "Personal name"
+                  }
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "target": "contributors.contributorTypeId",
+          "description": "Type of contributor",
+          "applyRulesOnConcatenatedData": true,
+          "ignoreSubsequentSubfields": true,
+          "subfield": [
+            "4",
+            "e"
+          ],
+          "rules": [
+            {
+              "conditions": [
+                {
+                  "type": "set_contributor_type_id_by_code_or_name",
+                  "parameter": {
+                    "contributorCodeSubfield": "4",
+                    "contributorNameSubfield": "e"
+                  }
+                }
+              ]
+            }
+          ],
+          "alternativeMapping": {
+            "target": "contributors.contributorTypeText",
+            "description": "Contributor type free text",
+            "ignoreSubsequentSubfields": true,
+            "subfield": [
+              "e"
+            ]
+          }
+        },
+        {
+          "target": "contributors.primary",
+          "description": "Primary contributor",
+          "applyRulesOnConcatenatedData": true,
+          "subfield": [
+          ],
+          "rules": [
+            {
+              "conditions": [],
+              "value": "false"
+            }
+          ]
+        },
+        {
+          "target": "contributors.name",
+          "description": "Personal Name",
+          "applyRulesOnConcatenatedData": true,
+          "subfield": [
+            "a"
+          ],
+          "rules": [
+            {
+              "conditions": [
+                {
+                  "type": "trim_period, trim"
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "indicators": {
+        "ind1": "2",
+        "ind2": "*"
+      },
+      "entity": [
+        {
+          "target": "contributors.contributorNameTypeId",
+          "description": "Type for Corporate Name",
+          "applyRulesOnConcatenatedData": true,
+          "subfield": [],
+          "rules": [
+            {
+              "conditions": [
+                {
+                  "type": "set_contributor_name_type_id",
+                  "parameter": {
+                    "name": "Corporate name"
+                  }
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "target": "contributors.contributorTypeId",
+          "description": "Type of contributor",
+          "applyRulesOnConcatenatedData": true,
+          "ignoreSubsequentSubfields": true,
+          "subfield": [
+            "4",
+            "e"
+          ],
+          "rules": [
+            {
+              "conditions": [
+                {
+                  "type": "set_contributor_type_id_by_code_or_name",
+                  "parameter": {
+                    "contributorCodeSubfield": "4",
+                    "contributorNameSubfield": "e"
+                  }
+                }
+              ]
+            }
+          ],
+          "alternativeMapping": {
+            "target": "contributors.contributorTypeText",
+            "description": "Contributor type free text",
+            "ignoreSubsequentSubfields": true,
+            "subfield": [
+              "e"
+            ]
+          }
+        },
+        {
+          "target": "contributors.primary",
+          "description": "Primary contributor",
+          "applyRulesOnConcatenatedData": true,
+          "subfield": [
+          ],
+          "rules": [
+            {
+              "conditions": [],
+              "value": "false"
+            }
+          ]
+        },
+        {
+          "target": "contributors.name",
+          "description": "Personal Name",
+          "applyRulesOnConcatenatedData": true,
+          "subfield": [
+            "a"
+          ],
+          "rules": [
+            {
+              "conditions": [
+                {
+                  "type": "trim_period, trim"
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    }
+  ],
   "780": [
     {
       "entity": [

--- a/mod-source-record-manager-server/src/main/resources/rules/marc_bib_rules.json
+++ b/mod-source-record-manager-server/src/main/resources/rules/marc_bib_rules.json
@@ -6520,7 +6520,6 @@
           "target": "contributors.contributorTypeId",
           "description": "Type of contributor",
           "applyRulesOnConcatenatedData": true,
-          "ignoreSubsequentSubfields": true,
           "subfield": [
             "4",
             "e"
@@ -6607,7 +6606,6 @@
           "target": "contributors.contributorTypeId",
           "description": "Type of contributor",
           "applyRulesOnConcatenatedData": true,
-          "ignoreSubsequentSubfields": true,
           "subfield": [
             "4",
             "e"
@@ -6694,7 +6692,6 @@
           "target": "contributors.contributorTypeId",
           "description": "Type of contributor",
           "applyRulesOnConcatenatedData": true,
-          "ignoreSubsequentSubfields": true,
           "subfield": [
             "4",
             "e"


### PR DESCRIPTION
## Purpose
To map  specific  MARC fields  to instance contributor. 

For subfield "e" as name:
- 100
- 110
- 700
- 710


For subfield "j" as name:
- 111
- 711


## Approach
* add marc-bib mapping rule for these fields
* documentation for "alternativeMapping" added.


## Learning
[MODSOURMAN-837](https://issues.folio.org/browse/MODSOURMAN-837)