### PR TITLE
MODSOURMAN-888 - Link update: Implement API endpoint to retrieve mapping metadata by record type

### DIFF
--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -455,6 +455,15 @@
           "permissionsRequired": [
             "mapping-metadata.get"
           ]
+        },
+        {
+          "methods": [
+            "GET"
+          ],
+          "pathPattern": "/mapping-metadata/type/{recordType}",
+          "permissionsRequired": [
+            "mapping-metadata.get"
+          ]
         }
       ]
     },

--- a/mod-source-record-manager-server/pom.xml
+++ b/mod-source-record-manager-server/pom.xml
@@ -201,7 +201,7 @@
     <dependency>
       <groupId>org.folio</groupId>
       <artifactId>data-import-processing-core</artifactId>
-      <version>3.5.0-SNAPSHOT</version>
+      <version>3.5.1</version>
     </dependency>
     <dependency>
       <groupId>org.folio</groupId>

--- a/mod-source-record-manager-server/src/main/java/org/folio/dao/JobExecutionDao.java
+++ b/mod-source-record-manager-server/src/main/java/org/folio/dao/JobExecutionDao.java
@@ -79,7 +79,7 @@ public interface JobExecutionDao {
   /**
    *
    * @param ids JobExecution Logs to be deleted using Ids
-   * @param tenantId
+   * @param tenantId tenant id
    * @return future of boolean depending upon success and failure
    */
   Future<DeleteJobExecutionsResp> softDeleteJobExecutionsByIds(List<String> ids, String tenantId);

--- a/mod-source-record-manager-server/src/main/java/org/folio/rest/impl/MappingMetadataProviderImpl.java
+++ b/mod-source-record-manager-server/src/main/java/org/folio/rest/impl/MappingMetadataProviderImpl.java
@@ -5,6 +5,7 @@ import io.vertx.core.Context;
 import io.vertx.core.Future;
 import io.vertx.core.Handler;
 import io.vertx.core.Vertx;
+import javax.ws.rs.BadRequestException;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.folio.dataimport.util.ExceptionHelper;
@@ -12,6 +13,7 @@ import org.folio.dataimport.util.OkapiConnectionParams;
 import org.folio.rest.jaxrs.resource.MappingMetadata;
 import org.folio.rest.tools.utils.TenantTool;
 import org.folio.services.MappingMetadataService;
+import org.folio.services.util.QueryPathUtil;
 import org.folio.spring.SpringContextUtil;
 import org.springframework.beans.factory.annotation.Autowired;
 
@@ -45,6 +47,27 @@ public class MappingMetadataProviderImpl implements MappingMetadata {
           .onComplete(asyncResultHandler);
       } catch (Exception e) {
         LOGGER.error("Failed to retrieve MappingMetadataDto entity for JobExecution with id {} for tenant {}", jobExecutionId, tenantId, e);
+        asyncResultHandler.handle(Future.succeededFuture(ExceptionHelper.mapExceptionToResponse(e)));
+      }
+    });
+  }
+
+  @Override
+  public void getMappingMetadataTypeByRecordType(String recordType, Map<String, String> okapiHeaders,
+                                                 Handler<AsyncResult<Response>> asyncResultHandler, Context vertxContext) {
+    vertxContext.runOnContext(v -> {
+      try {
+        OkapiConnectionParams params = new OkapiConnectionParams(okapiHeaders, vertxContext.owner());
+        mappingMetadataService.getMappingMetadataDtoByRecordType(
+            QueryPathUtil.toRecordType(recordType).orElseThrow(() ->
+              new BadRequestException("Only marc-bib, marc-holdings or marc-authority supported")), params)
+          .map(GetMappingMetadataByJobExecutionIdResponse::respond200WithApplicationJson)
+          .map(Response.class::cast)
+          .otherwise(ExceptionHelper::mapExceptionToResponse)
+          .onComplete(asyncResultHandler);
+      } catch (Exception e) {
+        LOGGER.error("Failed to retrieve MappingMetadataDto entity for recordType {} and tenant {}",
+          recordType, tenantId, e);
         asyncResultHandler.handle(Future.succeededFuture(ExceptionHelper.mapExceptionToResponse(e)));
       }
     });

--- a/mod-source-record-manager-server/src/main/java/org/folio/services/MappingMetadataService.java
+++ b/mod-source-record-manager-server/src/main/java/org/folio/services/MappingMetadataService.java
@@ -1,6 +1,7 @@
 package org.folio.services;
 
 import io.vertx.core.Future;
+import org.folio.Record;
 import org.folio.dataimport.util.OkapiConnectionParams;
 import org.folio.processing.mapping.defaultmapper.processor.parameters.MappingParameters;
 import org.folio.rest.jaxrs.model.MappingMetadataDto;
@@ -19,6 +20,15 @@ public interface MappingMetadataService {
    * @return MappingMetadataDto
    */
   Future<MappingMetadataDto> getMappingMetadataDto(String jobExecutionId, OkapiConnectionParams okapiParams);
+
+  /**
+   * Returns Mapping rules and Mapping parameters in MappingMetadataDto entity by recordType
+   *
+   * @param recordType  type of rules (e.g. MARC_BIB or MARK_HOLDING)
+   * @param okapiParams  okapi connection params
+   * @return MappingMetadataDto
+   */
+  Future<MappingMetadataDto> getMappingMetadataDtoByRecordType(Record.RecordType recordType, OkapiConnectionParams okapiParams);
 
   /**
    * Creates a snapshot of Mapping parameters and saves it to DB

--- a/mod-source-record-manager-server/src/test/java/org/folio/rest/impl/mappingMetadataProvider/MappingMetadataProviderAPITest.java
+++ b/mod-source-record-manager-server/src/test/java/org/folio/rest/impl/mappingMetadataProvider/MappingMetadataProviderAPITest.java
@@ -7,6 +7,7 @@ import io.vertx.core.json.JsonObject;
 import io.vertx.ext.unit.Async;
 import io.vertx.ext.unit.TestContext;
 import io.vertx.ext.unit.junit.VertxUnitRunner;
+import lombok.SneakyThrows;
 import org.apache.http.HttpStatus;
 import org.folio.TestUtil;
 import org.folio.dao.MappingParamsSnapshotDaoImpl;
@@ -50,7 +51,7 @@ public class MappingMetadataProviderAPITest extends AbstractRestTest {
     RestAssured.given()
       .spec(spec)
       .when()
-      .get(SERVICE_PATH + UUID.randomUUID().toString())
+      .get(SERVICE_PATH + UUID.randomUUID())
       .then()
       .statusCode(HttpStatus.SC_NOT_FOUND);
   }
@@ -73,6 +74,37 @@ public class MappingMetadataProviderAPITest extends AbstractRestTest {
       Assert.assertEquals(jobExecutionId, mappingMetadata.getString("jobExecutionId"));
       async.complete();
     });
+  }
+
+  @Test
+  public void shouldReturnBadRequestIfInvalidRecordType() {
+    var response = RestAssured.given()
+      .spec(spec)
+      .when()
+      .get(SERVICE_PATH + "type/invalid-record-type")
+      .then()
+      .statusCode(HttpStatus.SC_BAD_REQUEST)
+      .extract().body().asString();
+
+    Assert.assertEquals("Only marc-bib, marc-holdings or marc-authority supported", response);
+  }
+
+  @SneakyThrows
+  @Test
+  public void shouldReturnDefaultMappingMetadataByRecordTypeOnGet(TestContext context) {
+    JsonObject expectedRules = new JsonObject(TestUtil.readFileFromPath(MARC_BIB_RULES_PATH));
+    JsonObject expectedParams = new JsonObject(TestUtil.readFileFromPath(MARC_PARAMS_PATH));
+    JsonObject actual = new JsonObject(RestAssured.given()
+          .spec(spec)
+          .when()
+          .get(SERVICE_PATH + "type/marc-bib")
+          .then()
+          .statusCode(HttpStatus.SC_OK)
+          .extract().body().asString());
+
+      Assert.assertNotNull(actual);
+      Assert.assertEquals(expectedRules, new JsonObject(actual.getString("mappingRules")));
+      Assert.assertEquals(expectedParams, new JsonObject(actual.getString("mappingParams")));
   }
 
   private Future<String> saveMappingRules(String jobExecutionId) {

--- a/mod-source-record-manager-server/src/test/java/org/folio/rest/impl/mappingMetadataProvider/MappingMetadataProviderAPITest.java
+++ b/mod-source-record-manager-server/src/test/java/org/folio/rest/impl/mappingMetadataProvider/MappingMetadataProviderAPITest.java
@@ -7,7 +7,8 @@ import io.vertx.core.json.JsonObject;
 import io.vertx.ext.unit.Async;
 import io.vertx.ext.unit.TestContext;
 import io.vertx.ext.unit.junit.VertxUnitRunner;
-import lombok.SneakyThrows;
+import java.io.IOException;
+import java.util.UUID;
 import org.apache.http.HttpStatus;
 import org.folio.TestUtil;
 import org.folio.dao.MappingParamsSnapshotDaoImpl;
@@ -22,9 +23,6 @@ import org.junit.runner.RunWith;
 import org.mockito.InjectMocks;
 import org.mockito.MockitoAnnotations;
 import org.mockito.Spy;
-
-import java.io.IOException;
-import java.util.UUID;
 
 @RunWith(VertxUnitRunner.class)
 public class MappingMetadataProviderAPITest extends AbstractRestTest {
@@ -89,9 +87,8 @@ public class MappingMetadataProviderAPITest extends AbstractRestTest {
     Assert.assertEquals("Only marc-bib, marc-holdings or marc-authority supported", response);
   }
 
-  @SneakyThrows
   @Test
-  public void shouldReturnDefaultMappingMetadataByRecordTypeOnGet(TestContext context) {
+  public void shouldReturnDefaultMappingMetadataByRecordTypeOnGet(TestContext context) throws IOException {
     JsonObject expectedRules = new JsonObject(TestUtil.readFileFromPath(MARC_BIB_RULES_PATH));
     JsonObject expectedParams = new JsonObject(TestUtil.readFileFromPath(MARC_PARAMS_PATH));
     JsonObject actual = new JsonObject(RestAssured.given()

--- a/mod-source-record-manager-server/src/test/resources/org/folio/services/marc_bib_rules.json
+++ b/mod-source-record-manager-server/src/test/resources/org/folio/services/marc_bib_rules.json
@@ -1081,6 +1081,14 @@
     {
       "entity": [
         {
+          "target": "contributors.authorityId",
+          "description": "Authority ID that controlling the contributor",
+          "applyRulesOnConcatenatedData": true,
+          "subfield": [
+            "9"
+          ]
+        },
+        {
           "target": "contributors.contributorNameTypeId",
           "description": "Type for Personal Name",
           "applyRulesOnConcatenatedData": true,
@@ -1183,6 +1191,14 @@
     {
       "entity": [
         {
+          "target": "contributors.authorityId",
+          "description": "Authority ID that controlling the contributor",
+          "applyRulesOnConcatenatedData": true,
+          "subfield": [
+            "9"
+          ]
+        },
+        {
           "target": "contributors.contributorNameTypeId",
           "description": "Type for Corporate Name",
           "applyRulesOnConcatenatedData": true,
@@ -1282,6 +1298,14 @@
   "111": [
     {
       "entity": [
+        {
+          "target": "contributors.authorityId",
+          "description": "Authority ID that controlling the contributor",
+          "applyRulesOnConcatenatedData": true,
+          "subfield": [
+            "9"
+          ]
+        },
         {
           "target": "contributors.contributorNameTypeId",
           "description": "Type for Meeting Name",
@@ -5625,14 +5649,17 @@
         },
         {
           "target": "notes.staffOnly",
-          "description": "If true, determines that the note should not be visible for others than staff",
+          "description": "If the 1st indicator equals 0, determines that the note should not be visible for others than staff",
           "subfield": [
             "a"
           ],
           "rules": [
             {
-              "conditions": [],
-              "value": "false"
+              "conditions": [
+                {
+                  "type": "set_note_staff_only_via_indicator"
+                }
+              ]
             }
           ]
         }
@@ -6142,6 +6169,14 @@
     {
       "entity": [
         {
+          "target": "contributors.authorityId",
+          "description": "Authority ID that controlling the contributor",
+          "applyRulesOnConcatenatedData": true,
+          "subfield": [
+            "9"
+          ]
+        },
+        {
           "target": "contributors.contributorNameTypeId",
           "description": "Type for Personal Name",
           "applyRulesOnConcatenatedData": true,
@@ -6244,6 +6279,14 @@
     {
       "entity": [
         {
+          "target": "contributors.authorityId",
+          "description": "Authority ID that controlling the contributor",
+          "applyRulesOnConcatenatedData": true,
+          "subfield": [
+            "9"
+          ]
+        },
+        {
           "target": "contributors.contributorNameTypeId",
           "description": "Type for Corporate Name",
           "applyRulesOnConcatenatedData": true,
@@ -6343,6 +6386,14 @@
   "711": [
     {
       "entity": [
+        {
+          "target": "contributors.authorityId",
+          "description": "Authority ID that controlling the contributor",
+          "applyRulesOnConcatenatedData": true,
+          "subfield": [
+            "9"
+          ]
+        },
         {
           "target": "contributors.contributorNameTypeId",
           "description": "Type for Meeting Name",

--- a/mod-source-record-manager-server/src/test/resources/org/folio/services/marc_mapping_params.json
+++ b/mod-source-record-manager-server/src/test/resources/org/folio/services/marc_mapping_params.json
@@ -25,5 +25,7 @@
   "loanTypes": [],
   "itemNoteTypes": [],
   "marcFieldProtectionSettings": [],
-  "tenantConfiguration": ""
+  "tenantConfiguration": "",
+  "authorityNoteTypes": [],
+  "authoritySourceFiles": []
 }

--- a/ramls/mapping-metadata-provider.raml
+++ b/ramls/mapping-metadata-provider.raml
@@ -41,3 +41,23 @@ resourceTypes:
           body:
             text/plain:
               example: "Internal server error"
+
+  /type/{recordType}:
+    displayName: recordType
+    description: get mapping metadata by record type
+    get:
+      responses:
+        200:
+          body:
+            application/json:
+              type: mappingMetadataDto
+        404:
+          description: "Not found"
+          body:
+            text/plain:
+              example: "Not found"
+        500:
+          description: "Internal server error"
+          body:
+            text/plain:
+              example: "Internal server error"


### PR DESCRIPTION
Purpose
As described in MODSOURMAN-888, implemented API endpoint to retrieve mapping metadata by record type

Approach

- Extend mapping-metadata-provider API interface with new endpoint (permission could be same)
- Use QueryPathUtil.toRecordType for record-type conversion
- Load mapping rules from the database and mapping metadata from a local cache

Learning
https://issues.folio.org/browse/MODSOURMAN-888