### PR TITLE
[MODSOURMAN-867]Data import: 500 Error when user tries to sort by cli…

### DIFF
--- a/mod-source-record-manager-server/src/main/resources/templates/db_scripts/remove_records_where_parent_id_is_null.sql
+++ b/mod-source-record-manager-server/src/main/resources/templates/db_scripts/remove_records_where_parent_id_is_null.sql
@@ -1,0 +1,1 @@
+delete from ${myuniversity}_${mymodule}.job_execution where parent_job_id is null;

--- a/mod-source-record-manager-server/src/main/resources/templates/db_scripts/schema.json
+++ b/mod-source-record-manager-server/src/main/resources/templates/db_scripts/schema.json
@@ -231,6 +231,11 @@
       "run": "after",
       "snippetPath": "update_set_file_name_from_null_to_no_file_name.sql",
       "fromModuleVersion": "mod-source-record-manager-3.5.1"
+    },
+    {
+      "run": "after",
+      "snippetPath": "remove_records_where_parent_id_is_null.sql",
+      "fromModuleVersion": "mod-source-record-manager-3.5.1"
     }
   ]
 }


### PR DESCRIPTION
https://issues.folio.org/browse/MODSOURMAN-867
Overview: When a user tries to sort data on the View All page by clicking on the title of the columns, a 500 error occurs in the response from the server.

Workaround: set filter by date from "2020-06-30" to "current date".

Precondition:

Authorized user with "Data import: Can upload files, import, and view logs" permission

Steps to Reproduce:

Go to the Data import app
Click on the Actions button at the top right of the screen
Select  View all 
Open devtools
Select the "Network" section
Click on the "Records" / "Job profile" / "Ended running" / "ID" titles of columns (2 times on each title)
Expected Results:

When user click on the "Records" / "Job profile" / "Ended running" / "ID"  for the first time, the result list must be sorted by this column in ascending order (0-9; A-z).

When a user clicks on the title for the second time, the result list must be sorted by this column in descending order (9-0; Z-a).

Actual Results: 500 Error occurred in the response from the server.
Additional Information:
URL: https://bugfest-mg.int.aws.folio.org/
On Snapshots the issue is not reproduced.
**