### PR TITLE
MODSOURMAN-907: The '2' number of Instance is displayed in cell in the row with the 'Updated' row header at the individual import job's log

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,7 @@
 ## 2022-xx-xx v3.6.0-SNAPSHOT
 * [MODSOURMAN-873](https://issues.folio.org/browse/MODSOURMAN-873) Add MARC 720 field to default MARC Bib-Instance mapping and adjust relator term mapping
 * [MODSOURMAN-837](https://issues.folio.org/browse/MODSOURMAN-837) MARC bib - FOLIO instance mapping | Update default mapping to change how Relator term is populated on instance record
+* [MODSOURMAN-890](https://issues.folio.org/browse/MODSOURMAN-890) The '2' number of Instance is displayed in cell in the row with the 'Updated' row header at the individual import job's log
 
 ## 2022-10-24 v3.5.0
 * [MODSOURMAN-858](https://issues.folio.org/browse/MODSOURMAN-858) Mapping bib's $9 into contributors.authorityId field

--- a/mod-source-record-manager-server/src/main/resources/templates/db_scripts/create_get_job_execution_summary_function.sql
+++ b/mod-source-record-manager-server/src/main/resources/templates/db_scripts/create_get_job_execution_summary_function.sql
@@ -21,7 +21,7 @@ BEGIN
 
       COUNT(DISTINCT(entity_id)) FILTER (WHERE entity_type = 'INSTANCE' AND action_type = 'CREATE' AND action_status = 'COMPLETED') AS total_created_instances,
       COUNT(DISTINCT(entity_id)) FILTER (WHERE entity_type = 'INSTANCE' AND action_type = 'UPDATE' AND action_status = 'COMPLETED') AS total_updated_instances,
-      COUNT(DISTINCT(entity_id)) FILTER (WHERE entity_type = 'INSTANCE' AND (action_type = 'NON_MATCH' OR action_status = 'ERROR')) AS total_discarded_instances,
+      COUNT(*) FILTER (WHERE entity_type = 'INSTANCE' AND (action_type = 'NON_MATCH' OR action_status = 'ERROR')) AS total_discarded_instances,
       COUNT(*) FILTER (WHERE entity_type = 'INSTANCE' AND action_status = 'ERROR') AS total_instances_errors,
 
       COUNT(*) FILTER (WHERE entity_type = 'HOLDINGS' AND action_type = 'CREATE' AND action_status = 'COMPLETED') AS total_created_holdings,

--- a/mod-source-record-manager-server/src/main/resources/templates/db_scripts/create_get_job_execution_summary_function.sql
+++ b/mod-source-record-manager-server/src/main/resources/templates/db_scripts/create_get_job_execution_summary_function.sql
@@ -22,7 +22,7 @@ BEGIN
       COUNT(DISTINCT(entity_id)) FILTER (WHERE entity_type = 'INSTANCE' AND action_type = 'CREATE' AND action_status = 'COMPLETED') AS total_created_instances,
       COUNT(DISTINCT(entity_id)) FILTER (WHERE entity_type = 'INSTANCE' AND action_type = 'UPDATE' AND action_status = 'COMPLETED') AS total_updated_instances,
       COUNT(DISTINCT(entity_id)) FILTER (WHERE entity_type = 'INSTANCE' AND (action_type = 'NON_MATCH' OR action_status = 'ERROR')) AS total_discarded_instances,
-      COUNT(DISTINCT(entity_id)) FILTER (WHERE entity_type = 'INSTANCE' AND action_status = 'ERROR') AS total_instances_errors,
+      COUNT(*) FILTER (WHERE entity_type = 'INSTANCE' AND action_status = 'ERROR') AS total_instances_errors,
 
       COUNT(*) FILTER (WHERE entity_type = 'HOLDINGS' AND action_type = 'CREATE' AND action_status = 'COMPLETED') AS total_created_holdings,
       COUNT(*) FILTER (WHERE entity_type = 'HOLDINGS' AND action_type = 'UPDATE' AND action_status = 'COMPLETED') AS total_updated_holdings,

--- a/mod-source-record-manager-server/src/main/resources/templates/db_scripts/create_get_job_execution_summary_function.sql
+++ b/mod-source-record-manager-server/src/main/resources/templates/db_scripts/create_get_job_execution_summary_function.sql
@@ -19,10 +19,10 @@ BEGIN
       COUNT(*) FILTER (WHERE entity_type IN ('MARC_BIBLIOGRAPHIC', 'MARC_HOLDINGS', 'MARC_AUTHORITY', 'EDIFACT') AND (action_type = 'NON_MATCH' OR action_status = 'ERROR')) AS total_discarded_source_records,
       COUNT(*) FILTER (WHERE entity_type IN ('MARC_BIBLIOGRAPHIC', 'MARC_HOLDINGS', 'MARC_AUTHORITY', 'EDIFACT') AND action_status = 'ERROR') AS total_source_records_errors,
 
-      COUNT(*) FILTER (WHERE entity_type = 'INSTANCE' AND action_type = 'CREATE' AND action_status = 'COMPLETED') AS total_created_instances,
-      COUNT(*) FILTER (WHERE entity_type = 'INSTANCE' AND action_type = 'UPDATE' AND action_status = 'COMPLETED') AS total_updated_instances,
-      COUNT(*) FILTER (WHERE entity_type = 'INSTANCE' AND (action_type = 'NON_MATCH' OR action_status = 'ERROR')) AS total_discarded_instances,
-      COUNT(*) FILTER (WHERE entity_type = 'INSTANCE' AND action_status = 'ERROR') AS total_instances_errors,
+      COUNT(DISTINCT(entity_id)) FILTER (WHERE entity_type = 'INSTANCE' AND action_type = 'CREATE' AND action_status = 'COMPLETED') AS total_created_instances,
+      COUNT(DISTINCT(entity_id)) FILTER (WHERE entity_type = 'INSTANCE' AND action_type = 'UPDATE' AND action_status = 'COMPLETED') AS total_updated_instances,
+      COUNT(DISTINCT(entity_id)) FILTER (WHERE entity_type = 'INSTANCE' AND (action_type = 'NON_MATCH' OR action_status = 'ERROR')) AS total_discarded_instances,
+      COUNT(DISTINCT(entity_id)) FILTER (WHERE entity_type = 'INSTANCE' AND action_status = 'ERROR') AS total_instances_errors,
 
       COUNT(*) FILTER (WHERE entity_type = 'HOLDINGS' AND action_type = 'CREATE' AND action_status = 'COMPLETED') AS total_created_holdings,
       COUNT(*) FILTER (WHERE entity_type = 'HOLDINGS' AND action_type = 'UPDATE' AND action_status = 'COMPLETED') AS total_updated_holdings,

--- a/mod-source-record-manager-server/src/main/resources/templates/db_scripts/schema.json
+++ b/mod-source-record-manager-server/src/main/resources/templates/db_scripts/schema.json
@@ -190,7 +190,7 @@
     {
       "run": "after",
       "snippetPath": "create_get_job_execution_summary_function.sql",
-      "fromModuleVersion": "mod-source-record-manager-3.4.0"
+      "fromModuleVersion": "mod-source-record-manager-3.5.3"
     },
     {
       "run": "after",

--- a/mod-source-record-manager-server/src/test/java/org/folio/rest/impl/metadataProvider/MetadataProviderJobExecutionAPITest.java
+++ b/mod-source-record-manager-server/src/test/java/org/folio/rest/impl/metadataProvider/MetadataProviderJobExecutionAPITest.java
@@ -978,7 +978,7 @@ public class MetadataProviderJobExecutionAPITest extends AbstractRestTest {
 
     Future<JournalRecord> future = Future.succeededFuture()
       .compose(v -> createJournalRecord(createdJobExecution.getId(), sourceRecordId, null, null, null,  0, CREATE, MARC_BIBLIOGRAPHIC, COMPLETED, null))
-      .compose(v -> createJournalRecord(createdJobExecution.getId(), sourceRecordId, UUID.randomUUID().toString(), null, null,  0, NON_MATCH, INSTANCE, COMPLETED, null))
+      .compose(v -> createJournalRecord(createdJobExecution.getId(), sourceRecordId, null, null, null,  0, NON_MATCH, INSTANCE, COMPLETED, null))
       .onFailure(context::fail);
 
     future.onComplete(ar -> context.verify(v -> {
@@ -1015,7 +1015,7 @@ public class MetadataProviderJobExecutionAPITest extends AbstractRestTest {
 
     Future<JournalRecord> future = Future.succeededFuture()
       .compose(v -> createJournalRecord(createdJobExecution.getId(), sourceRecordId, null, null, null, 0, CREATE, MARC_BIBLIOGRAPHIC, COMPLETED, null))
-      .compose(v -> createJournalRecord(createdJobExecution.getId(), sourceRecordId, UUID.randomUUID().toString(), null, null,  0, CREATE, INSTANCE, ERROR, "error msg"))
+      .compose(v -> createJournalRecord(createdJobExecution.getId(), sourceRecordId, null, null, null,  0, CREATE, INSTANCE, ERROR, "error msg"))
       .onFailure(context::fail);
 
     future.onComplete(ar -> context.verify(v -> {

--- a/mod-source-record-manager-server/src/test/java/org/folio/rest/impl/metadataProvider/MetadataProviderJobExecutionAPITest.java
+++ b/mod-source-record-manager-server/src/test/java/org/folio/rest/impl/metadataProvider/MetadataProviderJobExecutionAPITest.java
@@ -886,7 +886,7 @@ public class MetadataProviderJobExecutionAPITest extends AbstractRestTest {
     String instanceEntityId = UUID.randomUUID().toString();
     Future<JournalRecord> future = Future.succeededFuture()
       .compose(v -> createJournalRecord(jobExecutionId, sourceRecordId, null, null, recordTitle, 0, CREATE, MARC_BIBLIOGRAPHIC, COMPLETED, null))
-      .compose(v -> createJournalRecord(jobExecutionId, sourceRecordId, instanceEntityId, null, recordTitle, 0, CREATE, INSTANCE, COMPLETED, null))
+      .compose(v -> createJournalRecord(jobExecutionId, sourceRecordId, instanceEntityId, null, recordTitle, 0, UPDATE, INSTANCE, COMPLETED, null))
       .compose(v -> createJournalRecord(jobExecutionId, sourceRecordId, instanceEntityId, null, recordTitle, 0, UPDATE, INSTANCE, COMPLETED, null))
       .onFailure(context::fail);
 


### PR DESCRIPTION
## Purpose
Avoid situations when 2 or more actions were processed for the 1 Instance - calculate it as 1 Instance.

## Approach
Improved script via distinct by entity_id.

## Learning
https://issues.folio.org/browse/MODSOURMAN-907
