### PR TITLE
[MODSOURMAN-891]SRS MARC Created when No Create Action in Job Profile

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -2,7 +2,7 @@
 * [MODSOURMAN-873](https://issues.folio.org/browse/MODSOURMAN-873) Add MARC 720 field to default MARC Bib-Instance mapping and adjust relator term mapping
 * [MODSOURMAN-837](https://issues.folio.org/browse/MODSOURMAN-837) MARC bib - FOLIO instance mapping | Update default mapping to change how Relator term is populated on instance record
 * [MODSOURMAN-890](https://issues.folio.org/browse/MODSOURMAN-890) The '2' number of Instance is displayed in cell in the row with the 'Updated' row header at the individual import job's log
-
+* [MODSOURMAN-891](https://issues.folio.org/browse/MODSOURMAN-891) SRS MARC Created when No Create Action in Job Profile
 ## 2022-10-24 v3.5.0
 * [MODSOURMAN-858](https://issues.folio.org/browse/MODSOURMAN-858) Mapping bib's $9 into contributors.authorityId field
 * [MODSOURMAN-838](https://issues.folio.org/browse/MODSOURMAN-838) Search by LCCN "010 $a" subfield value with "\" at the end don't retrieve results

--- a/mod-source-record-manager-server/src/main/java/org/folio/verticle/consumers/util/MarcImportEventsHandler.java
+++ b/mod-source-record-manager-server/src/main/java/org/folio/verticle/consumers/util/MarcImportEventsHandler.java
@@ -1,8 +1,5 @@
 package org.folio.verticle.consumers.util;
 
-import static org.folio.rest.jaxrs.model.JournalRecord.EntityType.MARC_AUTHORITY;
-import static org.folio.rest.jaxrs.model.JournalRecord.EntityType.MARC_BIBLIOGRAPHIC;
-
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -27,6 +24,12 @@ import org.folio.services.journal.JournalRecordMapperException;
 import org.folio.services.journal.JournalService;
 import org.folio.services.journal.JournalUtil;
 import org.folio.services.util.ParsedRecordUtil;
+
+import static org.folio.rest.jaxrs.model.JournalRecord.EntityType.HOLDINGS;
+import static org.folio.rest.jaxrs.model.JournalRecord.EntityType.ITEM;
+import static org.folio.rest.jaxrs.model.JournalRecord.EntityType.INSTANCE;
+import static org.folio.rest.jaxrs.model.JournalRecord.EntityType.MARC_AUTHORITY;
+import static org.folio.rest.jaxrs.model.JournalRecord.EntityType.MARC_BIBLIOGRAPHIC;
 
 @Component
 public class MarcImportEventsHandler implements SpecificEventHandler {
@@ -124,6 +127,12 @@ public class MarcImportEventsHandler implements SpecificEventHandler {
             })
             .map(title -> Future.succeededFuture(journalRecord.withTitle(title)))
             .orElseGet(() -> Future.succeededFuture(journalRecord)));
+      }
+    } else if (entityType == HOLDINGS || entityType == ITEM) {
+      String recordAsString = eventPayload.getContext().get(INSTANCE.value());
+      if (StringUtils.isNotBlank(recordAsString)) {
+        var title = (String) Json.decodeValue(recordAsString, Map.class).get("title");
+        journalRecord.setTitle(title);
       }
     }
 

--- a/mod-source-record-manager-server/src/test/java/org/folio/rest/impl/AbstractRestTest.java
+++ b/mod-source-record-manager-server/src/test/java/org/folio/rest/impl/AbstractRestTest.java
@@ -78,8 +78,8 @@ import static org.folio.kafka.KafkaTopicNameHelper.getDefaultNameSpace;
 import static org.folio.rest.jaxrs.model.ProfileSnapshotWrapper.ContentType.ACTION_PROFILE;
 import static org.folio.rest.jaxrs.model.ProfileSnapshotWrapper.ContentType.JOB_PROFILE;
 import static org.folio.rest.jaxrs.model.ProfileSnapshotWrapper.ContentType.MAPPING_PROFILE;
-import static org.folio.services.util.EventHandlingUtil.constructModuleName;
 import static org.folio.rest.util.OkapiConnectionParams.OKAPI_TOKEN_HEADER;
+import static org.folio.services.util.EventHandlingUtil.constructModuleName;
 
 /**
  * Abstract test for the REST API testing needs.
@@ -213,7 +213,11 @@ public abstract class AbstractRestTest {
       new ProfileSnapshotWrapper()
         .withProfileId(actionMarcHoldingsCreateProfile.getId())
         .withContentType(ACTION_PROFILE)
-        .withContent(actionMarcHoldingsCreateProfile)));
+        .withContent(actionMarcHoldingsCreateProfile)
+        .withChildSnapshotWrappers(List.of(new ProfileSnapshotWrapper()
+          .withProfileId(marcHoldingsMappingProfile.getId())
+          .withContentType(MAPPING_PROFILE)
+          .withContent(marcHoldingsMappingProfile)))));
 
   protected ProfileSnapshotWrapper profileCreateMarcHoldingsSnapshotWrapperResponse = new ProfileSnapshotWrapper()
     .withId(UUID.randomUUID().toString())

--- a/mod-source-record-manager-server/src/test/java/org/folio/rest/impl/changeManager/ChangeManagerAPITest.java
+++ b/mod-source-record-manager-server/src/test/java/org/folio/rest/impl/changeManager/ChangeManagerAPITest.java
@@ -113,7 +113,6 @@ public class ChangeManagerAPITest extends AbstractRestTest {
   private static final String DEFAULT_MARC_HOLDINGS_JOB_PROFILE_ID = "80898dee-449f-44dd-9c8e-37d5eb469b1d";
 
   private static final String DEFAULT_MARC_AUTHORITY_JOB_PROFILE_ID = "6eefa4c6-bbf7-4845-ad82-de7fc5abd0e3";
-
   private static final String JOB_PROFILE_ID = UUID.randomUUID().toString();
 
   private Set<JobExecution.SubordinationType> parentTypes = EnumSet.of(
@@ -1605,7 +1604,7 @@ public class ChangeManagerAPITest extends AbstractRestTest {
       .observeFor(30, TimeUnit.SECONDS)
       .build());
 
-    Event obtainedEvent = Json.decodeValue(observedValues.get(1), Event.class);
+    Event obtainedEvent = Json.decodeValue(observedValues.get(0), Event.class);
     assertEquals(DI_RAW_RECORDS_CHUNK_PARSED.value(), obtainedEvent.getEventType());
 
     RecordCollection processedRecords = Json
@@ -1984,68 +1983,13 @@ public class ChangeManagerAPITest extends AbstractRestTest {
       .observeFor(30, TimeUnit.SECONDS)
       .build());
 
-    Event obtainedEvent = Json.decodeValue(observedValues.get(6), Event.class);
+    Event obtainedEvent = Json.decodeValue(observedValues.get(5), Event.class);
     assertEquals(DI_RAW_RECORDS_CHUNK_PARSED.value(), obtainedEvent.getEventType());
     RecordCollection recordCollection = Json
       .decodeValue(obtainedEvent.getEventPayload(), RecordCollection.class);
     Assert.assertNotNull(recordCollection.getRecords().get(0).getMatchedId());
     Assert.assertNotNull(recordCollection.getRecords().get(0).getErrorRecord());
     Assert.assertEquals( "{\"error\":\"A new Instance was not created because the incoming record already contained a 999ff$s or 999ff$i field\"}", recordCollection.getRecords().get(0).getErrorRecord().getDescription());
-  }
-
-  @Test
-  public void shouldNotHaveErrorRecordIf999ffsFieldExistsAndCreateMarcHoldingsActionProfile(TestContext testContext) throws InterruptedException {
-    InitJobExecutionsRsDto response =
-      constructAndPostInitJobExecutionRqDto(1);
-    List<JobExecution> createdJobExecutions = response.getJobExecutions();
-    assertThat(createdJobExecutions.size(), is(1));
-    JobExecution jobExec = createdJobExecutions.get(0);
-
-
-    WireMock.stubFor(WireMock.get("/data-import-profiles/jobProfiles/"+ DEFAULT_MARC_HOLDINGS_JOB_PROFILE_ID +"?withRelations=false&")
-      .willReturn(WireMock.ok().withBody(Json.encode(new JobProfile().withId(DEFAULT_MARC_HOLDINGS_JOB_PROFILE_ID).withName("Default - Create Holdings and SRS MARC Holdings")))));
-
-    WireMock.stubFor(post(RECORDS_SERVICE_URL)
-      .willReturn(created().withTransformers(RequestToResponseTransformer.NAME)));
-    WireMock.stubFor(post(new UrlPathPattern(new RegexPattern(PROFILE_SNAPSHOT_URL + "/.*"), true))
-      .willReturn(WireMock.created().withBody(Json.encode(profileMarcHoldingsSnapshotWrapperResponse))));
-    WireMock.stubFor(get(new UrlPathPattern(new RegexPattern(PROFILE_SNAPSHOT_URL + "/.*"), true))
-      .willReturn(WireMock.ok().withBody(Json.encode(profileMarcHoldingsSnapshotWrapperResponse))));
-
-    Async async = testContext.async();
-    RestAssured.given()
-      .spec(spec)
-      .body(new JobProfileInfo()
-        .withName("MARC records")
-        .withId(DEFAULT_MARC_HOLDINGS_JOB_PROFILE_ID)
-        .withDataType(DataType.MARC))
-      .when()
-      .put(JOB_EXECUTION_PATH + jobExec.getId() + JOB_PROFILE_PATH)
-      .then()
-      .statusCode(HttpStatus.SC_OK);
-    async.complete();
-
-    async = testContext.async();
-    RestAssured.given()
-      .spec(spec)
-      .body(rawRecordsDto_3)
-      .when()
-      .post(JOB_EXECUTION_PATH + jobExec.getId() + RECORDS_PATH)
-      .then()
-      .statusCode(HttpStatus.SC_NO_CONTENT);
-    async.complete();
-
-    String topicToObserve = formatToKafkaTopicName(DI_RAW_RECORDS_CHUNK_PARSED.value());
-    List<String> observedValues = kafkaCluster.observeValues(ObserveKeyValues.on(topicToObserve, 1)
-      .observeFor(30, TimeUnit.SECONDS)
-      .build());
-
-    Event obtainedEvent = Json.decodeValue(observedValues.get(0), Event.class);
-    assertEquals(DI_RAW_RECORDS_CHUNK_PARSED.value(), obtainedEvent.getEventType());
-    RecordCollection recordCollection = Json
-      .decodeValue(obtainedEvent.getEventPayload(), RecordCollection.class);
-    Assert.assertNotNull(recordCollection.getRecords().get(0).getMatchedId());
-    Assert.assertNull(recordCollection.getRecords().get(0).getErrorRecord());
   }
 
   @Test
@@ -2095,7 +2039,7 @@ public class ChangeManagerAPITest extends AbstractRestTest {
       .observeFor(30, TimeUnit.SECONDS)
       .build());
 
-    Event obtainedEvent = Json.decodeValue(observedValues.get(4), Event.class);
+    Event obtainedEvent = Json.decodeValue(observedValues.get(3), Event.class);
     assertEquals(DI_RAW_RECORDS_CHUNK_PARSED.value(), obtainedEvent.getEventType());
     RecordCollection recordCollection = Json
       .decodeValue(obtainedEvent.getEventPayload(), RecordCollection.class);
@@ -2143,7 +2087,7 @@ public class ChangeManagerAPITest extends AbstractRestTest {
       .observeFor(30, TimeUnit.SECONDS)
       .build());
 
-    Event obtainedEvent = Json.decodeValue(observedValues.get(3), Event.class);
+    Event obtainedEvent = Json.decodeValue(observedValues.get(2), Event.class);
     assertEquals(DI_RAW_RECORDS_CHUNK_PARSED.value(), obtainedEvent.getEventType());
     RecordCollection recordCollection = Json.decodeValue(obtainedEvent.getEventPayload(), RecordCollection.class);
     assertEquals(1, recordCollection.getRecords().size());
@@ -2197,7 +2141,7 @@ public class ChangeManagerAPITest extends AbstractRestTest {
       .observeFor(30, TimeUnit.SECONDS)
       .build());
 
-    Event obtainedEvent = Json.decodeValue(observedValues.get(8), Event.class);
+    Event obtainedEvent = Json.decodeValue(observedValues.get(7), Event.class);
     assertEquals(DI_RAW_RECORDS_CHUNK_PARSED.value(), obtainedEvent.getEventType());
     RecordCollection recordCollection = Json
       .decodeValue(obtainedEvent.getEventPayload(), RecordCollection.class);

--- a/mod-source-record-manager-server/src/test/java/org/folio/services/ChangeEngineServiceImplTest.java
+++ b/mod-source-record-manager-server/src/test/java/org/folio/services/ChangeEngineServiceImplTest.java
@@ -1,5 +1,9 @@
 package org.folio.services;
 
+import static org.folio.rest.jaxrs.model.DataImportEventTypes.DI_MARC_FOR_UPDATE_RECEIVED;
+import static org.folio.rest.jaxrs.model.ProfileSnapshotWrapper.ContentType.ACTION_PROFILE;
+import static org.folio.rest.jaxrs.model.ProfileSnapshotWrapper.ContentType.JOB_PROFILE;
+import static org.folio.rest.jaxrs.model.ProfileSnapshotWrapper.ContentType.MAPPING_PROFILE;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.hasSize;
@@ -9,6 +13,9 @@ import static org.junit.Assert.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyList;
 import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import static org.folio.services.ChangeEngineServiceImpl.RECORD_ID_HEADER;
@@ -25,7 +32,9 @@ import io.vertx.core.json.Json;
 import io.vertx.core.json.JsonObject;
 import io.vertx.kafka.client.producer.KafkaHeader;
 
+import org.folio.rest.jaxrs.model.EntityType;
 import org.folio.rest.jaxrs.model.MappingMetadataDto;
+import org.folio.rest.jaxrs.model.MappingProfile;
 import org.folio.services.validation.JobProfileSnapshotValidationService;
 import org.junit.Before;
 import org.junit.Test;
@@ -150,7 +159,7 @@ public class ChangeEngineServiceImplTest {
     JobExecution jobExecution = getTestJobExecution();
     jobExecution.setJobProfileSnapshotWrapper(new ProfileSnapshotWrapper()
       .withChildSnapshotWrappers(List.of(new ProfileSnapshotWrapper()
-        .withContentType(ProfileSnapshotWrapper.ContentType.ACTION_PROFILE)
+        .withContentType(ACTION_PROFILE)
         .withContent(new JsonObject(Json.encode(new ActionProfile()
           .withAction(ActionProfile.Action.UPDATE)
           .withFolioRecord(ActionProfile.FolioRecord.MARC_BIBLIOGRAPHIC))).getMap())
@@ -178,7 +187,7 @@ public class ChangeEngineServiceImplTest {
     JobExecution jobExecution = getTestJobExecution();
     jobExecution.setJobProfileSnapshotWrapper(new ProfileSnapshotWrapper()
       .withChildSnapshotWrappers(List.of(new ProfileSnapshotWrapper()
-        .withContentType(ProfileSnapshotWrapper.ContentType.ACTION_PROFILE)
+        .withContentType(ACTION_PROFILE)
         .withContent(new JsonObject(Json.encode(new ActionProfile()
           .withAction(ActionProfile.Action.DELETE)
           .withFolioRecord(ActionProfile.FolioRecord.MARC_AUTHORITY))).getMap())
@@ -307,6 +316,144 @@ public class ChangeEngineServiceImplTest {
     assertThat(actual.get(0).getErrorRecord(), nullValue());
     assertThat(actual.get(0).getMatchedId(), equalTo("7ca42730-9ba6-4bc8-98d3-f068728504c9"));
     assertThat(actual.get(0).getExternalIdsHolder().getInstanceId(), equalTo("29573076-a7ee-462a-8f9b-2659ab7df23c"));
+  }
+
+  @Test
+  public void shouldOnlyUpdateIfOnlyCreateHoldings() {
+    String rawMarc = "00182cc  a22000851  4500001000900000004000800009005001700017008003300034852002900067\u001E10245123\u001E9928371\u001E20170607135730.0\u001E1706072u    8   4001uu   0901128\u001E0 \u001Fbfine\u001FhN7433.3\u001Fi.B87 2014\u001E\u001D";
+
+    RawRecordsDto rawRecordsDto = getTestRawRecordsDto(rawMarc);
+    JobExecution jobExecution = new JobExecution()
+      .withId(UUID.randomUUID().toString())
+      .withUserId(UUID.randomUUID().toString())
+      .withJobProfileSnapshotWrapper(constructCreateMarcHoldingsSnapshotWrapper())
+      .withJobProfileInfo(new JobProfileInfo().withId(UUID.randomUUID().toString())
+        .withName("test").withDataType(JobProfileInfo.DataType.MARC));
+
+    mockServicesForParseRawRecordsChunkForJobExecution();
+
+    try (var mockedStatic = Mockito.mockStatic(EventHandlingUtil.class)) {
+      mockedStatic.when(() -> EventHandlingUtil.sendEventToKafka(any(), any(), any(), kafkaHeadersCaptor.capture(), any(), any()))
+        .thenReturn(Future.succeededFuture(true));
+      service.parseRawRecordsChunkForJobExecution(rawRecordsDto, jobExecution, "1", okapiConnectionParams).result();
+    }
+
+    verify(recordsPublishingService).sendEventsWithRecords(any(), eq(jobExecution.getId()), any(), eq(DI_MARC_FOR_UPDATE_RECEIVED.value()));
+  }
+
+  @Test
+  public void shouldNotUpdateIfRecordTypeIsNotMarcBib() {
+    String rawMarc = "00182uu  a22000851  4500001000900000004000800009005001700017008003300034852002900067\u001E10245123\u001E9928371\u001E20170607135730.0\u001E1706072u    8   4001uu   0901128\u001E0 \u001Fbfine\u001FhN7433.3\u001Fi.B87 2014\u001E\u001D";
+
+    RawRecordsDto rawRecordsDto = getTestRawRecordsDto(rawMarc);
+    JobExecution jobExecution = new JobExecution()
+      .withId(UUID.randomUUID().toString())
+      .withUserId(UUID.randomUUID().toString())
+      .withJobProfileSnapshotWrapper(constructCreateMarcHoldingsSnapshotWrapper())
+      .withJobProfileInfo(new JobProfileInfo().withId(UUID.randomUUID().toString())
+        .withName("test").withDataType(JobProfileInfo.DataType.MARC));
+
+    when(marcRecordAnalyzer.process(any())).thenReturn(MarcRecordType.HOLDING);
+    when(jobExecutionSourceChunkDao.getById(any(), any()))
+      .thenReturn(Future.succeededFuture(Optional.of(new JobExecutionSourceChunk())));
+    when(jobExecutionSourceChunkDao.update(any(), any())).thenReturn(Future.succeededFuture(new JobExecutionSourceChunk()));
+
+
+    try (var mockedStatic = Mockito.mockStatic(EventHandlingUtil.class)) {
+      mockedStatic.when(() -> EventHandlingUtil.sendEventToKafka(any(), any(), any(), kafkaHeadersCaptor.capture(), any(), any()))
+        .thenReturn(Future.succeededFuture(true));
+      service.parseRawRecordsChunkForJobExecution(rawRecordsDto, jobExecution, "1", okapiConnectionParams).result();
+    }
+
+    verify(recordsPublishingService, never()).sendEventsWithRecords(any(), any(), any(), any());
+  }
+
+  @Test
+  public void shouldNotUpdateIfCreateInstanceActionExist() {
+    String rawMarc = "00182cc  a22000851  4500001000900000004000800009005001700017008003300034852002900067\u001E10245123\u001E9928371\u001E20170607135730.0\u001E1706072u    8   4001uu   0901128\u001E0 \u001Fbfine\u001FhN7433.3\u001Fi.B87 2014\u001E\u001D";
+
+    RawRecordsDto rawRecordsDto = getTestRawRecordsDto(rawMarc);
+    JobExecution jobExecution = new JobExecution()
+      .withId(UUID.randomUUID().toString())
+      .withUserId(UUID.randomUUID().toString())
+      .withJobProfileSnapshotWrapper(constructCreateMarcHoldingsAndInstanceSnapshotWrapper())
+      .withJobProfileInfo(new JobProfileInfo().withId(UUID.randomUUID().toString())
+        .withName("test").withDataType(JobProfileInfo.DataType.MARC));
+
+    mockServicesForParseRawRecordsChunkForJobExecution();
+
+    try (var mockedStatic = Mockito.mockStatic(EventHandlingUtil.class)) {
+      mockedStatic.when(() -> EventHandlingUtil.sendEventToKafka(any(), any(), any(), kafkaHeadersCaptor.capture(), any(), any()))
+        .thenReturn(Future.succeededFuture(true));
+      service.parseRawRecordsChunkForJobExecution(rawRecordsDto, jobExecution, "1", okapiConnectionParams).result();
+    }
+
+    verify(recordsPublishingService, never()).sendEventsWithRecords(any(), any(), any(), any());
+  }
+
+  private void mockServicesForParseRawRecordsChunkForJobExecution() {
+    when(marcRecordAnalyzer.process(any())).thenReturn(MarcRecordType.BIB);
+    when(recordsPublishingService.sendEventsWithRecords(any(), any(), any(), any())).thenReturn(Future.succeededFuture(true));
+    when(jobExecutionSourceChunkDao.getById(any(), any()))
+      .thenReturn(Future.succeededFuture(Optional.of(new JobExecutionSourceChunk())));
+    when(jobExecutionSourceChunkDao.update(any(), any())).thenReturn(Future.succeededFuture(new JobExecutionSourceChunk()));
+
+  }
+
+  private ProfileSnapshotWrapper constructCreateMarcHoldingsAndInstanceSnapshotWrapper() {
+    return new ProfileSnapshotWrapper()
+      .withId(UUID.randomUUID().toString())
+      .withContentType(JOB_PROFILE)
+      .withContent(new JsonObject())
+      .withChildSnapshotWrappers(List.of(new ProfileSnapshotWrapper()
+          .withProfileId(UUID.randomUUID().toString())
+          .withContentType(ACTION_PROFILE)
+          .withContent(new JsonObject(Json.encode(new ActionProfile()
+            .withId(UUID.randomUUID().toString())
+            .withName("Create Instance")
+            .withAction(ActionProfile.Action.CREATE)
+            .withFolioRecord(ActionProfile.FolioRecord.INSTANCE))).getMap())
+        , new ProfileSnapshotWrapper()
+          .withProfileId(UUID.randomUUID().toString())
+          .withContentType(ACTION_PROFILE)
+          .withContent(new JsonObject(Json.encode(new ActionProfile()
+            .withId(UUID.randomUUID().toString())
+            .withName("Create MARC-Holdings ")
+            .withAction(ActionProfile.Action.CREATE)
+            .withFolioRecord(ActionProfile.FolioRecord.HOLDINGS))).getMap())
+          .withChildSnapshotWrappers(Collections.singletonList(new ProfileSnapshotWrapper()
+            .withProfileId(UUID.randomUUID().toString())
+            .withContentType(MAPPING_PROFILE)
+            .withContent(new JsonObject(Json.encode(new MappingProfile()
+              .withId(UUID.randomUUID().toString())
+              .withName("Create MARC-Holdings ")
+              .withIncomingRecordType(EntityType.MARC_HOLDINGS)
+              .withExistingRecordType(EntityType.HOLDINGS))).getMap()
+            )))));
+  }
+
+  ProfileSnapshotWrapper constructCreateMarcHoldingsSnapshotWrapper() {
+    return new ProfileSnapshotWrapper()
+      .withId(UUID.randomUUID().toString())
+      .withContentType(JOB_PROFILE)
+      .withContent(new JsonObject())
+      .withChildSnapshotWrappers(List.of(new ProfileSnapshotWrapper()
+        .withProfileId(UUID.randomUUID().toString())
+        .withContentType(ACTION_PROFILE)
+        .withContent(new JsonObject(Json.encode(new ActionProfile()
+          .withId(UUID.randomUUID().toString())
+          .withName("Create MARC-Holdings ")
+          .withAction(ActionProfile.Action.CREATE)
+          .withFolioRecord(ActionProfile.FolioRecord.HOLDINGS))).getMap())
+        .withChildSnapshotWrappers(Collections.singletonList(new ProfileSnapshotWrapper()
+          .withProfileId(UUID.randomUUID().toString())
+          .withContentType(MAPPING_PROFILE)
+          .withContent(new JsonObject(Json.encode(new MappingProfile()
+            .withId(UUID.randomUUID().toString())
+            .withName("Create MARC-Holdings ")
+            .withIncomingRecordType(EntityType.MARC_HOLDINGS)
+            .withExistingRecordType(EntityType.HOLDINGS))).getMap()
+          )))));
   }
 
   private RawRecordsDto getTestRawRecordsDto(String marcHoldingsRecValid) {


### PR DESCRIPTION
https://issues.folio.org/browse/MODSOURMAN-891
Overview: When you want to create either a holdings connected to an existing instance or an item connected to an existing holdings, you match to either that holdings hrid or instance hrid and have an action to create either the holdings or item. What is happening is that the holdings and items are created AND the log also says the SRS MARC is created.

Current workaround: No workaround

Steps to Reproduce:

Log into FOLIO-snapshot as diku_admin
Go to Settings/Data Export
Create a new mapping
SRS and Holdings
Map Holdings HRID to 901$a
Map Holdings Id to 902$a
Create a new data export job linked to that mapping
Go to Settings/Data Import
Create a new field mapping for an item
Item mat type: Electronic resource
Loan type: Online
Status: Available
Create a new action "Create item" linked to that item field mapping
Create a new match for 901$a to Holdings hrid
Create a new job with that match and on matches, Creates item record
Go to Inventory
Find or create a Source = MARC Instance with 1 holdings record and no item records
Copy that Instance HRID and search for it in Inventory, so that you have only 1 search result
Go to Actions/Save instance UUIDs
Go to Data Export
Upload the UUIDs text file that was just downloaded
Apply the export job profile created in step 4 and export the file
Download the newly-created MARC file
Go to Data Import
Upload that exported mrc file and select test job to create item
Item is created
Log also says SRS Marc bibs are created
Case 2: For Holdings creation:

follow the same steps as above
except find an Inventory instance with no holdings
Create a field mapping to create a holdings record, and an associated action profile
create a field mapping for holdings record and a match from 001 to instance hrid.
Expected Results: The log should have a dash for all the MARC SRS bibs and instances. There's no action to create/update srs marc bibs or instances in either case

Actual Results: I suspect that this is creating orphan srs bibs whenever you create a holdings attached to an existing instance or an item attached to an existing holdings.

Additional Information: This is happening in snapshot and Morning Glory.
