### PR TITLE
[MODSOURMAN-920]The "500" error appears when user creates "MARC Holdi…

### DIFF
--- a/mod-source-record-manager-server/src/main/java/org/folio/services/ChangeEngineServiceImpl.java
+++ b/mod-source-record-manager-server/src/main/java/org/folio/services/ChangeEngineServiceImpl.java
@@ -273,6 +273,7 @@ public class ChangeEngineServiceImpl implements ChangeEngineService {
     return (containsMarcActionProfile(jobProfileSnapshotWrapper, itemAndHoldingsList, Action.CREATE) ||
       containsMarcActionProfile(jobProfileSnapshotWrapper, itemAndHoldingsList, Action.UPDATE)) &&
       !containsMarcActionProfile(jobProfileSnapshotWrapper, List.of(FolioRecord.INSTANCE), Action.CREATE) &&
+      !CollectionUtils.isEmpty(parsedRecords) &&
       parsedRecords.get(0).getRecordType() == MARC_BIB;
   }
 

--- a/mod-source-record-manager-server/src/test/java/org/folio/services/ChangeEngineServiceImplTest.java
+++ b/mod-source-record-manager-server/src/test/java/org/folio/services/ChangeEngineServiceImplTest.java
@@ -342,6 +342,29 @@ public class ChangeEngineServiceImplTest {
   }
 
   @Test
+  public void shouldOnlyUpdateIfOnlyUpdateItem() {
+    String rawMarc = "00182cc  a22000851  4500001000900000004000800009005001700017008003300034852002900067\u001E10245123\u001E9928371\u001E20170607135730.0\u001E1706072u    8   4001uu   0901128\u001E0 \u001Fbfine\u001FhN7433.3\u001Fi.B87 2014\u001E\u001D";
+
+    RawRecordsDto rawRecordsDto = getTestRawRecordsDto(rawMarc);
+    JobExecution jobExecution = new JobExecution()
+      .withId(UUID.randomUUID().toString())
+      .withUserId(UUID.randomUUID().toString())
+      .withJobProfileSnapshotWrapper(constructUpdateMarcItemSnapshotWrapper())
+      .withJobProfileInfo(new JobProfileInfo().withId(UUID.randomUUID().toString())
+        .withName("test").withDataType(JobProfileInfo.DataType.MARC));
+
+    mockServicesForParseRawRecordsChunkForJobExecution();
+
+    try (var mockedStatic = Mockito.mockStatic(EventHandlingUtil.class)) {
+      mockedStatic.when(() -> EventHandlingUtil.sendEventToKafka(any(), any(), any(), kafkaHeadersCaptor.capture(), any(), any()))
+        .thenReturn(Future.succeededFuture(true));
+      service.parseRawRecordsChunkForJobExecution(rawRecordsDto, jobExecution, "1", okapiConnectionParams).result();
+    }
+
+    verify(recordsPublishingService).sendEventsWithRecords(any(), eq(jobExecution.getId()), any(), eq(DI_MARC_FOR_UPDATE_RECEIVED.value()));
+  }
+
+  @Test
   public void shouldNotUpdateIfRecordTypeIsNotMarcBib() {
     String rawMarc = "00182uu  a22000851  4500001000900000004000800009005001700017008003300034852002900067\u001E10245123\u001E9928371\u001E20170607135730.0\u001E1706072u    8   4001uu   0901128\u001E0 \u001Fbfine\u001FhN7433.3\u001Fi.B87 2014\u001E\u001D";
 
@@ -381,6 +404,27 @@ public class ChangeEngineServiceImplTest {
         .withName("test").withDataType(JobProfileInfo.DataType.MARC));
 
     mockServicesForParseRawRecordsChunkForJobExecution();
+
+    try (var mockedStatic = Mockito.mockStatic(EventHandlingUtil.class)) {
+      mockedStatic.when(() -> EventHandlingUtil.sendEventToKafka(any(), any(), any(), kafkaHeadersCaptor.capture(), any(), any()))
+        .thenReturn(Future.succeededFuture(true));
+      service.parseRawRecordsChunkForJobExecution(rawRecordsDto, jobExecution, "1", okapiConnectionParams).result();
+    }
+
+    verify(recordsPublishingService, never()).sendEventsWithRecords(any(), any(), any(), any());
+  }
+
+  @Test
+  public void shouldNotUpdateIfNoParsedRecords() {
+    RawRecordsDto rawRecordsDto = new RawRecordsDto().withId(UUID.randomUUID().toString())
+      .withRecordsMetadata(new RecordsMetadata().withContentType(RecordsMetadata.ContentType.MARC_RAW))
+      .withInitialRecords(Collections.emptyList());
+    JobExecution jobExecution = new JobExecution()
+      .withId(UUID.randomUUID().toString())
+      .withUserId(UUID.randomUUID().toString())
+      .withJobProfileSnapshotWrapper(constructCreateMarcHoldingsAndInstanceSnapshotWrapper())
+      .withJobProfileInfo(new JobProfileInfo().withId(UUID.randomUUID().toString())
+        .withName("test").withDataType(JobProfileInfo.DataType.MARC));
 
     try (var mockedStatic = Mockito.mockStatic(EventHandlingUtil.class)) {
       mockedStatic.when(() -> EventHandlingUtil.sendEventToKafka(any(), any(), any(), kafkaHeadersCaptor.capture(), any(), any()))
@@ -453,6 +497,30 @@ public class ChangeEngineServiceImplTest {
             .withName("Create MARC-Holdings ")
             .withIncomingRecordType(EntityType.MARC_HOLDINGS)
             .withExistingRecordType(EntityType.HOLDINGS))).getMap()
+          )))));
+  }
+
+  ProfileSnapshotWrapper constructUpdateMarcItemSnapshotWrapper() {
+    return new ProfileSnapshotWrapper()
+      .withId(UUID.randomUUID().toString())
+      .withContentType(JOB_PROFILE)
+      .withContent(new JsonObject())
+      .withChildSnapshotWrappers(List.of(new ProfileSnapshotWrapper()
+        .withProfileId(UUID.randomUUID().toString())
+        .withContentType(ACTION_PROFILE)
+        .withContent(new JsonObject(Json.encode(new ActionProfile()
+          .withId(UUID.randomUUID().toString())
+          .withName("Create MARC-Holdings ")
+          .withAction(ActionProfile.Action.UPDATE)
+          .withFolioRecord(ActionProfile.FolioRecord.ITEM))).getMap())
+        .withChildSnapshotWrappers(Collections.singletonList(new ProfileSnapshotWrapper()
+          .withProfileId(UUID.randomUUID().toString())
+          .withContentType(MAPPING_PROFILE)
+          .withContent(new JsonObject(Json.encode(new MappingProfile()
+            .withId(UUID.randomUUID().toString())
+            .withName("Create MARC-Holdings ")
+            .withIncomingRecordType(EntityType.MARC_HOLDINGS)
+            .withExistingRecordType(EntityType.ITEM))).getMap()
           )))));
   }
 


### PR DESCRIPTION
Overview: The POST request for the endpoint "/records-editor/records" is failed with the "500" error when user creates the "MARC Holdings" record.
Steps to Reproduce:

Log into Snapshot-2 / Nolana BF FOLIO environment as User with the following permissions: 
Inventory: All permissions
quickMARC: View, edit MARC holdings record,
quickMARC: Create a new MARC holdings record.
The detail view of "Instance" record with source = "MARC" has been opened at the third pane via "Inventory" app.
Click on the "Actions" button and select the "Add MARC holdings record" option from the expanded dopdown.
Fill in "852" subfield with $b value (any), by clicking on "Permanent location look-up" button and choose values from the dropdown lists for "Institution", "Campus", "Library", "Location" >> Click on the "Save & Close" button in pop-up modal.
[For examle: "$b KU/CC/DI/A]
Click on the "Save & close" button.
Expected Results: The successful toast notification is displayed. The new "MARC Holdings" record detail view pane is displayed.
Actual Results: The "500" error is displayed in "DevTools". User stays at the creating of new "MARC Holdings" record pane.
But, actually, the record has been created (See attached screencast).
Additional Information:
The error message: "{"message":"Internal Server Error, Please contact System Administrator or try again","type":"-2","code":"INTERNAL_SERVER_ERROR"}"
The editing of "MARC Holdings" work as expected.
The Import of "MARC Holdings" - work as expected.