### PR TITLE
[MODSOURMAN-920]The "500" error appears when user creates "MARC Holdings" record

### DIFF
--- a/mod-source-record-manager-server/src/main/java/org/folio/services/ChangeEngineServiceImpl.java
+++ b/mod-source-record-manager-server/src/main/java/org/folio/services/ChangeEngineServiceImpl.java
@@ -273,6 +273,7 @@ public class ChangeEngineServiceImpl implements ChangeEngineService {
     return (containsMarcActionProfile(jobProfileSnapshotWrapper, itemAndHoldingsList, Action.CREATE) ||
       containsMarcActionProfile(jobProfileSnapshotWrapper, itemAndHoldingsList, Action.UPDATE)) &&
       !containsMarcActionProfile(jobProfileSnapshotWrapper, List.of(FolioRecord.INSTANCE), Action.CREATE) &&
+      !CollectionUtils.isEmpty(parsedRecords) &&
       parsedRecords.get(0).getRecordType() == MARC_BIB;
   }
 


### PR DESCRIPTION
Overview: The POST request for the endpoint "/records-editor/records" is failed with the "500" error when user creates the "MARC Holdings" record.
Steps to Reproduce:

Log into Snapshot-2 / Nolana BF FOLIO environment as User with the following permissions: 
Inventory: All permissions
quickMARC: View, edit MARC holdings record,
quickMARC: Create a new MARC holdings record.
The detail view of "Instance" record with source = "MARC" has been opened at the third pane via "Inventory" app.
Click on the "Actions" button and select the "Add MARC holdings record" option from the expanded dopdown.
Fill in "852" subfield with $b value (any), by clicking on "Permanent location look-up" button and choose values from the dropdown lists for "Institution", "Campus", "Library", "Location" >> Click on the "Save & Close" button in pop-up modal.
[For examle: "$b KU/CC/DI/A]
Click on the "Save & close" button.
Expected Results: The successful toast notification is displayed. The new "MARC Holdings" record detail view pane is displayed.
Actual Results: The "500" error is displayed in "DevTools". User stays at the creating of new "MARC Holdings" record pane.
But, actually, the record has been created (See attached screencast).
Additional Information:
The error message: "{"message":"Internal Server Error, Please contact System Administrator or try again","type":"-2","code":"INTERNAL_SERVER_ERROR"}"
The editing of "MARC Holdings" work as expected.
The Import of "MARC Holdings" - work as expected.
Interested parties: [Pavlo Smahin](https://issues.folio.org/secure/ViewProfile.jspa?name=psmagin) , [Khalilah Gambrell](https://issues.folio.org/secure/ViewProfile.jspa?name=kgambrell)