### PR TITLE
MODSOURMAN-923: Release v3.4.6 with Spring 5.2.22 fixing Spring4Shell (MG)

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,6 @@
+## 2022-12-22 v3.4.6
+* [MODSOURMAN-923](https://issues.folio.org/browse/MODSOURMAN-923) Spring 5.2.22 fixing Spring4Shell CVE-2022-22965 (MG)
+
 ## 2022-09-20 v3.4.5
 * [MODSOURMAN-874](https://issues.folio.org/browse/MODSOURMAN-874) Data import: fails the creation of a Holding through a match on the 999 ff field.
 

--- a/mod-source-record-manager-client/pom.xml
+++ b/mod-source-record-manager-client/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.folio</groupId>
     <artifactId>mod-source-record-manager</artifactId>
-    <version>3.4.6-SNAPSHOT</version>
+    <version>3.4.6</version>
   </parent>
 
   <properties>

--- a/mod-source-record-manager-client/pom.xml
+++ b/mod-source-record-manager-client/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.folio</groupId>
     <artifactId>mod-source-record-manager</artifactId>
-    <version>3.4.6</version>
+    <version>3.4.7-SNAPSHOT</version>
   </parent>
 
   <properties>

--- a/mod-source-record-manager-server/pom.xml
+++ b/mod-source-record-manager-server/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.folio</groupId>
     <artifactId>mod-source-record-manager</artifactId>
-    <version>3.4.6</version>
+    <version>3.4.7-SNAPSHOT</version>
   </parent>
 
   <properties>

--- a/mod-source-record-manager-server/pom.xml
+++ b/mod-source-record-manager-server/pom.xml
@@ -171,7 +171,6 @@
     <dependency>
       <groupId>org.springframework</groupId>
       <artifactId>spring-test</artifactId>
-      <version>5.2.6.RELEASE</version>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/mod-source-record-manager-server/pom.xml
+++ b/mod-source-record-manager-server/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.folio</groupId>
     <artifactId>mod-source-record-manager</artifactId>
-    <version>3.4.6-SNAPSHOT</version>
+    <version>3.4.6</version>
   </parent>
 
   <properties>

--- a/pom.xml
+++ b/pom.xml
@@ -186,6 +186,13 @@
         <type>pom</type>
         <scope>import</scope>
       </dependency>
+      <dependency>
+        <groupId>org.springframework</groupId>
+        <artifactId>spring-framework-bom</artifactId>
+        <version>5.2.22.RELEASE</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
     </dependencies>
   </dependencyManagement>
 

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.folio</groupId>
   <artifactId>mod-source-record-manager</artifactId>
-  <version>3.4.6</version>
+  <version>3.4.7-SNAPSHOT</version>
   <packaging>pom</packaging>
 
   <licenses>
@@ -151,7 +151,7 @@
     <url>https://github.com/folio-org/mod-source-record-manager</url>
     <connection>scm:git:git://github.com/folio-org/mod-source-record-manager</connection>
     <developerConnection>scm:git:git@github.com:folio-org/mod-source-record-manager.git</developerConnection>
-    <tag>v3.4.6</tag>
+    <tag>v3.4.0</tag>
   </scm>
 
   <pluginRepositories>

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.folio</groupId>
   <artifactId>mod-source-record-manager</artifactId>
-  <version>3.4.6-SNAPSHOT</version>
+  <version>3.4.6</version>
   <packaging>pom</packaging>
 
   <licenses>
@@ -151,7 +151,7 @@
     <url>https://github.com/folio-org/mod-source-record-manager</url>
     <connection>scm:git:git://github.com/folio-org/mod-source-record-manager</connection>
     <developerConnection>scm:git:git@github.com:folio-org/mod-source-record-manager.git</developerConnection>
-    <tag>v3.4.0</tag>
+    <tag>v3.4.6</tag>
   </scm>
 
   <pluginRepositories>


### PR DESCRIPTION
https://issues.folio.org/browse/MODSOURMAN-923

Upgrade Spring from 5.2.8.RELEASE to 5.2.22.RELEASE fixing Spring4Shell (https://github.com/advisories/GHSA-36p3-wjmg-h94x).

Release mod-source-record-manager v3.4.6 as Morning Glory Hot Fix.