### PR TITLE
[MODSOURMAN-930]Add missed permissions for invoice data import flow

### DIFF
--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -260,7 +260,17 @@
             "source-storage.snapshots.get",
             "source-storage.snapshots.put",
             "source-storage.verified.records",
-            "users.collection.get"
+            "users.collection.get",
+            "orders-storage.order-invoice-relationships.item.post",
+            "finance.exchange-rate.item.get",
+            "finance.expense-classes.collection.get",
+            "finance.funds.budget.item.get",
+            "finance.fiscal-years.item.get",
+            "finance.ledgers.collection.get",
+            "finance.transactions.collection.get",
+            "finance-storage.budgets.collection.get",
+            "finance-storage.budget-expense-classes.collection.get",
+            "finance-storage.fiscal-years.item.get"
           ]
         },
         {


### PR DESCRIPTION
https://issues.folio.org/browse/MODSOURMAN-930
After updating implementation of creating invoice flow the permissinon set has been updated. In order to support these changes in invoice data import flow the permission set in mod-data-source-manager should be updated as well.

Following permissions should be added:

"orders-storage.order-invoice-relationships.item.post",
"finance-storage.budget-expense-classes.collection.get",
"finance.ledgers.collection.get",
"finance.funds.budget.item.get",
"finance-storage.fiscal-years.item.get",
"finance.fiscal-years.item.get",
"finance-storage.budgets.collection.get",
"finance.transactions.collection.get",
"finance.expense-classes.collection.get",
"finance.exchange-rate.item.get"