### PR TITLE
[MODDATAIMP-758]Imrove logging (hide SQL requests)

### DIFF
--- a/mod-source-record-manager-server/src/main/java/org/folio/services/MappingRuleServiceImpl.java
+++ b/mod-source-record-manager-server/src/main/java/org/folio/services/MappingRuleServiceImpl.java
@@ -116,7 +116,7 @@ public class MappingRuleServiceImpl implements MappingRuleService {
 
   private Function<Optional<JsonObject>, Future<String>> saveRulesIfNotExist(Record.RecordType recordType,
                                                                              String tenantId, String defaultRules) {
-    LOGGER.debug("saveRulesIfNotExist:: recordType {}, defaultRules {}, tenantId {}", recordType, defaultRules, tenantId);
+    LOGGER.trace("saveRulesIfNotExist:: recordType {}, defaultRules {}, tenantId {}", recordType, defaultRules, tenantId);
     return existedRules -> {
       if (existedRules.isEmpty()) {
         return mappingRuleDao.save(new JsonObject(defaultRules), recordType, tenantId);

--- a/mod-source-record-manager-server/src/main/java/org/folio/services/util/EventHandlingUtil.java
+++ b/mod-source-record-manager-server/src/main/java/org/folio/services/util/EventHandlingUtil.java
@@ -42,7 +42,6 @@ public final class EventHandlingUtil {
    */
   public static Future<Boolean> sendEventToKafka(String tenantId, String eventPayload, String eventType,
                                                  List<KafkaHeader> kafkaHeaders, KafkaConfig kafkaConfig, String key) {
-    LOGGER.debug("sendEventToKafka:: Starting to send event to Kafka for eventType: {}", eventType);
     Event event = createEvent(eventPayload, eventType, tenantId);
 
     String topicName = createTopicName(eventType, tenantId, kafkaConfig);
@@ -55,6 +54,8 @@ public final class EventHandlingUtil {
     String recordId = extractHeader(kafkaHeaders, "recordId");
 
     String producerName = eventType + "_Producer";
+    LOGGER.debug("sendEventToKafka:: Starting to send event to Kafka for eventType: {} and recordId: {} and chunkId: {}", eventType, recordId, chunkId);
+
     KafkaProducer<String, String> producer =
       KafkaProducer.createShared(Vertx.currentContext().owner(), producerName, kafkaConfig.getProducerProps());
     producer.write(record, war -> {

--- a/mod-source-record-manager-server/src/main/resources/log4j2-json.properties
+++ b/mod-source-record-manager-server/src/main/resources/log4j2-json.properties
@@ -45,6 +45,10 @@ logger.folio_rest.name = org.folio.rest
 logger.folio_rest.level = WARN
 logger.folio_rest.appenderRef.stdout.ref = STDOUT
 
+logger.folio_persist.name = org.folio.rest.persist
+logger.folio_persist.level = ERROR
+logger.folio_persist.appenderRef.stdout.ref = STDOUT
+
 #disable ProducerConfig/ConsumerConfig messages in log
 logger.kafka.name = org.apache.kafka
 logger.kafka.level = warn

--- a/mod-source-record-manager-server/src/main/resources/log4j2.properties
+++ b/mod-source-record-manager-server/src/main/resources/log4j2.properties
@@ -29,6 +29,10 @@ logger.folio_rest.name = org.folio.rest
 logger.folio_rest.level = WARN
 logger.folio_rest.appenderRef.stdout.ref = STDOUT
 
+logger.folio_persist.name = org.folio.rest.persist
+logger.folio_persist.level = ERROR
+logger.folio_persist.appenderRef.stdout.ref = STDOUT
+
 #disable ProducerConfig/ConsumerConfig messages in log
 logger.kafka.name = org.apache.kafka
 logger.kafka.level = warn


### PR DESCRIPTION
https://issues.folio.org/browse/MODDATAIMP-758HAide SQL requests (org.folio.rest.persist.PostgresClient) from log files for the next modules:

mod-data-import
mod-source-record-storage
mod-data-import-converter-storage
mod-inventory-storage
This class logs SQL queries at the INFO level, which leads to a very large size of log files.

SRS: a lot of messages like this:
2023-01-05 09:28:12.246 WARN AbstractConfig The configuration 'ssl.protocol' was supplied but isn't a known config.
....
2023-01-05 09:28:12.246 WARN AbstractConfig The configuration 'ssl.truststore.type' was supplied but isn't a known config.

SRM: move to TRACE level or decrease defaultRules json
2023-01-05 01:55:50.850 [vert.x-eventloop-thread-1] [572525/proxy;692150/tenant] [diku] [] [mod_source_record_manager] DEBUG ppingRuleServiceImpl saveRulesIfNotExist:: recordType MARC_BIB, defaultRules {
"001": [
{

add recordId, or jobExecutionId, or other attributes to sendEventToKafka:
2023-01-05 12:46:12.034 DEBUG EventHandlingUtil sendEventToKafka:: Starting to send event to Kafka for eventType: DI_MARC_FOR_UPDATE_RECEIVED
2023-01-05 12:46:12.035 INFO EventHandlingUtil logSendingSucceeded:: Event with type: DI_MARC_FOR_UPDATE_RECEIVED and recordId: b17ea14c-c53a-44fa-baec-abc973d3cc45 was sent to kafka

mod-inventory: a lot of messages like this:
2023-01-05 01:44:27.078 WARN AbstractConfig [1498eqId] The configuration 'ssl.keystore.type' was supplied but isn't a known config.
...
2023-01-05 01:44:27.078 WARN AbstractConfig [1498eqId] The configuration 'ssl.truststore.location' was supplied but isn't a known config.

hide messages below:
2023-01-05 01:44:27.158 INFO AbstractConfig [1578eqId] ConsumerConfig values:
2023-01-05 01:44:31.805 INFO GroupResponseHandler [6225eqId] [Consumer clientId=consumer-DI_SRS_MARC_HOLDING_RECORD_CREATED.mod-inventory-19.1.0-82....
2023-01-05 01:54:58.456 INFO Metadata [632876eqId] [Consumer clientId=consumer-srs.marc-bib.mod-inventory-19.1.0-10, groupId=srs.marc-bib.mod-inventory-19.1.0] Resetting the last seen epoch of partition
2023-01-05 01:54:58.470 INFO ConsumerCoordinator [632890eqId] [Consumer clientId=consumer-srs.marc-bib.mod-inventory-19.1.0-10, groupId=srs.marc-bib.mod-inventory-19.1.0] Revoke previously assigned partitions