### PR TITLE
MODSOURMAN-941 Add query param for metadata-provider/jobExecutions to filter by file…

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -3,6 +3,8 @@
 * [MODSOURMAN-837](https://issues.folio.org/browse/MODSOURMAN-837) MARC bib - FOLIO instance mapping | Update default mapping to change how Relator term is populated on instance record
 * [MODSOURMAN-890](https://issues.folio.org/browse/MODSOURMAN-890) The '2' number of Instance is displayed in cell in the row with the 'Updated' row header at the individual import job's log
 * [MODSOURMAN-891](https://issues.folio.org/browse/MODSOURMAN-891) SRS MARC Created when No Create Action in Job Profile
+* [MODSOURMAN-941](https://issues.folio.org/browse/MODSOURMAN-941) Add query param to allow filtering by fileName
+
 ## 2022-10-24 v3.5.0
 * [MODSOURMAN-858](https://issues.folio.org/browse/MODSOURMAN-858) Mapping bib's $9 into contributors.authorityId field
 * [MODSOURMAN-838](https://issues.folio.org/browse/MODSOURMAN-838) Search by LCCN "010 $a" subfield value with "\" at the end don't retrieve results

--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -82,7 +82,7 @@
   "provides": [
     {
       "id": "source-manager-job-executions",
-      "version": "3.1",
+      "version": "3.2",
       "handlers": [
         {
           "methods": [

--- a/mod-source-record-manager-server/src/main/java/org/folio/dao/JobExecutionFilter.java
+++ b/mod-source-record-manager-server/src/main/java/org/folio/dao/JobExecutionFilter.java
@@ -28,6 +28,7 @@ public class JobExecutionFilter {
   private List<JobExecution.UiStatus> uiStatusAny;
   private String hrIdPattern;
   private String fileNamePattern;
+  private List<String> fileNameNotAny;
   private List<String> profileIdAny;
   private String userId;
   private Date completedAfter;
@@ -60,6 +61,11 @@ public class JobExecutionFilter {
 
   public JobExecutionFilter withFileNamePattern(String fileNamePattern) {
     this.fileNamePattern = fileNamePattern;
+    return this;
+  }
+
+  public JobExecutionFilter withFileNameNotAny(List<String> fileNameNotAny) {
+    this.fileNameNotAny = fileNameNotAny;
     return this;
   }
 
@@ -115,6 +121,9 @@ public class JobExecutionFilter {
       if (isNotEmpty(fileNamePattern)) {
         addCondition(conditionBuilder, buildLikeCondition(FILE_NAME_FIELD, fileNamePattern));
       }
+    }
+    if (isNotEmpty(fileNameNotAny)) {
+      addCondition(conditionBuilder, buildNotInCondition(FILE_NAME_FIELD,fileNameNotAny));
     }
     if (isNotEmpty(profileIdAny)) {
       addCondition(conditionBuilder, buildInCondition(JOB_PROFILE_ID_FIELD, profileIdAny));

--- a/mod-source-record-manager-server/src/main/java/org/folio/rest/impl/MetadataProviderImpl.java
+++ b/mod-source-record-manager-server/src/main/java/org/folio/rest/impl/MetadataProviderImpl.java
@@ -24,6 +24,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 
 import javax.ws.rs.BadRequestException;
 import javax.ws.rs.NotFoundException;
+import javax.ws.rs.QueryParam;
 import javax.ws.rs.core.Response;
 import java.util.ArrayList;
 import java.util.Date;
@@ -59,7 +60,7 @@ public class MetadataProviderImpl implements MetadataProvider {
 
   @Override
   public void getMetadataProviderJobExecutions(List<String> statusAny, List<String> profileIdNotAny, String statusNot,
-                                               List<String> uiStatusAny, String hrId, String fileName,
+                                               List<String> uiStatusAny, String hrId, String fileName, List<String> fileNameNotAny,
                                                List<String> profileIdAny, String userId, Date completedAfter, Date completedBefore,
                                                List<String> sortBy, int offset, int limit, Map<String, String> okapiHeaders,
                                                Handler<AsyncResult<Response>> asyncResultHandler, Context vertxContext) {
@@ -67,7 +68,7 @@ public class MetadataProviderImpl implements MetadataProvider {
       try {
         LOGGER.debug("getMetadataProviderJobExecutions:: sortBy {}", sortBy);
         List<SortField> sortFields = mapSortQueryToSortFields(sortBy);
-        JobExecutionFilter filter = buildJobExecutionFilter(statusAny, profileIdNotAny, statusNot, uiStatusAny, hrId, fileName, profileIdAny, userId, completedAfter, completedBefore);
+        JobExecutionFilter filter = buildJobExecutionFilter(statusAny, profileIdNotAny, statusNot, uiStatusAny, hrId, fileName, fileNameNotAny, profileIdAny, userId, completedAfter, completedBefore);
         jobExecutionService.getJobExecutionsWithoutParentMultiple(filter, sortFields, offset, limit, tenantId)
           .map(GetMetadataProviderJobExecutionsResponse::respond200WithApplicationJson)
           .map(Response.class::cast)
@@ -197,7 +198,8 @@ public class MetadataProviderImpl implements MetadataProvider {
 
   private JobExecutionFilter buildJobExecutionFilter(List<String> statusAny, List<String> profileIdNotAny, String statusNot,
                                                      List<String> uiStatusAny, String hrIdPattern, String fileNamePattern,
-                                                     List<String> profileIdAny, String userId, Date completedAfter, Date completedBefore) {
+                                                     List<String> fileNameNotAny, List<String> profileIdAny, String userId,
+                                                     Date completedAfter, Date completedBefore) {
     List<JobExecution.Status> statuses = statusAny.stream()
       .map(JobExecution.Status::fromValue)
       .collect(Collectors.toList());
@@ -213,6 +215,7 @@ public class MetadataProviderImpl implements MetadataProvider {
       .withUiStatusAny(uiStatuses)
       .withHrIdPattern(hrIdPattern)
       .withFileNamePattern(fileNamePattern)
+      .withFileNameNotAny(fileNameNotAny)
       .withProfileIdAny(profileIdAny)
       .withUserId(userId)
       .withCompletedAfter(completedAfter)

--- a/ramls/metadata-provider.raml
+++ b/ramls/metadata-provider.raml
@@ -71,6 +71,11 @@ resourceTypes:
           type: string
           example: importBib1.bib
           required: false
+        fileNameNotAny:
+          description: Filter by specified file names
+          type: string[]
+          example: ["No file name"]
+          required: false
         profileIdAny:
           description: Filter by specified job profile ids
           type: string[]


### PR DESCRIPTION
…Name

Add query param fileNameNotAny for /metadata-provider/jobExecutions endpoint to allow filtering out jobs by excluding specified fileNames (in particular, "No file name" for ISRI jobs

