### PR TITLE
MODSOURMAN-936 - Add logic in Journal Handler for DI_ORDER_READY_FOR_POST_PROCESSING event 

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -4,6 +4,7 @@
 * [MODSOURMAN-890](https://issues.folio.org/browse/MODSOURMAN-890) The '2' number of Instance is displayed in cell in the row with the 'Updated' row header at the individual import job's log
 * [MODSOURMAN-891](https://issues.folio.org/browse/MODSOURMAN-891) SRS MARC Created when No Create Action in Job Profile
 * [MODSOURMAN-941](https://issues.folio.org/browse/MODSOURMAN-941) Add query param to allow filtering by fileName
+* [MODSOURMAN-936](https://issues.folio.org/browse/MODSOURMAN-936) Add logic in Journal Handler for Post-Processing event
 
 ## 2022-10-24 v3.5.0
 * [MODSOURMAN-858](https://issues.folio.org/browse/MODSOURMAN-858) Mapping bib's $9 into contributors.authorityId field

--- a/mod-source-record-manager-server/src/main/java/org/folio/rest/impl/MetadataProviderImpl.java
+++ b/mod-source-record-manager-server/src/main/java/org/folio/rest/impl/MetadataProviderImpl.java
@@ -24,7 +24,6 @@ import org.springframework.beans.factory.annotation.Autowired;
 
 import javax.ws.rs.BadRequestException;
 import javax.ws.rs.NotFoundException;
-import javax.ws.rs.QueryParam;
 import javax.ws.rs.core.Response;
 import java.util.ArrayList;
 import java.util.Date;

--- a/mod-source-record-manager-server/src/main/java/org/folio/verticle/DataImportJournalConsumersVerticle.java
+++ b/mod-source-record-manager-server/src/main/java/org/folio/verticle/DataImportJournalConsumersVerticle.java
@@ -17,6 +17,7 @@ import static org.folio.rest.jaxrs.model.DataImportEventTypes.DI_INVOICE_CREATED
 import static org.folio.rest.jaxrs.model.DataImportEventTypes.DI_LOG_SRS_MARC_AUTHORITY_RECORD_CREATED;
 import static org.folio.rest.jaxrs.model.DataImportEventTypes.DI_LOG_SRS_MARC_BIB_RECORD_CREATED;
 import static org.folio.rest.jaxrs.model.DataImportEventTypes.DI_LOG_SRS_MARC_BIB_RECORD_UPDATED;
+import static org.folio.rest.jaxrs.model.DataImportEventTypes.DI_ORDER_CREATED_READY_FOR_POST_PROCESSING;
 import static org.folio.rest.jaxrs.model.DataImportEventTypes.DI_SRS_MARC_AUTHORITY_RECORD_CREATED;
 import static org.folio.rest.jaxrs.model.DataImportEventTypes.DI_SRS_MARC_AUTHORITY_RECORD_NOT_MATCHED;
 import static org.folio.rest.jaxrs.model.DataImportEventTypes.DI_SRS_MARC_BIB_RECORD_MODIFIED;
@@ -77,6 +78,7 @@ public class DataImportJournalConsumersVerticle extends AbstractConsumersVerticl
       DI_SRS_MARC_HOLDINGS_RECORD_UPDATED.value(),
       DI_SRS_MARC_AUTHORITY_RECORD_CREATED.value(),
       DI_LOG_SRS_MARC_AUTHORITY_RECORD_CREATED.value(),
+      DI_ORDER_CREATED_READY_FOR_POST_PROCESSING.value(),
       DI_COMPLETED.value(),
       DI_ERROR.value()
     );

--- a/mod-source-record-manager-server/src/main/java/org/folio/verticle/consumers/util/JournalParams.java
+++ b/mod-source-record-manager-server/src/main/java/org/folio/verticle/consumers/util/JournalParams.java
@@ -268,15 +268,16 @@ public class JournalParams {
           JournalRecord.ActionStatus.COMPLETED));
       }
     },
+    DI_ORDER_CREATED_READY_FOR_POST_PROCESSING {
+      @Override
+      public Optional<JournalParams> getJournalParams(DataImportEventPayload eventPayload) {
+        return getJournalParamsUsingLastEventInChain(eventPayload);
+      }
+    },
     DI_COMPLETED {
       @Override
       public Optional<JournalParams> getJournalParams(DataImportEventPayload eventPayload) {
-        String lastEventType = eventPayload.getEventsChain().stream().reduce((first, second) -> second).get();
-        JournalParamsEnum journalParamsEnumItem = NAMES.get(lastEventType);
-        if (journalParamsEnumItem != null) {
-          return journalParamsEnumItem.getJournalParams(eventPayload);
-        }
-        return Optional.empty();
+        return getJournalParamsUsingLastEventInChain(eventPayload);
       }
     },
     DI_ERROR {
@@ -302,6 +303,15 @@ public class JournalParams {
 
     private static final Map<String, JournalParamsEnum> NAMES = Stream.of(values())
       .collect(Collectors.toMap(JournalParamsEnum::toString, Function.identity()));
+
+    private static Optional<JournalParams> getJournalParamsUsingLastEventInChain(DataImportEventPayload eventPayload) {
+      String lastEventType = eventPayload.getEventsChain().stream().reduce((first, second) -> second).get();
+      JournalParamsEnum journalParamsEnumItem = NAMES.get(lastEventType);
+      if (journalParamsEnumItem != null) {
+        return journalParamsEnumItem.getJournalParams(eventPayload);
+      }
+      return Optional.empty();
+    }
 
     public static JournalParamsEnum getValue(final String name) {
       JournalParamsEnum value = NAMES.get(name);

--- a/mod-source-record-manager-server/src/test/java/org/folio/verticle/consumers/util/JournalParamsTest.java
+++ b/mod-source-record-manager-server/src/test/java/org/folio/verticle/consumers/util/JournalParamsTest.java
@@ -17,6 +17,7 @@ import static org.folio.rest.jaxrs.model.DataImportEventTypes.DI_INVENTORY_ITEM_
 import static org.folio.rest.jaxrs.model.DataImportEventTypes.DI_LOG_SRS_MARC_AUTHORITY_RECORD_CREATED;
 import static org.folio.rest.jaxrs.model.DataImportEventTypes.DI_LOG_SRS_MARC_BIB_RECORD_CREATED;
 import static org.folio.rest.jaxrs.model.DataImportEventTypes.DI_LOG_SRS_MARC_BIB_RECORD_UPDATED;
+import static org.folio.rest.jaxrs.model.DataImportEventTypes.DI_ORDER_CREATED_READY_FOR_POST_PROCESSING;
 import static org.folio.rest.jaxrs.model.DataImportEventTypes.DI_SRS_MARC_AUTHORITY_RECORD_CREATED;
 import static org.folio.rest.jaxrs.model.DataImportEventTypes.DI_SRS_MARC_AUTHORITY_RECORD_NOT_MATCHED;
 import static org.folio.rest.jaxrs.model.DataImportEventTypes.DI_SRS_MARC_AUTHORITY_RECORD_MATCHED;
@@ -31,6 +32,7 @@ import static org.folio.rest.jaxrs.model.DataImportEventTypes.DI_SRS_MARC_HOLDIN
 
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Optional;
 
 import io.vertx.core.json.JsonObject;
@@ -310,4 +312,39 @@ public class JournalParamsTest {
   public void shouldThrowExceptionWhenJournalParamsNameIsNotAvailable() {
     JournalParams.JournalParamsEnum.getValue("not available event");
   }
+
+  @Test
+  public void shouldReturnInstanceCreatedParamsWhenEventIsOrderCreatedReadyForPostProcessingAndInstanceCreatedLastInEventsChain() {
+    returnJournalParamsByEventTypeAndLastEventInChain(DI_ORDER_CREATED_READY_FOR_POST_PROCESSING, DI_INVENTORY_INSTANCE_CREATED,
+      JournalRecord.EntityType.INSTANCE, JournalRecord.ActionType.CREATE);
+  }
+
+  @Test
+  public void shouldReturnHoldingsCreatedParamsWhenEventIsOrderCreatedReadyForPostProcessingAndHoldingsCreatedLastInEventsChain() {
+    returnJournalParamsByEventTypeAndLastEventInChain(DI_ORDER_CREATED_READY_FOR_POST_PROCESSING, DI_INVENTORY_HOLDING_CREATED,
+      JournalRecord.EntityType.HOLDINGS, JournalRecord.ActionType.CREATE);
+  }
+
+  @Test
+  public void shouldReturnItemCreatedParamsWhenEventIsOrderCreatedReadyForPostProcessingAndItemCreatedLastInEventsChain() {
+    returnJournalParamsByEventTypeAndLastEventInChain(DI_ORDER_CREATED_READY_FOR_POST_PROCESSING, DI_INVENTORY_ITEM_CREATED,
+      JournalRecord.EntityType.ITEM, JournalRecord.ActionType.CREATE);
+  }
+
+  private void returnJournalParamsByEventTypeAndLastEventInChain(DataImportEventTypes eventType, DataImportEventTypes lastEvent,
+                                                                 JournalRecord.EntityType expectedEntityType,
+                                                                 JournalRecord.ActionType expectedActionType) {
+    eventPayload.setEventType(eventType.value());
+    eventPayload.setEventsChain(List.of(lastEvent.value()));
+
+    var journalParamsOptional =
+      JournalParams.JournalParamsEnum.getValue(eventPayload.getEventType()).getJournalParams(eventPayload);
+
+    Assert.assertTrue(journalParamsOptional.isPresent());
+    var journalParams = journalParamsOptional.get();
+    Assert.assertEquals(expectedEntityType, journalParams.journalEntityType);
+    Assert.assertEquals(expectedActionType, journalParams.journalActionType);
+    Assert.assertEquals(JournalRecord.ActionStatus.COMPLETED, journalParams.journalActionStatus);
+  }
+
 }

--- a/mod-source-record-manager-server/src/test/java/org/folio/verticle/consumers/util/JournalParamsTest.java
+++ b/mod-source-record-manager-server/src/test/java/org/folio/verticle/consumers/util/JournalParamsTest.java
@@ -18,6 +18,7 @@ import static org.folio.rest.jaxrs.model.DataImportEventTypes.DI_LOG_SRS_MARC_AU
 import static org.folio.rest.jaxrs.model.DataImportEventTypes.DI_LOG_SRS_MARC_BIB_RECORD_CREATED;
 import static org.folio.rest.jaxrs.model.DataImportEventTypes.DI_LOG_SRS_MARC_BIB_RECORD_UPDATED;
 import static org.folio.rest.jaxrs.model.DataImportEventTypes.DI_ORDER_CREATED_READY_FOR_POST_PROCESSING;
+import static org.folio.rest.jaxrs.model.DataImportEventTypes.DI_PENDING_ORDER_CREATED;
 import static org.folio.rest.jaxrs.model.DataImportEventTypes.DI_SRS_MARC_AUTHORITY_RECORD_CREATED;
 import static org.folio.rest.jaxrs.model.DataImportEventTypes.DI_SRS_MARC_AUTHORITY_RECORD_NOT_MATCHED;
 import static org.folio.rest.jaxrs.model.DataImportEventTypes.DI_SRS_MARC_AUTHORITY_RECORD_MATCHED;
@@ -345,6 +346,17 @@ public class JournalParamsTest {
     Assert.assertEquals(expectedEntityType, journalParams.journalEntityType);
     Assert.assertEquals(expectedActionType, journalParams.journalActionType);
     Assert.assertEquals(JournalRecord.ActionStatus.COMPLETED, journalParams.journalActionStatus);
+  }
+
+  @Test
+  public void shouldReturnEmptyOptionalWhenEventIsOrderCreatedReadyForPostProcessingAndLastEventIsNotAnyOfInventoryRecordsCreated() {
+    eventPayload.setEventType(DI_ORDER_CREATED_READY_FOR_POST_PROCESSING.value());
+    eventPayload.setEventsChain(List.of(DI_PENDING_ORDER_CREATED.value()));
+
+    var journalParamsOptional =
+      JournalParams.JournalParamsEnum.getValue(eventPayload.getEventType()).getJournalParams(eventPayload);
+
+    Assert.assertTrue(journalParamsOptional.isEmpty());
   }
 
 }


### PR DESCRIPTION
## Purpose
to save information to the data import log about inventory records (instance, holdings, item) creation on receiving "DI_ORDER_READY_FOR_POST_PROCESSING" event.

## Approach
* expand JournalParamsEnum with logic to return journal params based on the last event. If a last event is not related to instance/holdings/item creation, then don't save info to import journal
* add tests


## Learning
[MODSOURMAN-936](https://issues.folio.org/browse/MODSOURMAN-936)