### PR TITLE
MODSOURMAN-937: Send DI_MARC_BIB_FOR_ORDER_CREATED event for Importing Orders

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -4,6 +4,7 @@
 * [MODSOURMAN-890](https://issues.folio.org/browse/MODSOURMAN-890) The '2' number of Instance is displayed in cell in the row with the 'Updated' row header at the individual import job's log
 * [MODSOURMAN-891](https://issues.folio.org/browse/MODSOURMAN-891) SRS MARC Created when No Create Action in Job Profile
 * [MODSOURMAN-941](https://issues.folio.org/browse/MODSOURMAN-941) Add query param to allow filtering by fileName
+* [MODSOURMAN-937](https://issues.folio.org/browse/MODSOURMAN-937) Send DI_MARC_BIB_FOR_ORDER_CREATED event for Importing Orders
 
 ## 2022-10-24 v3.5.0
 * [MODSOURMAN-858](https://issues.folio.org/browse/MODSOURMAN-858) Mapping bib's $9 into contributors.authorityId field

--- a/mod-source-record-manager-server/src/main/java/org/folio/verticle/consumers/StoredRecordChunksKafkaHandler.java
+++ b/mod-source-record-manager-server/src/main/java/org/folio/verticle/consumers/StoredRecordChunksKafkaHandler.java
@@ -120,6 +120,7 @@ public class StoredRecordChunksKafkaHandler implements AsyncRecordHandler<String
           return jobExecutionService.getJobExecutionById(jobExecutionId, okapiConnectionParams.getTenantId())
             .compose(jobExecutionOptional -> {
               if (jobExecutionOptional.isPresent()) {
+                LOGGER.debug("handle:: JobExecution found by id {}: chunkId:{} chunkNumber: {} ", jobExecutionId, chunkId, chunkNumber);
                 return setOrderEventTypeIfNeeded(jobExecutionOptional.get(), eventType);
               } else {
                 LOGGER.warn("handle:: Couldn't find JobExecution by id {}: chunkId:{} chunkNumber: {} ", jobExecutionId, chunkId, chunkNumber);
@@ -153,6 +154,7 @@ public class StoredRecordChunksKafkaHandler implements AsyncRecordHandler<String
 
       if (!actionProfiles.isEmpty() && checkIfOrderCreateActionProfileExists(actionProfiles)) {
         dataImportEventTypes = DI_MARC_BIB_FOR_ORDER_CREATED;
+        LOGGER.debug("setOrderEventTypeIfNeeded:: Event type for Order's logic set by jobExecutionId {} ", jobExecution.getId());
       }
     }
     return Future.succeededFuture(dataImportEventTypes);

--- a/mod-source-record-manager-server/src/main/java/org/folio/verticle/consumers/StoredRecordChunksKafkaHandler.java
+++ b/mod-source-record-manager-server/src/main/java/org/folio/verticle/consumers/StoredRecordChunksKafkaHandler.java
@@ -1,5 +1,6 @@
 package org.folio.verticle.consumers;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import io.vertx.core.Future;
 import io.vertx.core.Vertx;
 import io.vertx.core.json.Json;
@@ -14,12 +15,15 @@ import org.folio.kafka.AsyncRecordHandler;
 import org.folio.kafka.KafkaHeaderUtils;
 import org.folio.rest.jaxrs.model.DataImportEventTypes;
 import org.folio.rest.jaxrs.model.Event;
+import org.folio.rest.jaxrs.model.JobExecution;
 import org.folio.rest.jaxrs.model.JournalRecord;
 import org.folio.rest.jaxrs.model.JournalRecord.EntityType;
+import org.folio.rest.jaxrs.model.ProfileSnapshotWrapper;
 import org.folio.rest.jaxrs.model.Record;
 import org.folio.rest.jaxrs.model.Record.RecordType;
 import org.folio.rest.jaxrs.model.RecordsBatchResponse;
 import org.folio.services.EventProcessedService;
+import org.folio.services.JobExecutionService;
 import org.folio.services.MappingRuleCache;
 import org.folio.services.RecordsPublishingService;
 import org.folio.services.entity.MappingRuleCacheKey;
@@ -29,14 +33,18 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.stereotype.Component;
 
+import javax.ws.rs.NotFoundException;
 import java.util.Date;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.stream.Collectors;
 
+import static java.lang.String.format;
 import static org.apache.commons.lang3.ObjectUtils.allNotNull;
 import static org.folio.rest.jaxrs.model.DataImportEventTypes.DI_EDIFACT_RECORD_CREATED;
+import static org.folio.rest.jaxrs.model.DataImportEventTypes.DI_MARC_BIB_FOR_ORDER_CREATED;
 import static org.folio.rest.jaxrs.model.DataImportEventTypes.DI_SRS_MARC_AUTHORITY_RECORD_CREATED;
 import static org.folio.rest.jaxrs.model.DataImportEventTypes.DI_SRS_MARC_BIB_RECORD_CREATED;
 import static org.folio.rest.jaxrs.model.DataImportEventTypes.DI_SRS_MARC_HOLDING_RECORD_CREATED;
@@ -53,6 +61,10 @@ public class StoredRecordChunksKafkaHandler implements AsyncRecordHandler<String
   private static final Logger LOGGER = LogManager.getLogger();
   private static final String INSTANCE_TITLE_FIELD_PATH = "title";
   public static final String STORED_RECORD_CHUNKS_KAFKA_HANDLER_UUID = "4d39ced7-9b67-4bdc-b232-343dbb5b8cef";
+  public static final String ORDER_TYPE = "ORDER";
+  public static final String FOLIO_RECORD = "folioRecord";
+  public static final String ACTION_FIELD = "action";
+  public static final String CREATE_ACTION = "CREATE";
 
   private static final Map<RecordType, DataImportEventTypes> RECORD_TYPE_TO_EVENT_TYPE = Map.of(
     MARC_BIB, DI_SRS_MARC_BIB_RECORD_CREATED,
@@ -65,17 +77,20 @@ public class StoredRecordChunksKafkaHandler implements AsyncRecordHandler<String
   private EventProcessedService eventProcessedService;
   private JournalService journalService;
   private MappingRuleCache mappingRuleCache;
+  private JobExecutionService jobExecutionService;
   private Vertx vertx;
 
   public StoredRecordChunksKafkaHandler(@Autowired @Qualifier("recordsPublishingService") RecordsPublishingService recordsPublishingService,
                                         @Autowired @Qualifier("journalServiceProxy") JournalService journalService,
                                         @Autowired @Qualifier("eventProcessedService") EventProcessedService eventProcessedService,
+                                        @Autowired JobExecutionService jobExecutionService,
                                         @Autowired MappingRuleCache mappingRuleCache,
                                         @Autowired Vertx vertx) {
     this.recordsPublishingService = recordsPublishingService;
     this.eventProcessedService = eventProcessedService;
     this.journalService = journalService;
     this.mappingRuleCache = mappingRuleCache;
+    this.jobExecutionService = jobExecutionService;
     this.vertx = vertx;
   }
 
@@ -102,8 +117,17 @@ public class StoredRecordChunksKafkaHandler implements AsyncRecordHandler<String
 
           LOGGER.debug("handle:: RecordsBatchResponse has been received, starting processing chunkId: {} chunkNumber: {} jobExecutionId: {}", chunkId, chunkNumber, jobExecutionId);
           saveCreatedRecordsInfoToDataImportLog(storedRecords, okapiConnectionParams.getTenantId());
-          return recordsPublishingService.sendEventsWithRecords(storedRecords, jobExecutionId,
-              okapiConnectionParams, eventType.value())
+          return jobExecutionService.getJobExecutionById(jobExecutionId, okapiConnectionParams.getTenantId())
+            .compose(jobExecutionOptional -> {
+              if (jobExecutionOptional.isPresent()) {
+                return setEventTypeForOrderIfNeeded(jobExecutionOptional.get(), eventType);
+              } else {
+                LOGGER.warn("handle:: Couldn't find JobExecution by id {}: chunkId:{} chunkNumber: {} ", jobExecutionId, chunkId, chunkNumber);
+                return Future.failedFuture(new NotFoundException(format("Couldn't find JobExecution with id %s chunkId:%s chunkNumber: %s", jobExecutionId, chunkId, chunkNumber)));
+              }
+            })
+            .compose(eventTypes -> recordsPublishingService.sendEventsWithRecords(storedRecords, jobExecutionId,
+              okapiConnectionParams, eventTypes.value()))
             .compose(b -> {
               LOGGER.debug("handle:: RecordsBatchResponse processing has been completed chunkId: {} chunkNumber: {} jobExecutionId: {}", chunkId, chunkNumber, jobExecutionId);
               return Future.succeededFuture(chunkId);
@@ -116,6 +140,32 @@ public class StoredRecordChunksKafkaHandler implements AsyncRecordHandler<String
       LOGGER.warn("handle:: Can't process kafka record: ", e);
       return Future.failedFuture(e);
     }
+  }
+
+  private Future<DataImportEventTypes> setEventTypeForOrderIfNeeded(JobExecution jobExecution, DataImportEventTypes dataImportEventTypes) {
+    if (jobExecution.getJobProfileSnapshotWrapper() != null) {
+      ProfileSnapshotWrapper profileSnapshotWrapper = new ObjectMapper().convertValue(jobExecution.getJobProfileSnapshotWrapper(), ProfileSnapshotWrapper.class);
+      List<ProfileSnapshotWrapper> actionProfiles = profileSnapshotWrapper
+        .getChildSnapshotWrappers()
+        .stream()
+        .filter(e -> e.getContentType() == ProfileSnapshotWrapper.ContentType.ACTION_PROFILE)
+        .collect(Collectors.toList());
+
+      if (!actionProfiles.isEmpty() && checkIfOrderActionProfileExists(actionProfiles)) {
+        dataImportEventTypes = DI_MARC_BIB_FOR_ORDER_CREATED;
+      }
+    }
+    return Future.succeededFuture(dataImportEventTypes);
+  }
+
+  private static boolean checkIfOrderActionProfileExists(List<ProfileSnapshotWrapper> actionProfiles) {
+    for (ProfileSnapshotWrapper actionProfile : actionProfiles) {
+      LinkedHashMap<String, String> content = new ObjectMapper().convertValue(actionProfile.getContent(), LinkedHashMap.class);
+      if (content.get(FOLIO_RECORD).equals(ORDER_TYPE) && content.get(ACTION_FIELD).equals(CREATE_ACTION)) {
+        return true;
+      }
+    }
+    return false;
   }
 
   private void saveCreatedRecordsInfoToDataImportLog(List<Record> storedRecords, String tenantId) {

--- a/mod-source-record-manager-server/src/test/java/org/folio/rest/impl/AbstractRestTest.java
+++ b/mod-source-record-manager-server/src/test/java/org/folio/rest/impl/AbstractRestTest.java
@@ -204,6 +204,27 @@ public abstract class AbstractRestTest {
         .withContentType(ACTION_PROFILE)
         .withContent(actionProfile)));
 
+  protected JobProfile orderJobProfile = new JobProfile()
+    .withId(UUID.randomUUID().toString())
+    .withName("Create Order")
+    .withDataType(JobProfile.DataType.MARC);
+
+  private final ActionProfile orderActionProfile = new ActionProfile()
+    .withId(UUID.randomUUID().toString())
+    .withName("Create Order")
+    .withAction(ActionProfile.Action.CREATE)
+    .withFolioRecord(ActionProfile.FolioRecord.ORDER);
+  protected ProfileSnapshotWrapper orderProfileSnapshotWrapperResponse = new ProfileSnapshotWrapper()
+    .withId(UUID.randomUUID().toString())
+    .withProfileId(orderJobProfile.getId())
+    .withContentType(JOB_PROFILE)
+    .withContent(orderJobProfile)
+    .withChildSnapshotWrappers(Collections.singletonList(
+      new ProfileSnapshotWrapper()
+        .withProfileId(orderActionProfile.getId())
+        .withContentType(ACTION_PROFILE)
+        .withContent(orderActionProfile)));
+
   protected ProfileSnapshotWrapper profileMarcHoldingsSnapshotWrapperResponse = new ProfileSnapshotWrapper()
     .withId(UUID.randomUUID().toString())
     .withProfileId(jobProfile.getId())

--- a/mod-source-record-manager-server/src/test/java/org/folio/verticle/consumers/StoredRecordChunksKafkaHandlerTest.java
+++ b/mod-source-record-manager-server/src/test/java/org/folio/verticle/consumers/StoredRecordChunksKafkaHandlerTest.java
@@ -149,7 +149,7 @@ public class StoredRecordChunksKafkaHandlerTest {
       .withEventPayload(Json.encode(savedRecordsBatch));
 
     when(kafkaRecord.value()).thenReturn(Json.encode(event));
-    when(kafkaRecord.headers()).thenReturn(List.of(KafkaHeader.header(OKAPI_HEADER_TENANT.toLowerCase(), TENANT_ID)));
+    when(kafkaRecord.headers()).thenReturn(List.of(KafkaHeader.header(OKAPI_HEADER_TENANT.toLowerCase(), TENANT_ID), KafkaHeader.header("jobExecutionId", UUID.randomUUID().toString())));
     when(eventProcessedService.collectData(STORED_RECORD_CHUNKS_KAFKA_HANDLER_UUID, event.getId(), TENANT_ID)).thenReturn(Future.succeededFuture());
 
     // when
@@ -172,7 +172,7 @@ public class StoredRecordChunksKafkaHandlerTest {
       .withEventPayload(Json.encode(savedRecordsBatch));
 
     when(kafkaRecord.value()).thenReturn(Json.encode(event));
-    when(kafkaRecord.headers()).thenReturn(List.of(KafkaHeader.header(OKAPI_HEADER_TENANT.toLowerCase(), TENANT_ID)));
+    when(kafkaRecord.headers()).thenReturn(List.of(KafkaHeader.header(OKAPI_HEADER_TENANT.toLowerCase(), TENANT_ID), KafkaHeader.header("jobExecutionId", UUID.randomUUID().toString())));
     when(eventProcessedService.collectData(STORED_RECORD_CHUNKS_KAFKA_HANDLER_UUID, event.getId(), TENANT_ID)).thenReturn(Future.succeededFuture());
     when(mappingRuleCache.get(new MappingRuleCacheKey(TENANT_ID, EntityType.EDIFACT))).thenReturn(Future.failedFuture(new Exception()));
 
@@ -199,9 +199,6 @@ public class StoredRecordChunksKafkaHandlerTest {
     when(kafkaRecord.headers()).thenReturn(List.of(KafkaHeader.header(OKAPI_HEADER_TENANT.toLowerCase(), TENANT_ID)));
     when(eventProcessedService.collectData(STORED_RECORD_CHUNKS_KAFKA_HANDLER_UUID, event.getId(), TENANT_ID)).thenReturn(Future.succeededFuture());
     when(mappingRuleCache.get(new MappingRuleCacheKey(TENANT_ID, EntityType.EDIFACT))).thenReturn(Future.failedFuture(new Exception()));
-    when(recordsPublishingService
-      .sendEventsWithRecords(anyList(), isNull(), any(OkapiConnectionParams.class), anyString()))
-      .thenReturn(Future.failedFuture(new Exception()));
 
     // when
     Future<String> future = storedRecordChunksKafkaHandler.handle(kafkaRecord);
@@ -224,11 +221,11 @@ public class StoredRecordChunksKafkaHandlerTest {
       .withEventPayload(Json.encode(savedRecordsBatch));
 
     when(kafkaRecord.value()).thenReturn(Json.encode(event));
-    when(kafkaRecord.headers()).thenReturn(List.of(KafkaHeader.header(OKAPI_HEADER_TENANT.toLowerCase(), TENANT_ID)));
+    when(kafkaRecord.headers()).thenReturn(List.of(KafkaHeader.header(OKAPI_HEADER_TENANT.toLowerCase(), TENANT_ID), KafkaHeader.header("jobExecutionId", UUID.randomUUID().toString())));
     when(eventProcessedService.collectData(STORED_RECORD_CHUNKS_KAFKA_HANDLER_UUID, event.getId(), TENANT_ID)).thenReturn(Future.succeededFuture());
     when(mappingRuleCache.get(new MappingRuleCacheKey(TENANT_ID, entityType))).thenReturn(Future.succeededFuture(Optional.of(mappingRules)));
     when(recordsPublishingService
-      .sendEventsWithRecords(anyList(), isNull(), any(OkapiConnectionParams.class), anyString()))
+      .sendEventsWithRecords(anyList(), anyString(), any(OkapiConnectionParams.class), anyString()))
       .thenReturn(Future.succeededFuture(true));
 
     // when

--- a/mod-source-record-manager-server/src/test/java/org/folio/verticle/consumers/StoredRecordChunksKafkaHandlerTest.java
+++ b/mod-source-record-manager-server/src/test/java/org/folio/verticle/consumers/StoredRecordChunksKafkaHandlerTest.java
@@ -89,7 +89,7 @@ public class StoredRecordChunksKafkaHandlerTest {
   @Before
   public void setUp() {
     storedRecordChunksKafkaHandler = new StoredRecordChunksKafkaHandler(recordsPublishingService, journalService, eventProcessedService,jobExecutionService, mappingRuleCache,  vertx);
-    when(jobExecutionService.getJobExecutionById(any(), TENANT_ID))
+    when(jobExecutionService.getJobExecutionById(anyString(), anyString()))
       .thenReturn(Future.succeededFuture(Optional.of(new JobExecution())));
   }
 

--- a/mod-source-record-manager-server/src/test/java/org/folio/verticle/consumers/StoredRecordChunksKafkaHandlerTest.java
+++ b/mod-source-record-manager-server/src/test/java/org/folio/verticle/consumers/StoredRecordChunksKafkaHandlerTest.java
@@ -12,11 +12,13 @@ import org.folio.dataimport.util.OkapiConnectionParams;
 import org.folio.kafka.exception.DuplicateEventException;
 import org.folio.kafka.AsyncRecordHandler;
 import org.folio.rest.jaxrs.model.Event;
+import org.folio.rest.jaxrs.model.JobExecution;
 import org.folio.rest.jaxrs.model.JournalRecord;
 import org.folio.rest.jaxrs.model.JournalRecord.EntityType;
 import org.folio.rest.jaxrs.model.Record;
 import org.folio.rest.jaxrs.model.RecordsBatchResponse;
 import org.folio.services.EventProcessedService;
+import org.folio.services.JobExecutionService;
 import org.folio.services.MappingRuleCache;
 import org.folio.services.RecordsPublishingService;
 import org.folio.services.entity.MappingRuleCacheKey;
@@ -35,6 +37,7 @@ import java.util.Optional;
 import java.util.UUID;
 
 import static org.folio.rest.RestVerticle.OKAPI_HEADER_TENANT;
+import static org.folio.rest.jaxrs.model.DataImportEventTypes.DI_SRS_MARC_BIB_RECORD_CREATED;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -70,6 +73,8 @@ public class StoredRecordChunksKafkaHandlerTest {
   private EventProcessedService eventProcessedService;
   @Mock
   private MappingRuleCache mappingRuleCache;
+  @Mock
+  private JobExecutionService jobExecutionService;
   @Captor
   private ArgumentCaptor<JsonArray> journalRecordsCaptor;
 
@@ -83,7 +88,9 @@ public class StoredRecordChunksKafkaHandlerTest {
 
   @Before
   public void setUp() {
-    storedRecordChunksKafkaHandler = new StoredRecordChunksKafkaHandler(recordsPublishingService, journalService, eventProcessedService, mappingRuleCache, vertx);
+    storedRecordChunksKafkaHandler = new StoredRecordChunksKafkaHandler(recordsPublishingService, journalService, eventProcessedService,jobExecutionService, mappingRuleCache,  vertx);
+    when(jobExecutionService.getJobExecutionById(any(), TENANT_ID))
+      .thenReturn(Future.succeededFuture(Optional.of(new JobExecution())));
   }
 
   @Test


### PR DESCRIPTION
## Purpose
To differentiate the flow of importing Orders from regular DI, when MARC Bibs are saved in SRS a different event should be issued to be received by mod-orders. SRM should publish DI_MARC_BIB_FOR_ORDER_CREATED. Event type should be determined based on the action for creating Orders in the JobProfileWrSnapshotWrapper retrieved from JobExecution.

## Approach
Get JobExecution from DB and retrieve JobProfileSnapshotWrapper from it. If there is action on Order+Create, then set eventType for sending "DI_MARC_BIB_FOR_ORDER_CREATED"

## Learning
JIRA: https://issues.folio.org/browse/MODSOURMAN-937
