### PR TITLE
[MODSOURMAN-932] Return count of all PO_LINE in order summary

### DIFF
--- a/mod-source-record-manager-server/src/main/resources/templates/db_scripts/create_get_job_execution_summary_function.sql
+++ b/mod-source-record-manager-server/src/main/resources/templates/db_scripts/create_get_job_execution_summary_function.sql
@@ -39,10 +39,10 @@ BEGIN
       COUNT(*) FILTER (WHERE entity_type = 'AUTHORITY' AND (action_type = 'NON_MATCH' OR action_status = 'ERROR')) AS total_discarded_authorities,
       COUNT(*) FILTER (WHERE entity_type = 'AUTHORITY' AND action_status = 'ERROR') AS total_authorities_errors,
 
-      COUNT(DISTINCT(order_id)) FILTER (WHERE entity_type = 'PO_LINE' AND action_type = 'CREATE' AND action_status = 'COMPLETED') AS total_created_orders,
+      COUNT(*) FILTER (WHERE entity_type = 'PO_LINE' AND action_type = 'CREATE' AND action_status = 'COMPLETED') AS total_created_orders,
       0 AS total_updated_orders,
-      COUNT(DISTINCT(order_id)) FILTER (WHERE entity_type = 'PO_LINE' AND (action_type = 'NON_MATCH' OR action_status = 'ERROR')) AS total_discarded_orders,
-      COUNT(DISTINCT(order_id)) FILTER (WHERE entity_type = 'PO_LINE' AND action_status = 'ERROR') AS total_orders_errors,
+      COUNT(*) FILTER (WHERE entity_type = 'PO_LINE' AND (action_type = 'NON_MATCH' OR action_status = 'ERROR')) AS total_discarded_orders,
+      COUNT(*) FILTER (WHERE entity_type = 'PO_LINE' AND action_status = 'ERROR') AS total_orders_errors,
 
       COUNT(DISTINCT(source_id)) FILTER (WHERE entity_type = 'INVOICE' AND action_status = 'COMPLETED') AS total_created_invoices,
       0 AS total_updated_invoices,


### PR DESCRIPTION
## Purpose
Return count of all PO_LINE for order summary (not group by orderId)
(https://issues.folio.org/secure/attachment/52792/UIDATIMP-1264%20Mockup.png)
## Approach
Removed DISTINCT(orderId) from get_job_execution_summary function
