### PR TITLE
MODSOURMAN-946: Handle DI_ERROR event for POLines

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -8,6 +8,7 @@
 * [MODSOURMAN-948](https://issues.folio.org/browse/MODSOURMAN-948) Improve schema for the 'journal_records'-table to be able to import Orders
 * [MODSOURMAN-937](https://issues.folio.org/browse/MODSOURMAN-937) Send DI_MARC_BIB_FOR_ORDER_CREATED event for Importing Orders
 * [MODSOURMAN-932](https://issues.folio.org/browse/MODSOURMAN-932) Fill Journal Record info for Orders upon receiving DI_COMPLETED event
+* [MODSOURMAN-946](https://issues.folio.org/browse/MODSOURMAN-946) Handle DI_ERROR event for POLines
 
 ## 2022-10-24 v3.5.0
 * [MODSOURMAN-858](https://issues.folio.org/browse/MODSOURMAN-858) Mapping bib's $9 into contributors.authorityId field

--- a/mod-source-record-manager-server/src/main/java/org/folio/dao/JournalRecordDao.java
+++ b/mod-source-record-manager-server/src/main/java/org/folio/dao/JournalRecordDao.java
@@ -87,4 +87,14 @@ public interface JournalRecordDao {
    * @return future with {@link Optional} of JobExecutionSummaryDto
    */
   Future<Optional<JobExecutionSummaryDto>> getJobExecutionSummaryDto(String jobExecutionId, String tenantId);
+
+  /**
+   * Updates JournalRecords error-field by orderId and jobExecutionId
+   * @param jobExecutionId job execution id
+   * @param orderId orderId
+   * @param error current error message which should be set
+   * @param tenantId tenantId
+   * @return future with number of updated JournalRecords
+   */
+  Future<Integer> updateErrorJournalRecordsByOrderIdAndJobExecution(String jobExecutionId, String orderId, String error, String tenantId);
 }

--- a/mod-source-record-manager-server/src/main/java/org/folio/services/JournalRecordService.java
+++ b/mod-source-record-manager-server/src/main/java/org/folio/services/JournalRecordService.java
@@ -65,4 +65,14 @@ public interface JournalRecordService {
    * @return future with {@link Optional} of JobExecutionSummaryDto
    */
   Future<Optional<JobExecutionSummaryDto>> getJobExecutionSummaryDto(String jobExecutionId, String tenantId);
+
+  /**
+   * Updates  JournalRecords error-field with current error-message by the same orderId and jobExecutionId
+   * @param jobExecutionId jobExecutionId
+   * @param orderId orderId
+   * @param error error
+   * @param tenantId tenantId
+   * @return Future with JournalRecords updated number
+   */
+  Future<Integer> updateErrorJournalRecordsByOrderIdAndJobExecution(String jobExecutionId, String orderId, String error, String tenantId);
 }

--- a/mod-source-record-manager-server/src/main/java/org/folio/services/JournalRecordServiceImpl.java
+++ b/mod-source-record-manager-server/src/main/java/org/folio/services/JournalRecordServiceImpl.java
@@ -1,6 +1,7 @@
 package org.folio.services;
 
 import io.vertx.core.Future;
+import io.vertx.core.json.JsonObject;
 import org.folio.dao.JournalRecordDao;
 import org.folio.rest.jaxrs.model.JobExecutionSummaryDto;
 import org.folio.rest.jaxrs.model.JobLogEntryDtoCollection;
@@ -48,5 +49,10 @@ public class JournalRecordServiceImpl implements JournalRecordService {
   @Override
   public Future<Optional<JobExecutionSummaryDto>> getJobExecutionSummaryDto(String jobExecutionId, String tenantId) {
     return journalRecordDao.getJobExecutionSummaryDto(jobExecutionId, tenantId);
+  }
+
+  @Override
+  public Future<Integer> updateErrorJournalRecordsByOrderIdAndJobExecution(String jobExecutionId, String orderId, String error, String tenantId) {
+    return journalRecordDao.updateErrorJournalRecordsByOrderIdAndJobExecution(jobExecutionId, orderId, error, tenantId);
   }
 }

--- a/mod-source-record-manager-server/src/main/java/org/folio/verticle/consumers/util/MarcImportEventsHandler.java
+++ b/mod-source-record-manager-server/src/main/java/org/folio/verticle/consumers/util/MarcImportEventsHandler.java
@@ -117,7 +117,6 @@ public class MarcImportEventsHandler implements SpecificEventHandler {
   }
 
   private void processJournalRecordForOrder(JournalService journalService, DataImportEventPayload eventPayload, String tenantId, JournalRecord journalRecord) {
-    populateOrderTitleIfNeeded(journalRecord, eventPayload);
     if (journalRecord.getOrderId() != null) {
       journalRecordService.updateErrorJournalRecordsByOrderIdAndJobExecution(journalRecord.getJobExecutionId(), journalRecord.getOrderId(), journalRecord.getError(), tenantId)
         .onComplete(e -> journalService.save(JsonObject.mapFrom(journalRecord), tenantId));

--- a/mod-source-record-manager-server/src/main/java/org/folio/verticle/consumers/util/MarcImportEventsHandler.java
+++ b/mod-source-record-manager-server/src/main/java/org/folio/verticle/consumers/util/MarcImportEventsHandler.java
@@ -117,7 +117,7 @@ public class MarcImportEventsHandler implements SpecificEventHandler {
   }
 
   private void processJournalRecordForOrder(JournalService journalService, String tenantId, JournalRecord journalRecord) {
-    if (journalRecord.getOrderId() != null) {
+    if (journalRecord.getOrderId() != null && journalRecord.getError() != null) {
       journalRecordService.updateErrorJournalRecordsByOrderIdAndJobExecution(journalRecord.getJobExecutionId(), journalRecord.getOrderId(), journalRecord.getError(), tenantId)
         .onComplete(e -> journalService.save(JsonObject.mapFrom(journalRecord), tenantId));
     } else {

--- a/mod-source-record-manager-server/src/main/java/org/folio/verticle/consumers/util/MarcImportEventsHandler.java
+++ b/mod-source-record-manager-server/src/main/java/org/folio/verticle/consumers/util/MarcImportEventsHandler.java
@@ -49,12 +49,12 @@ public class MarcImportEventsHandler implements SpecificEventHandler {
 
   private final MappingRuleCache mappingRuleCache;
 
-  @Autowired
   private JournalRecordService journalRecordService;
 
   @Autowired
-  public MarcImportEventsHandler(MappingRuleCache mappingRuleCache) {
+  public MarcImportEventsHandler(MappingRuleCache mappingRuleCache, JournalRecordService journalRecordService) {
     this.mappingRuleCache = mappingRuleCache;
+    this.journalRecordService = journalRecordService;
   }
 
   private static BiFunction<ParsedRecord, JsonObject, String> marcBibTitleExtractor() {

--- a/mod-source-record-manager-server/src/test/java/org/folio/dao/JournalRecordDaoTest.java
+++ b/mod-source-record-manager-server/src/test/java/org/folio/dao/JournalRecordDaoTest.java
@@ -202,22 +202,18 @@ public class JournalRecordDaoTest extends AbstractRestTest {
       .withOrderId(UUID.randomUUID().toString())
       .withError("Testing Error");
 
-    Future<List<JournalRecord>> createdFuture = journalRecordDao.save(journalRecord1, TENANT_ID)
+    Future<Integer> updatedFuture = journalRecordDao.save(journalRecord1, TENANT_ID)
       .compose(ar -> journalRecordDao.save(journalRecord2, TENANT_ID))
       .compose(ar -> journalRecordDao.save(journalRecord3, TENANT_ID))
-      .compose(ar -> journalRecordDao.getByJobExecutionId(jobExec.getId(), "action_type", "asc", TENANT_ID));
+      .compose(ar -> journalRecordDao.updateErrorJournalRecordsByOrderIdAndJobExecution(jobExec.getId(), orderId,"Testing Error", TENANT_ID));
+
 
     Async async = testContext.async();
-    Future<Integer> updatedFuture = journalRecordDao.updateErrorJournalRecordsByOrderIdAndJobExecution(jobExec.getId(), orderId,"Testing Error", TENANT_ID);
-
-    createdFuture.onComplete(ar -> {
+    updatedFuture.onComplete(ar -> {
       testContext.verify(v -> {
         Assert.assertTrue(ar.succeeded());
-        updatedFuture.onComplete(e -> {
-          Assert.assertTrue(e.succeeded());
-          int updatedCount = e.result();
-          Assert.assertEquals(updatedCount, 2);
-        });
+          int updatedCount = ar.result();
+          Assert.assertEquals(2, updatedCount);
       });
       async.complete();
     });

--- a/mod-source-record-manager-server/src/test/java/org/folio/verticle/consumers/util/EventTypeHandlerSelectorTest.java
+++ b/mod-source-record-manager-server/src/test/java/org/folio/verticle/consumers/util/EventTypeHandlerSelectorTest.java
@@ -17,7 +17,7 @@ import static org.folio.rest.jaxrs.model.DataImportEventTypes.DI_INVENTORY_INSTA
 @RunWith(BlockJUnit4ClassRunner.class)
 public class EventTypeHandlerSelectorTest {
 
-  EventTypeHandlerSelector eventTypeHandlerSelector = new EventTypeHandlerSelector(new MarcImportEventsHandler(null));
+  EventTypeHandlerSelector eventTypeHandlerSelector = new EventTypeHandlerSelector(new MarcImportEventsHandler(null, null));
 
   @Test
   public void shouldReturnMarcImportEventHandler() {

--- a/mod-source-record-manager-server/src/test/java/org/folio/verticle/consumers/util/MarcImportEventsHandlerTest.java
+++ b/mod-source-record-manager-server/src/test/java/org/folio/verticle/consumers/util/MarcImportEventsHandlerTest.java
@@ -178,7 +178,7 @@ public class MarcImportEventsHandlerTest {
   }
 
   @Test
-  public void testShouldUpdateJournalRecordsIfPOLineWithErrorAndWithoutOrderId() throws JournalRecordMapperException {
+  public void testShouldNotUpdateJournalRecordsIfPOLineWithErrorAndWithoutOrderId() throws JournalRecordMapperException {
     String title = "The Journal of ecclesiastical history.";
     when(mappingRuleCache.get(any())).thenReturn(Future.succeededFuture(Optional.of(new JsonObject(
       Map.of("245", List.of(
@@ -194,6 +194,7 @@ public class MarcImportEventsHandlerTest {
 
     verify(journalService).save(journalRecordCaptor.capture(), eq(TEST_TENANT));
     var actualJournalRecord = journalRecordCaptor.getValue().mapTo(JournalRecord.class);
+    verify(journalRecordService, times(0)).updateErrorJournalRecordsByOrderIdAndJobExecution(anyString(), anyString(), anyString(), anyString());
 
     assertNull(actualJournalRecord.getTitle());
   }


### PR DESCRIPTION
## Purpose
The main purpose is to handle DI_ERROR for Order/PO_Line importing for updating journal_record errors.

## Approach
There are two scenarios:
1. Update all records where entityType = PO_LINE and orderId = "{orderId}" and add current one with the same data.
2. Create only one record if  "orderId==null" and write the current record with the error message from the payload.

## Learning
JIRA: https://issues.folio.org/browse/MODSOURMAN-946
