### PR TITLE
[MODSOURMAN-899]Do not process chunks when the DI is stopped

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -10,6 +10,7 @@
 * [MODSOURMAN-932](https://issues.folio.org/browse/MODSOURMAN-932) Fill Journal Record info for Orders upon receiving DI_COMPLETED event
 * [MODSOURMAN-946](https://issues.folio.org/browse/MODSOURMAN-946) Handle DI_ERROR event for POLines
 * [MODSOURMAN-955](https://issues.folio.org/browse/MODSOURMAN-955) Include OrderId to the DTO that is used to display the json for POLine in DI log
+* [MODSOURMAN-899](https://issues.folio.org/browse/MODSOURMAN-899) Do not process chunks when the DI is stopped
 
 ## 2022-10-24 v3.5.0
 * [MODSOURMAN-858](https://issues.folio.org/browse/MODSOURMAN-858) Mapping bib's $9 into contributors.authorityId field

--- a/mod-source-record-manager-server/src/main/java/org/folio/services/ChunkProcessingService.java
+++ b/mod-source-record-manager-server/src/main/java/org/folio/services/ChunkProcessingService.java
@@ -2,6 +2,7 @@ package org.folio.services;
 
 import io.vertx.core.Future;
 import org.folio.dataimport.util.OkapiConnectionParams;
+import org.folio.rest.jaxrs.model.JobExecution;
 import org.folio.rest.jaxrs.model.RawRecordsDto;
 
 public interface ChunkProcessingService {
@@ -15,5 +16,7 @@ public interface ChunkProcessingService {
    * @return - true if chunk was processed correctly
    */
   Future<Boolean> processChunk(RawRecordsDto chunk, String jobExecutionId, OkapiConnectionParams params);
+
+  Future<Boolean> processChunk(RawRecordsDto incomingChunk, JobExecution jobExecution, OkapiConnectionParams params);
 
 }

--- a/mod-source-record-manager-server/src/main/java/org/folio/verticle/consumers/RawMarcChunksKafkaHandler.java
+++ b/mod-source-record-manager-server/src/main/java/org/folio/verticle/consumers/RawMarcChunksKafkaHandler.java
@@ -2,6 +2,7 @@ package org.folio.verticle.consumers;
 
 import io.vertx.core.Future;
 import io.vertx.core.Vertx;
+import io.vertx.core.impl.future.FailedFuture;
 import io.vertx.core.json.Json;
 import io.vertx.core.json.JsonObject;
 import io.vertx.kafka.client.consumer.KafkaConsumerRecord;
@@ -15,6 +16,7 @@ import org.folio.kafka.exception.DuplicateEventException;
 import org.folio.rest.jaxrs.model.Event;
 import org.folio.rest.jaxrs.model.RawRecordsDto;
 import org.folio.services.ChunkProcessingService;
+import org.folio.services.JobExecutionService;
 import org.folio.services.exceptions.RawChunkRecordsParsingException;
 import org.folio.services.exceptions.RecordsPublishingException;
 import org.folio.services.flowcontrol.RawRecordsFlowControlService;
@@ -22,7 +24,11 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.stereotype.Component;
 
+import javax.ws.rs.NotFoundException;
 import java.util.List;
+
+import static java.lang.String.format;
+import static org.folio.verticle.consumers.util.JobExecutionUtils.isNeedToSkip;
 
 @Component
 @Qualifier("RawMarcChunksKafkaHandler")
@@ -32,13 +38,16 @@ public class RawMarcChunksKafkaHandler implements AsyncRecordHandler<String, Str
 
   private final ChunkProcessingService eventDrivenChunkProcessingService;
   private final RawRecordsFlowControlService flowControlService;
+  private final JobExecutionService jobExecutionService;
   private final Vertx vertx;
 
   public RawMarcChunksKafkaHandler(@Autowired @Qualifier("eventDrivenChunkProcessingService")
                                      ChunkProcessingService eventDrivenChunkProcessingService,
                                    @Autowired RawRecordsFlowControlService flowControlService,
+                                   @Autowired JobExecutionService jobExecutionService,
                                    @Autowired Vertx vertx) {
     this.eventDrivenChunkProcessingService = eventDrivenChunkProcessingService;
+    this.jobExecutionService = jobExecutionService;
     this.flowControlService = flowControlService;
     this.vertx = vertx;
   }
@@ -51,39 +60,49 @@ public class RawMarcChunksKafkaHandler implements AsyncRecordHandler<String, Str
     String chunkNumber = okapiParams.getHeaders().get("chunkNumber");
     String jobExecutionId = okapiParams.getHeaders().get("jobExecutionId");
 
-    Event event = Json.decodeValue(record.value(), Event.class);
-    LOGGER.debug("handle:: Starting to handle of raw mark chunks from Kafka for event type: {}", event.getEventType());
-    try {
-      RawRecordsDto rawRecordsDto = new JsonObject(event.getEventPayload()).mapTo(RawRecordsDto.class);
-      if (!rawRecordsDto.getRecordsMetadata().getLast()) {
-        flowControlService.trackChunkReceivedEvent(okapiParams.getTenantId(), rawRecordsDto.getInitialRecords().size());
-      }
-
-      LOGGER.debug("handle:: RawRecordsDto has been received, starting processing jobExecutionId: {} chunkId: {} chunkNumber: {} - {}",
-        jobExecutionId, chunkId, chunkNumber, rawRecordsDto.getRecordsMetadata());
-      return eventDrivenChunkProcessingService
-        .processChunk(rawRecordsDto, jobExecutionId, okapiParams)
-        .compose(b -> {
-          LOGGER.debug("handle:: RawRecordsDto processing has been completed chunkId: {} chunkNumber: {} - {} for jobExecutionId: {}", chunkId, chunkNumber, rawRecordsDto.getRecordsMetadata(), jobExecutionId);
-          return Future.succeededFuture(record.key());
-        }, th -> {
-          if (th instanceof DuplicateEventException) {
-            LOGGER.info("handle:: Duplicate RawRecordsDto processing has been skipped for chunkId: {} chunkNumber: {} - {} for jobExecutionId: {}", chunkId, chunkNumber, rawRecordsDto.getRecordsMetadata(), jobExecutionId);
-            if (!rawRecordsDto.getRecordsMetadata().getLast()) {
-              flowControlService.trackChunkDuplicateEvent(okapiParams.getTenantId(), rawRecordsDto.getInitialRecords().size());
-            }
-            return Future.failedFuture(th);
-          } else if (th instanceof RecordsPublishingException) {
-            LOGGER.warn("handle:: RawRecordsDto entries publishing to Kafka has failed for chunkId: {} chunkNumber: {} - {} for jobExecutionId: {}", chunkId, chunkNumber, rawRecordsDto.getRecordsMetadata(), jobExecutionId, th);
-            return Future.failedFuture(th);
-          } else {
-            LOGGER.warn("handle:: RawRecordsDto processing has failed with errors chunkId: {} chunkNumber: {} - {} for jobExecutionId: {}", chunkId, chunkNumber, rawRecordsDto.getRecordsMetadata(), jobExecutionId, th);
-            return Future.failedFuture(new RawChunkRecordsParsingException(th, rawRecordsDto));
+    return jobExecutionService.getJobExecutionById(jobExecutionId, okapiParams.getTenantId())
+      .compose(jobExecutionOptional -> jobExecutionOptional.map(jobExecution -> {
+          if(isNeedToSkip(jobExecution)) {
+            LOGGER.info("handle:: do not handle because jobExecution with id: {} was cancelled", jobExecutionId);
+            return Future.succeededFuture(record.key());
           }
-        });
-    } catch (Exception e) {
-      LOGGER.warn("handle:: Can't process kafka record: ", e);
-      return Future.failedFuture(e);
-    }
+          Event event = Json.decodeValue(record.value(), Event.class);
+          LOGGER.debug("handle:: Starting to handle of raw mark chunks from Kafka for event type: {}", event.getEventType());
+          try {
+            RawRecordsDto rawRecordsDto = new JsonObject(event.getEventPayload()).mapTo(RawRecordsDto.class);
+            if (!rawRecordsDto.getRecordsMetadata().getLast()) {
+              flowControlService.trackChunkReceivedEvent(okapiParams.getTenantId(), rawRecordsDto.getInitialRecords().size());
+            }
+
+            LOGGER.debug("handle:: RawRecordsDto has been received, starting processing jobExecutionId: {} chunkId: {} chunkNumber: {} - {}",
+              jobExecutionId, chunkId, chunkNumber, rawRecordsDto.getRecordsMetadata());
+
+            return eventDrivenChunkProcessingService
+              .processChunk(rawRecordsDto, jobExecution, okapiParams)
+              .compose(b -> {
+                  LOGGER.debug("handle:: RawRecordsDto processing has been completed chunkId: {} chunkNumber: {} - {} for jobExecutionId: {}", chunkId, chunkNumber, rawRecordsDto.getRecordsMetadata(), jobExecutionId);
+                  return Future.succeededFuture(record.key());
+                },
+                th -> {
+                  if (th instanceof DuplicateEventException) {
+                    LOGGER.info("handle:: Duplicate RawRecordsDto processing has been skipped for chunkId: {} chunkNumber: {} - {} for jobExecutionId: {}", chunkId, chunkNumber, rawRecordsDto.getRecordsMetadata(), jobExecutionId);
+                    if (!rawRecordsDto.getRecordsMetadata().getLast()) {
+                      flowControlService.trackChunkDuplicateEvent(okapiParams.getTenantId(), rawRecordsDto.getInitialRecords().size());
+                    }
+                    return Future.failedFuture(th);
+                  } else if (th instanceof RecordsPublishingException) {
+                    LOGGER.warn("handle:: RawRecordsDto entries publishing to Kafka has failed for chunkId: {} chunkNumber: {} - {} for jobExecutionId: {}", chunkId, chunkNumber, rawRecordsDto.getRecordsMetadata(), jobExecutionId, th);
+                    return Future.failedFuture(th);
+                  } else {
+                    LOGGER.warn("handle:: RawRecordsDto processing has failed with errors chunkId: {} chunkNumber: {} - {} for jobExecutionId: {}", chunkId, chunkNumber, rawRecordsDto.getRecordsMetadata(), jobExecutionId, th);
+                    return Future.failedFuture(new RawChunkRecordsParsingException(th, rawRecordsDto));
+                  }
+                });
+          } catch (Exception e) {
+            LOGGER.warn("handle:: Can't process kafka record: ", e);
+            return new FailedFuture<String>(e);
+          }
+        })
+        .orElse(Future.failedFuture(new NotFoundException(format("Couldn't find JobExecution with id %s chunkId:%s chunkNumber: %s", jobExecutionId, chunkId, chunkNumber)))));
   }
 }

--- a/mod-source-record-manager-server/src/main/java/org/folio/verticle/consumers/util/JobExecutionUtils.java
+++ b/mod-source-record-manager-server/src/main/java/org/folio/verticle/consumers/util/JobExecutionUtils.java
@@ -1,0 +1,17 @@
+package org.folio.verticle.consumers.util;
+
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+import org.folio.rest.jaxrs.model.JobExecution;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.Objects;
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public class JobExecutionUtils {
+  public static final List<JobExecution.Status> SKIP_STATUSES = Arrays.asList(JobExecution.Status.CANCELLED);
+  public static boolean isNeedToSkip(JobExecution jobExecution) {
+    return Objects.nonNull(jobExecution.getStatus()) && SKIP_STATUSES.contains(jobExecution.getStatus());
+  }
+
+}

--- a/mod-source-record-manager-server/src/test/java/org/folio/verticle/consumers/RawMarcChunksKafkaHandlerTest.java
+++ b/mod-source-record-manager-server/src/test/java/org/folio/verticle/consumers/RawMarcChunksKafkaHandlerTest.java
@@ -1,0 +1,94 @@
+package org.folio.verticle.consumers;
+
+import io.vertx.core.Future;
+import io.vertx.core.Vertx;
+import io.vertx.core.json.JsonArray;
+import io.vertx.core.json.JsonObject;
+import io.vertx.kafka.client.consumer.KafkaConsumerRecord;
+import io.vertx.kafka.client.producer.KafkaHeader;
+import org.folio.TestUtil;
+import org.folio.dataimport.util.OkapiConnectionParams;
+import org.folio.kafka.AsyncRecordHandler;
+import org.folio.rest.jaxrs.model.JobExecution;
+import org.folio.services.ChunkProcessingService;
+import org.folio.services.EventProcessedService;
+import org.folio.services.JobExecutionService;
+import org.folio.services.MappingRuleCache;
+import org.folio.services.RecordsPublishingService;
+import org.folio.services.flowcontrol.RawRecordsFlowControlService;
+import org.folio.services.journal.JournalService;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.Optional;
+
+import static org.folio.rest.RestVerticle.OKAPI_HEADER_TENANT;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@RunWith(MockitoJUnitRunner.class)
+public class RawMarcChunksKafkaHandlerTest {
+  private static final String TENANT_ID = "diku";
+  private static final String MAPPING_RULES_PATH = "src/test/resources/org/folio/services/marc_bib_rules.json";
+
+  private static JsonObject mappingRules;
+
+  @Mock
+  private RecordsPublishingService recordsPublishingService;
+  @Mock
+  private KafkaConsumerRecord<String, String> kafkaRecord;
+  @Mock
+  private JournalService journalService;
+  @Mock
+  private EventProcessedService eventProcessedService;
+  @Mock
+  private ChunkProcessingService eventDrivenChunkProcessingService;
+  @Mock
+  private RawRecordsFlowControlService flowControlService;
+  @Mock
+  private MappingRuleCache mappingRuleCache;
+  @Mock
+  private JobExecutionService jobExecutionService;
+  @Captor
+  private ArgumentCaptor<JsonArray> journalRecordsCaptor;
+
+  private Vertx vertx = Vertx.vertx();
+  private AsyncRecordHandler<String, String> rawMarcChunksKafkaHandler;
+  @BeforeClass
+  public static void setUpClass() throws IOException {
+    mappingRules = new JsonObject(TestUtil.readFileFromPath(MAPPING_RULES_PATH));
+  }
+
+  @Before
+  public void setUp() {
+    rawMarcChunksKafkaHandler = new RawMarcChunksKafkaHandler(eventDrivenChunkProcessingService, flowControlService, jobExecutionService, vertx);
+//    when(jobExecutionService.getJobExecutionById(anyString(), anyString()))
+//      .thenReturn(Future.succeededFuture(Optional.of(new JobExecution())));
+  }
+
+  @Test
+  public void shouldNotHandleEventWhenJobExecutionWasCancelled() {
+    when(kafkaRecord.headers()).thenReturn(List.of(KafkaHeader.header(OKAPI_HEADER_TENANT.toLowerCase(), TENANT_ID)));
+    when(jobExecutionService.getJobExecutionById(any(), any())).thenReturn(Future.succeededFuture(Optional.of(new JobExecution().withStatus(JobExecution.Status.CANCELLED))));
+
+    // when
+    Future<String> future = rawMarcChunksKafkaHandler.handle(kafkaRecord);
+
+    // then
+    verify(recordsPublishingService, never()).sendEventsWithRecords(anyList(), anyString(), any(OkapiConnectionParams.class), anyString());
+    assertTrue(future.succeeded());
+  }
+}


### PR DESCRIPTION
https://issues.folio.org/browse/MODSOURMAN-899
Currently, when a user cancels job DI continues to process chunks related to this job.
In RawMarcChunksKafkaHandler and StoredRecordChunksKafkaHandler get jobExecutionId from Kafka headers, check JobExecution status, if canceled or deleted (empty result) - skip processing of the chunk (DI_ERROR messages NOT needed) without deserializing (unpacking) the chunks.

Check impact on job progress tracking - add same logic in DataImportKafkaHandler (DI_COMPLETE and DI_ERROR messages). Check behavior of FlowControl, create separate task to resolve any issues.

This method will increase the performance of the DI and reduce the load on the CPU.
