### PR TITLE
MODSOURMAN-961 - Provide actual incoming records amount on request jobExecution by id

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -11,6 +11,7 @@
 * [MODSOURMAN-946](https://issues.folio.org/browse/MODSOURMAN-946) Handle DI_ERROR event for POLines
 * [MODSOURMAN-955](https://issues.folio.org/browse/MODSOURMAN-955) Include OrderId to the DTO that is used to display the json for POLine in DI log
 * [MODSOURMAN-899](https://issues.folio.org/browse/MODSOURMAN-899) Do not process chunks when the DI is stopped
+* [MODSOURMAN-961](https://issues.folio.org/browse/MODSOURMAN-961) Provide actual incoming records total amount on request jobExecution by id
 
 ## 2022-10-24 v3.5.0
 * [MODSOURMAN-858](https://issues.folio.org/browse/MODSOURMAN-858) Mapping bib's $9 into contributors.authorityId field

--- a/mod-source-record-manager-server/src/main/java/org/folio/dao/JobExecutionDao.java
+++ b/mod-source-record-manager-server/src/main/java/org/folio/dao/JobExecutionDao.java
@@ -1,5 +1,6 @@
 package org.folio.dao;
 
+import io.vertx.core.AsyncResult;
 import io.vertx.core.Future;
 import org.folio.dao.util.JobExecutionMutator;
 import org.folio.dao.util.SortField;
@@ -10,6 +11,8 @@ import org.folio.rest.jaxrs.model.JobExecutionUserInfo;
 import org.folio.rest.jaxrs.model.JobExecutionUserInfoCollection;
 import org.folio.rest.jaxrs.model.JobProfileInfo;
 import org.folio.rest.jaxrs.model.JobProfileInfoCollection;
+import org.folio.rest.jaxrs.model.Progress;
+import org.folio.rest.persist.SQLConnection;
 
 import java.util.List;
 import java.util.Optional;
@@ -66,6 +69,17 @@ public interface JobExecutionDao {
    * @return optional of JobExecution
    */
   Future<Optional<JobExecution>> getJobExecutionById(String id, String tenantId);
+
+  /**
+   * Updates {@link JobExecution} progress by jobExecutionId from the specified {@code progress}
+   * within transaction of the specified {@code connection}
+   *
+   * @param connection  transaction connection
+   * @param progress    jobExecution progress to update
+   * @param tenantId    tenant id
+   * @return future of Void
+   */
+  Future<Void> updateJobExecutionProgress(AsyncResult<SQLConnection> connection, Progress progress, String tenantId);
 
   /**
    * Updates {@link JobExecution} in the db with row blocking

--- a/mod-source-record-manager-server/src/main/java/org/folio/dao/JobExecutionProgressDao.java
+++ b/mod-source-record-manager-server/src/main/java/org/folio/dao/JobExecutionProgressDao.java
@@ -6,7 +6,6 @@ import io.vertx.sqlclient.Row;
 import io.vertx.sqlclient.RowSet;
 import org.folio.rest.jaxrs.model.JobExecution;
 import org.folio.rest.jaxrs.model.JobExecutionProgress;
-import org.folio.rest.persist.Conn;
 import org.folio.rest.persist.SQLConnection;
 
 import java.util.Optional;

--- a/mod-source-record-manager-server/src/main/java/org/folio/dao/JobExecutionProgressDao.java
+++ b/mod-source-record-manager-server/src/main/java/org/folio/dao/JobExecutionProgressDao.java
@@ -1,10 +1,13 @@
 package org.folio.dao;
 
+import io.vertx.core.AsyncResult;
 import io.vertx.core.Future;
 import io.vertx.sqlclient.Row;
 import io.vertx.sqlclient.RowSet;
 import org.folio.rest.jaxrs.model.JobExecution;
 import org.folio.rest.jaxrs.model.JobExecutionProgress;
+import org.folio.rest.persist.Conn;
+import org.folio.rest.persist.SQLConnection;
 
 import java.util.Optional;
 import java.util.function.UnaryOperator;
@@ -26,12 +29,13 @@ public interface JobExecutionProgressDao {
   /**
    * Creates jobExecutionProgress for {@link JobExecution} with specified jobExecutionId
    *
+   * @param connection     transaction connection
    * @param jobExecutionId jobExecution id
    * @param totalRecords   total number of records to be processed
    * @param tenantId       tenant id
    * @return future with created JobExecutionProgress
    */
-  Future<JobExecutionProgress> initializeJobExecutionProgress(String jobExecutionId, Integer totalRecords, String tenantId);
+  Future<JobExecutionProgress> initializeJobExecutionProgress(AsyncResult<SQLConnection> connection, String jobExecutionId, Integer totalRecords, String tenantId);
 
   /**
    * Saves jobExecutionProgress entity to database

--- a/mod-source-record-manager-server/src/main/java/org/folio/dao/util/JobExecutionDBConstants.java
+++ b/mod-source-record-manager-server/src/main/java/org/folio/dao/util/JobExecutionDBConstants.java
@@ -91,6 +91,11 @@ public final class JobExecutionDBConstants {
     "total AS (SELECT count(*) AS total_count FROM unique_users)" +
     "SELECT j.*, p.* FROM unique_users j LEFT JOIN total p ON true LIMIT $1 OFFSET $2";
 
+  public static final String UPDATE_PROGRESS_SQL =
+    "UPDATE %s " +
+    "SET progress_current = $2, progress_total = $3 " +
+    "WHERE id = $1";
+
   private JobExecutionDBConstants() {
   }
 }

--- a/mod-source-record-manager-server/src/test/java/org/folio/rest/impl/changeManager/ChangeManagerAPITest.java
+++ b/mod-source-record-manager-server/src/test/java/org/folio/rest/impl/changeManager/ChangeManagerAPITest.java
@@ -136,6 +136,7 @@ public class ChangeManagerAPITest extends AbstractRestTest {
     .withRecordsMetadata(new RecordsMetadata()
       .withLast(false)
       .withCounter(15)
+      .withTotal(15)
       .withContentType(RecordsMetadata.ContentType.MARC_RAW))
     .withInitialRecords(Collections.singletonList(new InitialRecord().withRecord(CORRECT_RAW_RECORD_1))
     );
@@ -1040,7 +1041,7 @@ public class ChangeManagerAPITest extends AbstractRestTest {
       .statusCode(HttpStatus.SC_OK)
       .body("status", is(JobExecution.Status.PARSING_IN_PROGRESS.name()))
       .body("runBy.firstName", is("DIKU"))
-      .body("progress.total", is(100))
+      .body("progress.total", is(rawRecordsDto.getRecordsMetadata().getTotal()))
       .body("startedDate", notNullValue(Date.class)).log().all();
     async.complete();
   }

--- a/mod-source-record-manager-server/src/test/java/org/folio/rest/impl/changeManager/ChangeManagerAPITest.java
+++ b/mod-source-record-manager-server/src/test/java/org/folio/rest/impl/changeManager/ChangeManagerAPITest.java
@@ -999,7 +999,7 @@ public class ChangeManagerAPITest extends AbstractRestTest {
   }
 
   @Test
-  public void shouldProcessChunkOfRawRecords(TestContext testContext) throws IOException {
+  public void shouldProcessChunkOfRawRecords(TestContext testContext) {
     InitJobExecutionsRsDto response =
       constructAndPostInitJobExecutionRqDto(1);
     List<JobExecution> createdJobExecutions = response.getJobExecutions();
@@ -1088,7 +1088,7 @@ public class ChangeManagerAPITest extends AbstractRestTest {
       .then()
       .statusCode(HttpStatus.SC_OK)
       .body("runBy.firstName", is("DIKU"))
-      .body("progress.total", is(100))
+      .body("progress.total", is(rawRecordsDto.getRecordsMetadata().getTotal()))
       .body("startedDate", notNullValue(Date.class)).log().all();
     async.complete();
   }
@@ -1146,7 +1146,7 @@ public class ChangeManagerAPITest extends AbstractRestTest {
       .statusCode(HttpStatus.SC_OK)
       .body("status", is(JobExecution.Status.PARSING_IN_PROGRESS.name()))
       .body("runBy.firstName", is("DIKU"))
-      .body("progress.total", is(100))
+      .body("progress.total", is(rawRecordsDto.getRecordsMetadata().getTotal()))
       .body("startedDate", notNullValue(Date.class)).log().all();
 
     verify(1, getRequestedFor(urlEqualTo(IDENTIFIER_TYPES_URL)));
@@ -1253,7 +1253,7 @@ public class ChangeManagerAPITest extends AbstractRestTest {
       .statusCode(HttpStatus.SC_OK)
       .body("status", is(JobExecution.Status.PARSING_IN_PROGRESS.name()))
       .body("runBy.firstName", is("DIKU"))
-      .body("progress.total", is(100))
+      .body("progress.total", is(rawRecordsDto.getRecordsMetadata().getTotal()))
       .body("startedDate", notNullValue(Date.class)).log().all();
 
     async.complete();
@@ -1305,7 +1305,7 @@ public class ChangeManagerAPITest extends AbstractRestTest {
       .statusCode(HttpStatus.SC_OK)
       .body("status", is(JobExecution.Status.PARSING_IN_PROGRESS.name()))
       .body("runBy.firstName", is("DIKU"))
-      .body("progress.total", is(100))
+      .body("progress.total", is(rawRecordsDto.getRecordsMetadata().getTotal()))
       .body("startedDate", notNullValue(Date.class)).log().all();
     async.complete();
   }

--- a/mod-source-record-manager-server/src/test/java/org/folio/rest/impl/changeManager/ChangeManagerAPITest.java
+++ b/mod-source-record-manager-server/src/test/java/org/folio/rest/impl/changeManager/ChangeManagerAPITest.java
@@ -1088,7 +1088,7 @@ public class ChangeManagerAPITest extends AbstractRestTest {
       .then()
       .statusCode(HttpStatus.SC_OK)
       .body("runBy.firstName", is("DIKU"))
-      .body("progress.total", is(rawRecordsDto.getRecordsMetadata().getTotal()))
+      .body("progress.total", is(rawRecordsDto_2.getRecordsMetadata().getTotal()))
       .body("startedDate", notNullValue(Date.class)).log().all();
     async.complete();
   }


### PR DESCRIPTION
## Purpose
mod-orders module needs actual incoming total records amount to calculate expected po lines amount to be processed for particular order before opening it during orders import


## Approach
* add method into JobExecutionDao to update job progress with actual records amount directly in the jobExecution table
* refactor JobExecutionProgressDaoImpl::initializeJobExecutionProgress() method to be executed in scope of the outer transaction
* update jobExecution with actual records amount after import progress is initiated within the same transaction
* update tests


## Learning
[MODSOURMAN-961](https://issues.folio.org/browse/MODSOURMAN-961)