### PR TITLE
MODSOURMAN-966: direct get job_execution_by_id request to a W instanc…

### DIFF
--- a/mod-source-record-manager-server/src/main/java/org/folio/dao/JobExecutionDaoImpl.java
+++ b/mod-source-record-manager-server/src/main/java/org/folio/dao/JobExecutionDaoImpl.java
@@ -168,7 +168,7 @@ public class JobExecutionDaoImpl implements JobExecutionDao {
     try {
       String jobTable = formatFullTableName(tenantId, TABLE_NAME);
       String query = format(GET_BY_ID_SQL, jobTable);
-      pgClientFactory.createInstance(tenantId).selectRead(query, Tuple.of(UUID.fromString(id)), promise);
+      pgClientFactory.createInstance(tenantId).select(query, Tuple.of(UUID.fromString(id)), promise);
     } catch (Exception e) {
       LOGGER.warn("getJobExecutionById:: Error getting jobExecution by id", e);
       promise.fail(e);


### PR DESCRIPTION
…e of the DB

R/W split of the DB for mod-source-record-manager is disabled to avoid errors on single record operations ([MODSOURMAN-906](https://issues.folio.org/browse/MODSOURMAN-906), [MODSOURMAN-909](https://issues.folio.org/browse/MODSOURMAN-909)). Errors occur because request to assign the JobProfile (Update/write of the JobExecution) and the request to process a record (get/read JobExecution) come separately. In case Read instance is not synchronising fast enough, some single record operations and importing via API could fail.

## Purpose
Enable R/W split of the DB 

## Approach
Change request for getJobExecutionById to go to the main (write) version of the DB

#### TODOS and Open Questions
- [ ] This approach and possible other solutions will be documented in scope of MODSOURMAN-966

## Learning
https://wiki.folio.org/pages/viewpage.action?pageId=118265044