### PR TITLE
MODSOURMAN-971: Adjust journal records population to create multiple journal records for each Holdings/Item

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,7 @@
 ## 2023-03-xo v3.6.1-SNAPSHOT
 * [MODSOURMAN-957](https://issues.folio.org/browse/MODSOURMAN-957) The '1' number of SRS MARC and Instance are displayed in cells in the row with the 'Updated' row header at the individual import job's log
 * [MODDATAIMP-786](https://issues.folio.org/browse/MODDATAIMP-786) Update data-import-util library to v1.11.0
+* [MODSOURMAN-971](https://issues.folio.org/browse/MODSOURMAN-971) Adjust journal records population to create multiple journal records for each Holdings/Item
 
 ## 2023-02-24 v3.6.0
 * [MODSOURMAN-873](https://issues.folio.org/browse/MODSOURMAN-873) Add MARC 720 field to default MARC Bib-Instance mapping and adjust relator term mapping

--- a/mod-source-record-manager-server/src/main/java/org/folio/services/journal/JournalUtil.java
+++ b/mod-source-record-manager-server/src/main/java/org/folio/services/journal/JournalUtil.java
@@ -35,6 +35,7 @@ public class JournalUtil {
 
   public static final String ERROR_KEY = "ERROR";
   private static final String ENTITY_OR_RECORD_MAPPING_EXCEPTION_MSG = "Can`t map 'RECORD' or/and '%s'";
+  public static final String MULTIPLE_ERRORS_KEY = "ERRORS";
 
   private JournalUtil() {
 
@@ -94,7 +95,7 @@ public class JournalUtil {
         if (entityType == ITEM) {
           return processItems(actionType, entityType, actionStatus, eventPayloadContext, record);
         }
-        if (eventPayloadContext.get("ERRORS") != null) {
+        if (eventPayloadContext.get(MULTIPLE_ERRORS_KEY) != null) {
           return processErrors(actionType, entityType, actionStatus, eventPayloadContext, record);
         }
       }

--- a/mod-source-record-manager-server/src/main/java/org/folio/services/journal/JournalUtil.java
+++ b/mod-source-record-manager-server/src/main/java/org/folio/services/journal/JournalUtil.java
@@ -155,8 +155,7 @@ public class JournalUtil {
         .withActionDate(new Date())
         .withActionStatus(actionStatus)
         .withEntityId(itemAsJson.getString(ID_KEY))
-        .withEntityHrId(itemAsJson.getString(HRID_KEY))
-        .withInstanceId(itemAsJson.getString(INSTANCE_ID_KEY));
+        .withEntityHrId(itemAsJson.getString(HRID_KEY));
 
       if (eventPayloadContext.containsKey(INSTANCE.value())) {
         JsonObject instanceJson = new JsonObject(eventPayloadContext.get(INSTANCE.value()));

--- a/mod-source-record-manager-server/src/main/java/org/folio/services/journal/JournalUtil.java
+++ b/mod-source-record-manager-server/src/main/java/org/folio/services/journal/JournalUtil.java
@@ -85,10 +85,6 @@ public class JournalUtil {
           journalRecord.setEntityHrId(entityJson.getString("hrid"));
           return Lists.newArrayList(journalRecord);
         }
-        if (DI_ERROR == DataImportEventTypes.fromValue(eventPayload.getEventType())) {
-          journalRecord.setError(eventPayloadContext.get(ERROR_KEY));
-          return Lists.newArrayList(journalRecord);
-        }
         if (entityType == HOLDINGS) {
           return processHoldings(actionType, entityType, actionStatus, eventPayloadContext, record);
         }
@@ -98,6 +94,9 @@ public class JournalUtil {
         if (eventPayloadContext.get(MULTIPLE_ERRORS_KEY) != null) {
           return processErrors(actionType, entityType, actionStatus, eventPayloadContext, record);
         }
+      }
+      if (DI_ERROR == DataImportEventTypes.fromValue(eventPayload.getEventType())) {
+        journalRecord.setError(eventPayloadContext.get(ERROR_KEY));
       }
       return Lists.newArrayList(journalRecord);
     } catch (Exception e) {

--- a/mod-source-record-manager-server/src/main/java/org/folio/verticle/consumers/util/MarcImportEventsHandler.java
+++ b/mod-source-record-manager-server/src/main/java/org/folio/verticle/consumers/util/MarcImportEventsHandler.java
@@ -104,14 +104,16 @@ public class MarcImportEventsHandler implements SpecificEventHandler {
 
     if (journalParamsOptional.isPresent()) {
       JournalParams journalParams = journalParamsOptional.get();
-      JournalRecord journalRecord = JournalUtil.buildJournalRecordByEvent(eventPayload,
+      List<JournalRecord> journalRecords = JournalUtil.buildJournalRecordByEvent(eventPayload,
         journalParams.journalActionType, journalParams.journalEntityType, journalParams.journalActionStatus);
 
-      if (Objects.equals(journalRecord.getEntityType(), PO_LINE)) {
-        processJournalRecordForOrder(journalService, tenantId, journalRecord);
-      } else {
-        populateRecordTitleIfNeeded(journalRecord, eventPayload)
-          .onComplete(ar -> journalService.save(JsonObject.mapFrom(journalRecord), tenantId));
+      for (JournalRecord journalRecord : journalRecords) {
+        if (Objects.equals(journalRecord.getEntityType(), PO_LINE)) {
+          processJournalRecordForOrder(journalService, tenantId, journalRecord);
+        } else {
+          populateRecordTitleIfNeeded(journalRecord, eventPayload)
+            .onComplete(ar -> journalService.save(JsonObject.mapFrom(journalRecords), tenantId));
+        }
       }
     }
   }

--- a/mod-source-record-manager-server/src/main/resources/templates/db_scripts/schema.json
+++ b/mod-source-record-manager-server/src/main/resources/templates/db_scripts/schema.json
@@ -241,6 +241,11 @@
       "run": "after",
       "snippet": "ALTER TABLE journal_records ADD COLUMN IF NOT EXISTS order_id text;",
       "fromModuleVersion": "mod-source-record-manager-3.6.0"
+    },
+    {
+      "run": "after",
+      "snippet": "ALTER TABLE journal_records ADD COLUMN IF NOT EXISTS permanent_location_id text;",
+      "fromModuleVersion": "mod-source-record-manager-3.7.0"
     }
   ]
 }

--- a/mod-source-record-manager-server/src/test/java/org/folio/services/JournalUtilTest.java
+++ b/mod-source-record-manager-server/src/test/java/org/folio/services/JournalUtilTest.java
@@ -1,5 +1,6 @@
 package org.folio.services;
 
+import io.vertx.core.json.JsonArray;
 import io.vertx.core.json.JsonObject;
 import io.vertx.ext.unit.junit.VertxUnitRunner;
 import org.folio.DataImportEventPayload;
@@ -54,7 +55,7 @@ public class JournalUtilTest {
       .withEventType("DI_INVENTORY_INSTANCE_CREATED")
       .withContext(context);
 
-    List<JournalRecord>  journalRecord = JournalUtil.buildJournalRecordByEvent(eventPayload,
+    List<JournalRecord>  journalRecord = JournalUtil.buildJournalRecordsByEvent(eventPayload,
       CREATE, INSTANCE, COMPLETED);
 
     Assert.assertNotNull(journalRecord);
@@ -87,7 +88,7 @@ public class JournalUtilTest {
       .withEventType("DI_INVENTORY_INSTANCE_CREATED")
       .withContext(context);
 
-    JournalUtil.buildJournalRecordByEvent(eventPayload,
+    JournalUtil.buildJournalRecordsByEvent(eventPayload,
       CREATE, INSTANCE, COMPLETED);
   }
 
@@ -108,7 +109,7 @@ public class JournalUtilTest {
       .withEventType("DI_INVENTORY_HOLDING_NOT_MATCHED")
       .withContext(context);
 
-    List<JournalRecord> journalRecord = JournalUtil.buildJournalRecordByEvent(eventPayload,
+    List<JournalRecord> journalRecord = JournalUtil.buildJournalRecordsByEvent(eventPayload,
       NON_MATCH, HOLDINGS, COMPLETED);
 
     Assert.assertNotNull(journalRecord);
@@ -121,7 +122,7 @@ public class JournalUtilTest {
     Assert.assertNotNull(journalRecord.get(0).getActionDate());
   }
 
- /* @Test
+  @Test
   public void shouldBuildJournalRecordForHolding() throws JournalRecordMapperException {
     String instanceId = UUID.randomUUID().toString();
     String holdingsId = UUID.randomUUID().toString();
@@ -140,28 +141,31 @@ public class JournalUtilTest {
       .put("snapshotId", snapshotId)
       .put("order", 1);
 
+    JsonArray multipleHoldings = new JsonArray();
+    multipleHoldings.add(holdingsJson.encode());
+
     HashMap<String, String> context = new HashMap<>();
-    context.put(HOLDINGS.value(), holdingsJson.encode());
+    context.put(HOLDINGS.value(), String.valueOf(multipleHoldings.encode()));
     context.put(MARC_BIBLIOGRAPHIC.value(), recordJson.encode());
 
     DataImportEventPayload eventPayload = new DataImportEventPayload()
       .withEventType("DI_INVENTORY_HOLDING_CREATED")
       .withContext(context);
 
-    JournalRecord journalRecord = JournalUtil.buildJournalRecordByEvent(eventPayload,
+    List<JournalRecord> journalRecords = JournalUtil.buildJournalRecordsByEvent(eventPayload,
       CREATE, HOLDINGS, COMPLETED);
 
-    Assert.assertNotNull(journalRecord);
-    Assert.assertEquals(snapshotId, journalRecord.getJobExecutionId());
-    Assert.assertEquals(recordId, journalRecord.getSourceId());
-    Assert.assertEquals(1, journalRecord.getSourceRecordOrder().intValue());
-    Assert.assertEquals(HOLDINGS, journalRecord.getEntityType());
-    Assert.assertEquals(holdingsId, journalRecord.getEntityId());
-    Assert.assertEquals(holdingsHrid, journalRecord.getEntityHrId());
-    Assert.assertEquals(instanceId, journalRecord.getInstanceId());
-    Assert.assertEquals(CREATE, journalRecord.getActionType());
-    Assert.assertEquals(COMPLETED, journalRecord.getActionStatus());
-    Assert.assertNotNull(journalRecord.getActionDate());
+    Assert.assertNotNull(journalRecords);
+    Assert.assertEquals(snapshotId, journalRecords.get(0).getJobExecutionId());
+    Assert.assertEquals(recordId, journalRecords.get(0).getSourceId());
+    Assert.assertEquals(1, journalRecords.get(0).getSourceRecordOrder().intValue());
+    Assert.assertEquals(HOLDINGS, journalRecords.get(0).getEntityType());
+    Assert.assertEquals(holdingsId, journalRecords.get(0).getEntityId());
+    Assert.assertEquals(holdingsHrid, journalRecords.get(0).getEntityHrId());
+    Assert.assertEquals(instanceId, journalRecords.get(0).getInstanceId());
+    Assert.assertEquals(CREATE, journalRecords.get(0).getActionType());
+    Assert.assertEquals(COMPLETED, journalRecords.get(0).getActionStatus());
+    Assert.assertNotNull(journalRecords.get(0).getActionDate());
   }
 
   @Test
@@ -189,8 +193,11 @@ public class JournalUtilTest {
       .put("snapshotId", snapshotId)
       .put("order", 1);
 
+    JsonArray multipleItems = new JsonArray();
+    multipleItems.add(itemJson.encode());
+
     HashMap<String, String> context = new HashMap<>();
-    context.put(ITEM.value(), itemJson.encode());
+    context.put(ITEM.value(), String.valueOf(multipleItems));
     context.put(INSTANCE.value(), instanceJson.encode());
     context.put(MARC_BIBLIOGRAPHIC.value(), recordJson.encode());
 
@@ -198,21 +205,21 @@ public class JournalUtilTest {
       .withEventType("DI_INVENTORY_ITEM_CREATED")
       .withContext(context);
 
-    JournalRecord journalRecord = JournalUtil.buildJournalRecordByEvent(eventPayload,
+    List<JournalRecord> journalRecords = JournalUtil.buildJournalRecordsByEvent(eventPayload,
       CREATE, ITEM, COMPLETED);
 
-    Assert.assertNotNull(journalRecord);
-    Assert.assertEquals(snapshotId, journalRecord.getJobExecutionId());
-    Assert.assertEquals(recordId, journalRecord.getSourceId());
-    Assert.assertEquals(1, journalRecord.getSourceRecordOrder().intValue());
-    Assert.assertEquals(ITEM, journalRecord.getEntityType());
-    Assert.assertEquals(itemId, journalRecord.getEntityId());
-    Assert.assertEquals(itemHrid, journalRecord.getEntityHrId());
-    Assert.assertEquals(instanceId, journalRecord.getInstanceId());
-    Assert.assertEquals(holdingsId, journalRecord.getHoldingsId());
-    Assert.assertEquals(CREATE, journalRecord.getActionType());
-    Assert.assertEquals(COMPLETED, journalRecord.getActionStatus());
-    Assert.assertNotNull(journalRecord.getActionDate());
+    Assert.assertNotNull(journalRecords);
+    Assert.assertEquals(snapshotId, journalRecords.get(0).getJobExecutionId());
+    Assert.assertEquals(recordId, journalRecords.get(0).getSourceId());
+    Assert.assertEquals(1, journalRecords.get(0).getSourceRecordOrder().intValue());
+    Assert.assertEquals(ITEM, journalRecords.get(0).getEntityType());
+    Assert.assertEquals(itemId, journalRecords.get(0).getEntityId());
+    Assert.assertEquals(itemHrid, journalRecords.get(0).getEntityHrId());
+    Assert.assertEquals(instanceId, journalRecords.get(0).getInstanceId());
+    Assert.assertEquals(holdingsId, journalRecords.get(0).getHoldingsId());
+    Assert.assertEquals(CREATE, journalRecords.get(0).getActionType());
+    Assert.assertEquals(COMPLETED, journalRecords.get(0).getActionStatus());
+    Assert.assertNotNull(journalRecords.get(0).getActionDate());
   }
 
   @Test
@@ -241,31 +248,37 @@ public class JournalUtilTest {
       .put("snapshotId", snapshotId)
       .put("order", 1);
 
+    JsonArray multipleItems = new JsonArray();
+    multipleItems.add(itemJson.encode());
+
+    JsonArray multipleHoldings = new JsonArray();
+    multipleHoldings.add(holdingsJson.encode());
+
     HashMap<String, String> context = new HashMap<>();
-    context.put(ITEM.value(), itemJson.encode());
-    context.put(HOLDINGS.value(), holdingsJson.encode());
+    context.put(ITEM.value(), String.valueOf(multipleItems));
+    context.put(HOLDINGS.value(), String.valueOf(multipleHoldings));
     context.put(MARC_BIBLIOGRAPHIC.value(), recordJson.encode());
 
     DataImportEventPayload eventPayload = new DataImportEventPayload()
       .withEventType("DI_INVENTORY_ITEM_CREATED")
       .withContext(context);
 
-    JournalRecord journalRecord = JournalUtil.buildJournalRecordByEvent(eventPayload,
+    List<JournalRecord> journalRecords = JournalUtil.buildJournalRecordsByEvent(eventPayload,
       CREATE, ITEM, COMPLETED);
 
-    Assert.assertNotNull(journalRecord);
-    Assert.assertEquals(snapshotId, journalRecord.getJobExecutionId());
-    Assert.assertEquals(recordId, journalRecord.getSourceId());
-    Assert.assertEquals(1, journalRecord.getSourceRecordOrder().intValue());
-    Assert.assertEquals(ITEM, journalRecord.getEntityType());
-    Assert.assertEquals(itemId, journalRecord.getEntityId());
-    Assert.assertEquals(itemHrid, journalRecord.getEntityHrId());
-    Assert.assertEquals(instanceId, journalRecord.getInstanceId());
-    Assert.assertEquals(holdingsId, journalRecord.getHoldingsId());
-    Assert.assertEquals(CREATE, journalRecord.getActionType());
-    Assert.assertEquals(COMPLETED, journalRecord.getActionStatus());
-    Assert.assertNotNull(journalRecord.getActionDate());
-  }*/
+    Assert.assertNotNull(journalRecords);
+    Assert.assertEquals(snapshotId, journalRecords.get(0).getJobExecutionId());
+    Assert.assertEquals(recordId, journalRecords.get(0).getSourceId());
+    Assert.assertEquals(1, journalRecords.get(0).getSourceRecordOrder().intValue());
+    Assert.assertEquals(ITEM, journalRecords.get(0).getEntityType());
+    Assert.assertEquals(itemId, journalRecords.get(0).getEntityId());
+    Assert.assertEquals(itemHrid, journalRecords.get(0).getEntityHrId());
+    Assert.assertEquals(instanceId, journalRecords.get(0).getInstanceId());
+    Assert.assertEquals(holdingsId, journalRecords.get(0).getHoldingsId());
+    Assert.assertEquals(CREATE, journalRecords.get(0).getActionType());
+    Assert.assertEquals(COMPLETED, journalRecords.get(0).getActionStatus());
+    Assert.assertNotNull(journalRecords.get(0).getActionDate());
+  }
 
   @Test
   public void shouldBuildJournalRecordWhenNoRecord() throws JournalRecordMapperException {
@@ -279,7 +292,7 @@ public class JournalUtilTest {
       .withJobExecutionId(testJobExecutionId)
       .withContext(context);
 
-    List<JournalRecord> journalRecord = JournalUtil.buildJournalRecordByEvent(eventPayload,
+    List<JournalRecord> journalRecord = JournalUtil.buildJournalRecordsByEvent(eventPayload,
       CREATE, JournalRecord.EntityType.EDIFACT, COMPLETED);
 
     Assert.assertNotNull(journalRecord);
@@ -309,7 +322,7 @@ public class JournalUtilTest {
       .withEventType("DI_INVENTORY_INSTANCE_CREATED")
       .withContext(context);
 
-    List<JournalRecord> journalRecord = JournalUtil.buildJournalRecordByEvent(eventPayload,
+    List<JournalRecord> journalRecord = JournalUtil.buildJournalRecordsByEvent(eventPayload,
       CREATE, INSTANCE, COMPLETED);
 
     Assert.assertNotNull(journalRecord);
@@ -347,7 +360,7 @@ public class JournalUtilTest {
       .withEventsChain(Collections.singletonList("DI_ORDER_CREATED"))
       .withContext(context);
 
-    List<JournalRecord> journalRecord = JournalUtil.buildJournalRecordByEvent(eventPayload,
+    List<JournalRecord> journalRecord = JournalUtil.buildJournalRecordsByEvent(eventPayload,
       CREATE, PO_LINE, COMPLETED);
 
     Assert.assertNotNull(journalRecord);
@@ -360,5 +373,238 @@ public class JournalUtilTest {
     Assert.assertEquals(CREATE, journalRecord.get(0).getActionType());
     Assert.assertEquals(COMPLETED, journalRecord.get(0).getActionStatus());
     Assert.assertNotNull(journalRecord.get(0).getActionDate());
+  }
+
+  @Test
+  public void shouldBuildSeveralJournalRecordsForMultipleHolding() throws JournalRecordMapperException {
+    String instanceId = UUID.randomUUID().toString();
+    String firstHoldingsId = UUID.randomUUID().toString();
+    String secondHoldingsId = UUID.randomUUID().toString();
+    String firstHoldingsHrid = UUID.randomUUID().toString();
+    String secondHoldingsHrid = UUID.randomUUID().toString();
+    String firstPermanentLocationId = UUID.randomUUID().toString();
+    String secondPermanentLocationId = UUID.randomUUID().toString();
+
+    JsonObject firstHoldingsAsJson = new JsonObject()
+      .put("id", firstHoldingsId)
+      .put("hrid", firstHoldingsHrid)
+      .put("instanceId", instanceId)
+      .put("permanentLocationId", firstPermanentLocationId);
+
+    JsonObject secondHoldingsAsJson = new JsonObject()
+      .put("id", secondHoldingsId)
+      .put("hrid", secondHoldingsHrid)
+      .put("instanceId", instanceId)
+      .put("permanentLocationId", secondPermanentLocationId);
+
+    String recordId = UUID.randomUUID().toString();
+    String snapshotId = UUID.randomUUID().toString();
+
+    JsonObject recordJson = new JsonObject()
+      .put("id", recordId)
+      .put("snapshotId", snapshotId)
+      .put("order", 1);
+
+    JsonArray multipleHoldings = new JsonArray();
+    multipleHoldings.add(firstHoldingsAsJson.encode());
+    multipleHoldings.add(secondHoldingsAsJson.encode());
+
+
+    HashMap<String, String> context = new HashMap<>();
+    context.put(HOLDINGS.value(), String.valueOf(multipleHoldings.encode()));
+    context.put(MARC_BIBLIOGRAPHIC.value(), recordJson.encode());
+
+    DataImportEventPayload eventPayload = new DataImportEventPayload()
+      .withEventType("DI_INVENTORY_HOLDING_CREATED")
+      .withContext(context);
+
+    List<JournalRecord> journalRecords = JournalUtil.buildJournalRecordsByEvent(eventPayload,
+      CREATE, HOLDINGS, COMPLETED);
+
+    Assert.assertNotNull(journalRecords);
+    Assert.assertEquals(2, journalRecords.size());
+
+    Assert.assertEquals(snapshotId, journalRecords.get(0).getJobExecutionId());
+    Assert.assertEquals(recordId, journalRecords.get(0).getSourceId());
+    Assert.assertEquals(1, journalRecords.get(0).getSourceRecordOrder().intValue());
+    Assert.assertEquals(HOLDINGS, journalRecords.get(0).getEntityType());
+    Assert.assertEquals(firstHoldingsId, journalRecords.get(0).getEntityId());
+    Assert.assertEquals(firstHoldingsHrid, journalRecords.get(0).getEntityHrId());
+    Assert.assertEquals(instanceId, journalRecords.get(0).getInstanceId());
+    Assert.assertEquals(CREATE, journalRecords.get(0).getActionType());
+    Assert.assertEquals(COMPLETED, journalRecords.get(0).getActionStatus());
+    Assert.assertNotNull(journalRecords.get(0).getActionDate());
+    Assert.assertEquals(firstPermanentLocationId, journalRecords.get(0).getPermanentLocationId());
+
+    Assert.assertEquals(snapshotId, journalRecords.get(1).getJobExecutionId());
+    Assert.assertEquals(recordId, journalRecords.get(1).getSourceId());
+    Assert.assertEquals(1, journalRecords.get(1).getSourceRecordOrder().intValue());
+    Assert.assertEquals(HOLDINGS, journalRecords.get(1).getEntityType());
+    Assert.assertEquals(secondHoldingsId, journalRecords.get(1).getEntityId());
+    Assert.assertEquals(secondHoldingsHrid, journalRecords.get(1).getEntityHrId());
+    Assert.assertEquals(instanceId, journalRecords.get(1).getInstanceId());
+    Assert.assertEquals(CREATE, journalRecords.get(1).getActionType());
+    Assert.assertEquals(COMPLETED, journalRecords.get(1).getActionStatus());
+    Assert.assertNotNull(journalRecords.get(1).getActionDate());
+    Assert.assertEquals(secondPermanentLocationId, journalRecords.get(1).getPermanentLocationId());
+  }
+
+  @Test
+  public void shouldBuildSeveralJournalRecordForMultipleItemsWhenInstanceIsPopulated() throws JournalRecordMapperException {
+    String firstItemId = UUID.randomUUID().toString();
+    String firstItemHrid = UUID.randomUUID().toString();
+    String instanceId = UUID.randomUUID().toString();
+    String instanceHrid = UUID.randomUUID().toString();
+    String firstHoldingsId = UUID.randomUUID().toString();
+
+    String secondItemId = UUID.randomUUID().toString();
+    String secondItemHrid = UUID.randomUUID().toString();
+    String secondHoldingsId = UUID.randomUUID().toString();
+
+    JsonObject firstItemJson = new JsonObject()
+      .put("id", firstItemId)
+      .put("hrid", firstItemHrid)
+      .put("holdingsRecordId", firstHoldingsId);
+
+    JsonObject secondItemJson = new JsonObject()
+      .put("id", secondItemId)
+      .put("hrid", secondItemHrid)
+      .put("holdingsRecordId", secondHoldingsId);
+
+    JsonObject instanceJson = new JsonObject()
+      .put("id", instanceId)
+      .put("hrid", instanceHrid);
+
+    String recordId = UUID.randomUUID().toString();
+    String snapshotId = UUID.randomUUID().toString();
+
+    JsonObject recordJson = new JsonObject()
+      .put("id", recordId)
+      .put("snapshotId", snapshotId)
+      .put("order", 1);
+
+    JsonArray multipleItems = new JsonArray();
+    multipleItems.add(firstItemJson.encode());
+    multipleItems.add(secondItemJson.encode());
+
+
+    HashMap<String, String> context = new HashMap<>();
+    context.put(ITEM.value(), String.valueOf(multipleItems));
+    context.put(INSTANCE.value(), instanceJson.encode());
+    context.put(MARC_BIBLIOGRAPHIC.value(), recordJson.encode());
+
+    DataImportEventPayload eventPayload = new DataImportEventPayload()
+      .withEventType("DI_INVENTORY_ITEM_CREATED")
+      .withContext(context);
+
+    List<JournalRecord> journalRecords = JournalUtil.buildJournalRecordsByEvent(eventPayload,
+      CREATE, ITEM, COMPLETED);
+
+    Assert.assertNotNull(journalRecords);
+    Assert.assertEquals(2, journalRecords.size());
+
+    Assert.assertEquals(snapshotId, journalRecords.get(0).getJobExecutionId());
+    Assert.assertEquals(recordId, journalRecords.get(0).getSourceId());
+    Assert.assertEquals(1, journalRecords.get(0).getSourceRecordOrder().intValue());
+    Assert.assertEquals(ITEM, journalRecords.get(0).getEntityType());
+    Assert.assertEquals(firstItemId, journalRecords.get(0).getEntityId());
+    Assert.assertEquals(firstItemHrid, journalRecords.get(0).getEntityHrId());
+    Assert.assertEquals(instanceId, journalRecords.get(0).getInstanceId());
+    Assert.assertEquals(firstHoldingsId, journalRecords.get(0).getHoldingsId());
+    Assert.assertEquals(CREATE, journalRecords.get(0).getActionType());
+    Assert.assertEquals(COMPLETED, journalRecords.get(0).getActionStatus());
+    Assert.assertNotNull(journalRecords.get(0).getActionDate());
+
+    Assert.assertEquals(snapshotId, journalRecords.get(1).getJobExecutionId());
+    Assert.assertEquals(recordId, journalRecords.get(1).getSourceId());
+    Assert.assertEquals(1, journalRecords.get(1).getSourceRecordOrder().intValue());
+    Assert.assertEquals(ITEM, journalRecords.get(1).getEntityType());
+    Assert.assertEquals(secondItemId, journalRecords.get(1).getEntityId());
+    Assert.assertEquals(secondItemHrid, journalRecords.get(1).getEntityHrId());
+    Assert.assertEquals(instanceId, journalRecords.get(1).getInstanceId());
+    Assert.assertEquals(secondHoldingsId, journalRecords.get(1).getHoldingsId());
+    Assert.assertEquals(CREATE, journalRecords.get(1).getActionType());
+    Assert.assertEquals(COMPLETED, journalRecords.get(1).getActionStatus());
+    Assert.assertNotNull(journalRecords.get(1).getActionDate());
+  }
+
+  @Test
+  public void shouldBuildSeveralJournalRecordsForMultipleItemsWhenInstanceIsNotPopulatedAndItemsAreInTheSameHolding() throws JournalRecordMapperException {
+    String firstItemId = UUID.randomUUID().toString();
+    String firstItemHrid = UUID.randomUUID().toString();
+    String secondItemId = UUID.randomUUID().toString();
+    String secondItemHrid = UUID.randomUUID().toString();
+    String instanceId = UUID.randomUUID().toString();
+    String holdingsId = UUID.randomUUID().toString();
+    String holdingsHrid = UUID.randomUUID().toString();
+
+    JsonObject firstItemJson = new JsonObject()
+      .put("id", firstItemId)
+      .put("hrid", firstItemHrid)
+      .put("holdingsRecordId", holdingsId);
+
+    JsonObject secondItemJson = new JsonObject()
+      .put("id", secondItemId)
+      .put("hrid", secondItemHrid)
+      .put("holdingsRecordId", holdingsId);
+
+    JsonObject holdingsJson = new JsonObject()
+      .put("id", holdingsId)
+      .put("hrid", holdingsHrid)
+      .put("instanceId", instanceId);
+
+    String recordId = UUID.randomUUID().toString();
+    String snapshotId = UUID.randomUUID().toString();
+
+    JsonObject recordJson = new JsonObject()
+      .put("id", recordId)
+      .put("snapshotId", snapshotId)
+      .put("order", 1);
+
+    JsonArray multipleItems = new JsonArray();
+    multipleItems.add(firstItemJson.encode());
+    multipleItems.add(secondItemJson.encode());
+
+    JsonArray multipleHoldings = new JsonArray();
+    multipleHoldings.add(holdingsJson.encode());
+
+    HashMap<String, String> context = new HashMap<>();
+    context.put(ITEM.value(), String.valueOf(multipleItems));
+    context.put(HOLDINGS.value(), String.valueOf(multipleHoldings));
+    context.put(MARC_BIBLIOGRAPHIC.value(), recordJson.encode());
+
+    DataImportEventPayload eventPayload = new DataImportEventPayload()
+      .withEventType("DI_INVENTORY_ITEM_CREATED")
+      .withContext(context);
+
+    List<JournalRecord> journalRecords = JournalUtil.buildJournalRecordsByEvent(eventPayload,
+      CREATE, ITEM, COMPLETED);
+
+    Assert.assertNotNull(journalRecords);
+    Assert.assertEquals(2, journalRecords.size());
+
+    Assert.assertEquals(snapshotId, journalRecords.get(0).getJobExecutionId());
+    Assert.assertEquals(recordId, journalRecords.get(0).getSourceId());
+    Assert.assertEquals(1, journalRecords.get(0).getSourceRecordOrder().intValue());
+    Assert.assertEquals(ITEM, journalRecords.get(0).getEntityType());
+    Assert.assertEquals(firstItemId, journalRecords.get(0).getEntityId());
+    Assert.assertEquals(firstItemHrid, journalRecords.get(0).getEntityHrId());
+    Assert.assertEquals(instanceId, journalRecords.get(0).getInstanceId());
+    Assert.assertEquals(holdingsId, journalRecords.get(0).getHoldingsId());
+    Assert.assertEquals(CREATE, journalRecords.get(0).getActionType());
+    Assert.assertEquals(COMPLETED, journalRecords.get(0).getActionStatus());
+    Assert.assertNotNull(journalRecords.get(0).getActionDate());
+
+    Assert.assertEquals(snapshotId, journalRecords.get(1).getJobExecutionId());
+    Assert.assertEquals(recordId, journalRecords.get(1).getSourceId());
+    Assert.assertEquals(1, journalRecords.get(1).getSourceRecordOrder().intValue());
+    Assert.assertEquals(ITEM, journalRecords.get(1).getEntityType());
+    Assert.assertEquals(secondItemId, journalRecords.get(1).getEntityId());
+    Assert.assertEquals(secondItemHrid, journalRecords.get(1).getEntityHrId());
+    Assert.assertEquals(instanceId, journalRecords.get(1).getInstanceId());
+    Assert.assertEquals(holdingsId, journalRecords.get(1).getHoldingsId());
+    Assert.assertEquals(CREATE, journalRecords.get(1).getActionType());
+    Assert.assertEquals(COMPLETED, journalRecords.get(1).getActionStatus());
+    Assert.assertNotNull(journalRecords.get(1).getActionDate());
   }
 }

--- a/mod-source-record-manager-server/src/test/java/org/folio/services/JournalUtilTest.java
+++ b/mod-source-record-manager-server/src/test/java/org/folio/services/JournalUtilTest.java
@@ -265,7 +265,7 @@ public class JournalUtilTest {
     Assert.assertEquals(CREATE, journalRecord.getActionType());
     Assert.assertEquals(COMPLETED, journalRecord.getActionStatus());
     Assert.assertNotNull(journalRecord.getActionDate());
-  }
+  }*/
 
   @Test
   public void shouldBuildJournalRecordWhenNoRecord() throws JournalRecordMapperException {
@@ -279,17 +279,17 @@ public class JournalUtilTest {
       .withJobExecutionId(testJobExecutionId)
       .withContext(context);
 
-    JournalRecord journalRecord = JournalUtil.buildJournalRecordByEvent(eventPayload,
+    List<JournalRecord> journalRecord = JournalUtil.buildJournalRecordByEvent(eventPayload,
       CREATE, JournalRecord.EntityType.EDIFACT, COMPLETED);
 
     Assert.assertNotNull(journalRecord);
-    Assert.assertEquals(0, journalRecord.getSourceRecordOrder().intValue());
-    Assert.assertEquals(testError, journalRecord.getError());
-    Assert.assertEquals(testJobExecutionId, journalRecord.getJobExecutionId());
-    Assert.assertEquals(JournalRecord.EntityType.EDIFACT, journalRecord.getEntityType());
-    Assert.assertEquals(CREATE, journalRecord.getActionType());
-    Assert.assertEquals(COMPLETED, journalRecord.getActionStatus());
-    Assert.assertNotNull(journalRecord.getActionDate());
+    Assert.assertEquals(0, journalRecord.get(0).getSourceRecordOrder().intValue());
+    Assert.assertEquals(testError, journalRecord.get(0).getError());
+    Assert.assertEquals(testJobExecutionId, journalRecord.get(0).getJobExecutionId());
+    Assert.assertEquals(JournalRecord.EntityType.EDIFACT, journalRecord.get(0).getEntityType());
+    Assert.assertEquals(CREATE, journalRecord.get(0).getActionType());
+    Assert.assertEquals(COMPLETED, journalRecord.get(0).getActionStatus());
+    Assert.assertNotNull(journalRecord.get(0).getActionDate());
   }
 
   @Test
@@ -309,17 +309,17 @@ public class JournalUtilTest {
       .withEventType("DI_INVENTORY_INSTANCE_CREATED")
       .withContext(context);
 
-    JournalRecord journalRecord = JournalUtil.buildJournalRecordByEvent(eventPayload,
+    List<JournalRecord> journalRecord = JournalUtil.buildJournalRecordByEvent(eventPayload,
       CREATE, INSTANCE, COMPLETED);
 
     Assert.assertNotNull(journalRecord);
-    Assert.assertEquals(snapshotId, journalRecord.getJobExecutionId());
-    Assert.assertEquals(recordId, journalRecord.getSourceId());
-    Assert.assertEquals(1, journalRecord.getSourceRecordOrder().intValue());
-    Assert.assertEquals(INSTANCE, journalRecord.getEntityType());
-    Assert.assertEquals(CREATE, journalRecord.getActionType());
-    Assert.assertEquals(COMPLETED, journalRecord.getActionStatus());
-    Assert.assertNotNull(journalRecord.getActionDate());
+    Assert.assertEquals(snapshotId, journalRecord.get(0).getJobExecutionId());
+    Assert.assertEquals(recordId, journalRecord.get(0).getSourceId());
+    Assert.assertEquals(1, journalRecord.get(0).getSourceRecordOrder().intValue());
+    Assert.assertEquals(INSTANCE, journalRecord.get(0).getEntityType());
+    Assert.assertEquals(CREATE, journalRecord.get(0).getActionType());
+    Assert.assertEquals(COMPLETED, journalRecord.get(0).getActionStatus());
+    Assert.assertNotNull(journalRecord.get(0).getActionDate());
   }
 
   @Test
@@ -347,18 +347,18 @@ public class JournalUtilTest {
       .withEventsChain(Collections.singletonList("DI_ORDER_CREATED"))
       .withContext(context);
 
-    JournalRecord journalRecord = JournalUtil.buildJournalRecordByEvent(eventPayload,
+    List<JournalRecord> journalRecord = JournalUtil.buildJournalRecordByEvent(eventPayload,
       CREATE, PO_LINE, COMPLETED);
 
     Assert.assertNotNull(journalRecord);
-    Assert.assertEquals(snapshotId, journalRecord.getJobExecutionId());
-    Assert.assertEquals(recordId, journalRecord.getSourceId());
-    Assert.assertEquals(entityId, journalRecord.getEntityId());
-    Assert.assertEquals(purchaseOrderId, journalRecord.getOrderId());
-    Assert.assertEquals(1, journalRecord.getSourceRecordOrder().intValue());
-    Assert.assertEquals(PO_LINE, journalRecord.getEntityType());
-    Assert.assertEquals(CREATE, journalRecord.getActionType());
-    Assert.assertEquals(COMPLETED, journalRecord.getActionStatus());
-    Assert.assertNotNull(journalRecord.getActionDate());
-  }*/
+    Assert.assertEquals(snapshotId, journalRecord.get(0).getJobExecutionId());
+    Assert.assertEquals(recordId, journalRecord.get(0).getSourceId());
+    Assert.assertEquals(entityId, journalRecord.get(0).getEntityId());
+    Assert.assertEquals(purchaseOrderId, journalRecord.get(0).getOrderId());
+    Assert.assertEquals(1, journalRecord.get(0).getSourceRecordOrder().intValue());
+    Assert.assertEquals(PO_LINE, journalRecord.get(0).getEntityType());
+    Assert.assertEquals(CREATE, journalRecord.get(0).getActionType());
+    Assert.assertEquals(COMPLETED, journalRecord.get(0).getActionStatus());
+    Assert.assertNotNull(journalRecord.get(0).getActionDate());
+  }
 }

--- a/mod-source-record-manager-server/src/test/java/org/folio/services/JournalUtilTest.java
+++ b/mod-source-record-manager-server/src/test/java/org/folio/services/JournalUtilTest.java
@@ -12,6 +12,7 @@ import org.junit.runner.RunWith;
 
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.List;
 import java.util.UUID;
 
 import static org.folio.DataImportEventTypes.DI_ERROR;
@@ -53,19 +54,19 @@ public class JournalUtilTest {
       .withEventType("DI_INVENTORY_INSTANCE_CREATED")
       .withContext(context);
 
-    JournalRecord journalRecord = JournalUtil.buildJournalRecordByEvent(eventPayload,
+    List<JournalRecord>  journalRecord = JournalUtil.buildJournalRecordByEvent(eventPayload,
       CREATE, INSTANCE, COMPLETED);
 
     Assert.assertNotNull(journalRecord);
-    Assert.assertEquals(snapshotId, journalRecord.getJobExecutionId());
-    Assert.assertEquals(recordId, journalRecord.getSourceId());
-    Assert.assertEquals(1, journalRecord.getSourceRecordOrder().intValue());
-    Assert.assertEquals(INSTANCE, journalRecord.getEntityType());
-    Assert.assertEquals(instanceId, journalRecord.getEntityId());
-    Assert.assertEquals(instanceHrid, journalRecord.getEntityHrId());
-    Assert.assertEquals(CREATE, journalRecord.getActionType());
-    Assert.assertEquals(COMPLETED, journalRecord.getActionStatus());
-    Assert.assertNotNull(journalRecord.getActionDate());
+    Assert.assertEquals(snapshotId, journalRecord.get(0).getJobExecutionId());
+    Assert.assertEquals(recordId, journalRecord.get(0).getSourceId());
+    Assert.assertEquals(1, journalRecord.get(0).getSourceRecordOrder().intValue());
+    Assert.assertEquals(INSTANCE, journalRecord.get(0).getEntityType());
+    Assert.assertEquals(instanceId, journalRecord.get(0).getEntityId());
+    Assert.assertEquals(instanceHrid, journalRecord.get(0).getEntityHrId());
+    Assert.assertEquals(CREATE, journalRecord.get(0).getActionType());
+    Assert.assertEquals(COMPLETED, journalRecord.get(0).getActionStatus());
+    Assert.assertNotNull(journalRecord.get(0).getActionDate());
   }
 
   @Test(expected = JournalRecordMapperException.class)
@@ -107,20 +108,20 @@ public class JournalUtilTest {
       .withEventType("DI_INVENTORY_HOLDING_NOT_MATCHED")
       .withContext(context);
 
-    JournalRecord journalRecord = JournalUtil.buildJournalRecordByEvent(eventPayload,
+    List<JournalRecord> journalRecord = JournalUtil.buildJournalRecordByEvent(eventPayload,
       NON_MATCH, HOLDINGS, COMPLETED);
 
     Assert.assertNotNull(journalRecord);
-    Assert.assertEquals(snapshotId, journalRecord.getJobExecutionId());
-    Assert.assertEquals(recordId, journalRecord.getSourceId());
-    Assert.assertEquals(1, journalRecord.getSourceRecordOrder().intValue());
-    Assert.assertEquals(HOLDINGS, journalRecord.getEntityType());
-    Assert.assertEquals(NON_MATCH, journalRecord.getActionType());
-    Assert.assertEquals(COMPLETED, journalRecord.getActionStatus());
-    Assert.assertNotNull(journalRecord.getActionDate());
+    Assert.assertEquals(snapshotId, journalRecord.get(0).getJobExecutionId());
+    Assert.assertEquals(recordId, journalRecord.get(0).getSourceId());
+    Assert.assertEquals(1, journalRecord.get(0).getSourceRecordOrder().intValue());
+    Assert.assertEquals(HOLDINGS, journalRecord.get(0).getEntityType());
+    Assert.assertEquals(NON_MATCH, journalRecord.get(0).getActionType());
+    Assert.assertEquals(COMPLETED, journalRecord.get(0).getActionStatus());
+    Assert.assertNotNull(journalRecord.get(0).getActionDate());
   }
 
-  @Test
+ /* @Test
   public void shouldBuildJournalRecordForHolding() throws JournalRecordMapperException {
     String instanceId = UUID.randomUUID().toString();
     String holdingsId = UUID.randomUUID().toString();
@@ -359,5 +360,5 @@ public class JournalUtilTest {
     Assert.assertEquals(CREATE, journalRecord.getActionType());
     Assert.assertEquals(COMPLETED, journalRecord.getActionStatus());
     Assert.assertNotNull(journalRecord.getActionDate());
-  }
+  }*/
 }

--- a/mod-source-record-manager-server/src/test/java/org/folio/verticle/consumers/util/MarcImportEventsHandlerTest.java
+++ b/mod-source-record-manager-server/src/test/java/org/folio/verticle/consumers/util/MarcImportEventsHandlerTest.java
@@ -29,6 +29,7 @@ import java.util.concurrent.CompletableFuture;
 
 import io.vertx.core.Future;
 import io.vertx.core.json.Json;
+import io.vertx.core.json.JsonArray;
 import io.vertx.core.json.JsonObject;
 import io.vertx.ext.unit.junit.VertxUnitRunner;
 import org.folio.services.JournalRecordService;
@@ -60,7 +61,7 @@ public class MarcImportEventsHandlerTest {
   private final MarcFactory marcFactory = MarcFactory.newInstance();
 
   @Captor
-  private ArgumentCaptor<JsonObject> journalRecordCaptor;
+  private ArgumentCaptor<JsonArray> journalRecordCaptor;
   @Mock
   private MappingRuleCache mappingRuleCache;
   @Mock
@@ -96,8 +97,8 @@ public class MarcImportEventsHandlerTest {
 
     handler.handle(journalService, payload, TEST_TENANT);
 
-    verify(journalService).save(journalRecordCaptor.capture(), eq(TEST_TENANT));
-    var actualJournalRecord = journalRecordCaptor.getValue().mapTo(JournalRecord.class);
+    verify(journalService).saveBatch(journalRecordCaptor.capture(), eq(TEST_TENANT));
+    var actualJournalRecord = journalRecordCaptor.getValue().getJsonObject(0).mapTo(JournalRecord.class);
 
     assertEquals(expectedTitleStart + " " + expectedTitleEnd, actualJournalRecord.getTitle());
   }
@@ -116,8 +117,8 @@ public class MarcImportEventsHandlerTest {
 
     handler.handle(journalService, payload, TEST_TENANT);
 
-    verify(journalService).save(journalRecordCaptor.capture(), eq(TEST_TENANT));
-    var actualJournalRecord = journalRecordCaptor.getValue().mapTo(JournalRecord.class);
+    verify(journalService).saveBatch(journalRecordCaptor.capture(), eq(TEST_TENANT));
+    var actualJournalRecord = journalRecordCaptor.getValue().getJsonObject(0).mapTo(JournalRecord.class);
 
     assertEquals(expectedTitleStart + " " + expectedTitleEnd, actualJournalRecord.getTitle());
   }
@@ -137,8 +138,8 @@ public class MarcImportEventsHandlerTest {
     var payload = constructUpdateItemPayload(marcRecord);
     handler.handle(journalService, payload, TEST_TENANT);
 
-    verify(journalService).save(journalRecordCaptor.capture(), eq(TEST_TENANT));
-    var actualJournalRecord = journalRecordCaptor.getValue().mapTo(JournalRecord.class);
+    verify(journalService).saveBatch(journalRecordCaptor.capture(), eq(TEST_TENANT));
+    var actualJournalRecord = journalRecordCaptor.getValue().getJsonObject(0).mapTo(JournalRecord.class);
 
     assertEquals(title, actualJournalRecord.getTitle());
   }
@@ -158,8 +159,8 @@ public class MarcImportEventsHandlerTest {
     var payload = constructUpdateHoldingsPayload(marcRecord);
     handler.handle(journalService, payload, TEST_TENANT);
 
-    verify(journalService).save(journalRecordCaptor.capture(), eq(TEST_TENANT));
-    var actualJournalRecord = journalRecordCaptor.getValue().mapTo(JournalRecord.class);
+    verify(journalService).saveBatch(journalRecordCaptor.capture(), eq(TEST_TENANT));
+    var actualJournalRecord = journalRecordCaptor.getValue().getJsonObject(0).mapTo(JournalRecord.class);
 
     assertEquals(title, actualJournalRecord.getTitle());
   }
@@ -192,8 +193,8 @@ public class MarcImportEventsHandlerTest {
     var payload = constructCreateErrorPOLinePayloadWithoutOrderId(marcRecord);
     handler.handle(journalService, payload, TEST_TENANT);
 
-    verify(journalService).save(journalRecordCaptor.capture(), eq(TEST_TENANT));
-    var actualJournalRecord = journalRecordCaptor.getValue().mapTo(JournalRecord.class);
+    verify(journalService).saveBatch(journalRecordCaptor.capture(), eq(TEST_TENANT));
+    var actualJournalRecord = journalRecordCaptor.getValue().getJsonObject(0).mapTo(JournalRecord.class);
     verify(journalRecordService, times(0)).updateErrorJournalRecordsByOrderIdAndJobExecution(anyString(), anyString(), anyString(), anyString());
 
     assertNull(actualJournalRecord.getTitle());
@@ -216,10 +217,10 @@ public class MarcImportEventsHandlerTest {
     handler.handle(journalService, payload, TEST_TENANT);
 
     verify(journalRecordService).updateErrorJournalRecordsByOrderIdAndJobExecution(anyString(), anyString(), anyString(), anyString());
-    verify(journalService).save(journalRecordCaptor.capture(), eq(TEST_TENANT));
+    verify(journalService).saveBatch(journalRecordCaptor.capture(), eq(TEST_TENANT));
     verify(journalRecordService, times(1)).updateErrorJournalRecordsByOrderIdAndJobExecution(anyString(), anyString(), anyString(), anyString());
 
-    var actualJournalRecord = journalRecordCaptor.getValue().mapTo(JournalRecord.class);
+    var actualJournalRecord = journalRecordCaptor.getValue().getJsonObject(0).mapTo(JournalRecord.class);
 
     assertNull(actualJournalRecord.getTitle());
   }


### PR DESCRIPTION
## Purpose
Improve logic in srm to be able build and save JournalRecord for Multiple Holdins/Items.
Add a mechanism for the multiple "ERRORS" handling.


## Approach
Extend journal_records table to contain column for Holdings permanent location.
DI_INVENTORY_HOLDING_CREATED, DI_INVENTORY_HOLDING_UPDATED, DI_INVENTORY_ITEM_CREATED, DI_INVENTORY_ITEM_UPDATED, DI_COMPLETED events can contain list of successfully created/updated Holdings/Items and a list of errors if some of the Holdings/Items couldn't be created/updated.

Make changes in MarcImportEventsHandler to allow building multiple journal records for each successfully created/updated entity and for each error.

Examples of errors in DataImportEventPayload:

```
ERRORS: [{
id: "123",
error: "aaaaa"},
{
id: "234",
error: "aaaaa"
}]
```

## Learning
JIRA: https://issues.folio.org/browse/MODSOURMAN-971
