### PR TITLE
MODSOURMAN-965: Adjust progress tracking mechanism with regard to multiple values being created

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,7 @@
 ## 2023-03-xo v3.6.1-SNAPSHOT
 * [MODSOURMAN-957](https://issues.folio.org/browse/MODSOURMAN-957) The '1' number of SRS MARC and Instance are displayed in cells in the row with the 'Updated' row header at the individual import job's log
 * [MODDATAIMP-786](https://issues.folio.org/browse/MODDATAIMP-786) Update data-import-util library to v1.11.0
+* [MODSOURMAN-965](https://issues.folio.org/browse/MODSOURMAN-965) Adjust progress tracking mechanism with regard to multiple values being created
 
 ## 2023-02-24 v3.6.0
 * [MODSOURMAN-873](https://issues.folio.org/browse/MODSOURMAN-873) Add MARC 720 field to default MARC Bib-Instance mapping and adjust relator term mapping

--- a/mod-source-record-manager-server/src/main/java/org/folio/services/RecordProcessedEventHandlingServiceImpl.java
+++ b/mod-source-record-manager-server/src/main/java/org/folio/services/RecordProcessedEventHandlingServiceImpl.java
@@ -29,6 +29,7 @@ public class RecordProcessedEventHandlingServiceImpl implements EventHandlingSer
 
   private static final Logger LOGGER = LogManager.getLogger();
   public static final String ERROR_KEY = "ERROR";
+  public static final String ERRORS_KEY = "ERRORS";
 
   private JobExecutionProgressService jobExecutionProgressService;
   private JobExecutionService jobExecutionService;
@@ -57,7 +58,11 @@ public class RecordProcessedEventHandlingServiceImpl implements EventHandlingSer
       int successCount= 0;
       int errorCount = 0;
       if (DataImportEventTypes.DI_COMPLETED.equals(eventType)) {
-        successCount++;
+        if (dataImportEventPayload.getContext().containsKey(ERRORS_KEY)) {
+          errorCount++;
+        } else {
+          successCount++;
+        }
       } else if (DataImportEventTypes.DI_ERROR.equals(eventType)) {
         errorCount++;
       } else {

--- a/mod-source-record-manager-server/src/test/java/org/folio/services/RecordProcessedEventHandlingServiceImplTest.java
+++ b/mod-source-record-manager-server/src/test/java/org/folio/services/RecordProcessedEventHandlingServiceImplTest.java
@@ -450,52 +450,5 @@ public class RecordProcessedEventHandlingServiceImplTest extends AbstractRestTes
         });
       async.complete();
     });
-
- /*   // given
-    Async async = context.async();
-    RawRecordsDto rawRecordsDto = new RawRecordsDto()
-      .withInitialRecords(Collections.singletonList(new InitialRecord().withRecord(CORRECT_RAW_RECORD)))
-      .withRecordsMetadata(new RecordsMetadata()
-        .withLast(true)
-        .withCounter(2)
-        .withTotal(2)
-        .withContentType(RecordsMetadata.ContentType.MARC_RAW));
-
-    HashMap<String, String> payloadContext = new HashMap<>();
-    DataImportEventPayload datImpErrorEventPayload = new DataImportEventPayload()
-      .withEventType(DataImportEventTypes.DI_ERROR.value())
-      .withContext(payloadContext);
-
-
-    DataImportEventPayload datImpCompletedEventPayload = new DataImportEventPayload()
-      .withEventType(DataImportEventTypes.DI_COMPLETED.value())
-      .withContext(payloadContext);
-
-    Future<Boolean> future = jobExecutionService.initializeJobExecutions(initJobExecutionsRqDto, params)
-      .compose(initJobExecutionsRsDto -> jobExecutionService.setJobProfileToJobExecution(initJobExecutionsRsDto.getParentJobExecutionId(), jobProfileInfo, params))
-      .map(jobExecution -> {
-        datImpErrorEventPayload.withJobExecutionId(jobExecution.getId());
-        return datImpCompletedEventPayload.withJobExecutionId(jobExecution.getId());
-      })
-      .compose(ar -> chunkProcessingService.processChunk(rawRecordsDto, datImpErrorEventPayload.getJobExecutionId(), params));
-
-    // when
-    Future<Optional<JobExecution>> jobFuture = future
-      .compose(ar -> recordProcessedEventHandlingService.handle(Json.encode(datImpCompletedEventPayload), params))
-      .compose(ar -> jobExecutionService.getJobExecutionById(datImpCompletedEventPayload.getJobExecutionId(), TENANT_ID));
-
-    // then
-    jobFuture.onComplete(ar -> {
-      context.assertTrue(ar.succeeded());
-      context.assertTrue(ar.result().isPresent());
-      JobExecution jobExecution = ar.result().get();
-      context.assertEquals(ERROR, jobExecution.getStatus());
-      context.assertEquals(JobExecution.UiStatus.ERROR, jobExecution.getUiStatus());
-      context.assertEquals(rawRecordsDto.getRecordsMetadata().getTotal(), jobExecution.getProgress().getTotal());
-      context.assertNotNull(jobExecution.getStartedDate());
-      context.assertNotNull(jobExecution.getCompletedDate());
-      verify(2, putRequestedFor(new UrlPathPattern(new RegexPattern(SNAPSHOT_SERVICE_URL + "/.*"), true)));
-      async.complete();
-    });*/
   }
 }


### PR DESCRIPTION
## Purpose
One event would be issued when multiple Holdings or Items were created, DI should also support partial success - in case at least one of the Holdings or Items were created/updated, further processing of the profile for the given record should be continued. Therefore, DI_COMPLETED event payload will contain a list of successfully created entities and a list of errors. In case at least one of the entities failed to be created/updated it should be counted as an error upon completion.

## Approach
Added logic in RecordProcessedEventHandlingServiceImpl to check payload of DI_COMPLETED event and count it as an error in case at least one error present (there is something by the key ERROR in the event payload)


## Learning
JIRA: https://issues.folio.org/browse/MODSOURMAN-965