### PR TITLE
MODSOURMAN-974 MARC bib $9 handling | Remove $9 subfields from linkable fields

### DIFF
--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -77,10 +77,6 @@
     {
       "id": "authority-source-files",
       "version": "1.0"
-    },
-    {
-      "id": "instance-authority-linking-rules",
-      "version": "1.0"
     }
   ],
   "provides": [
@@ -543,6 +539,12 @@
           "permissionsRequired": []
         }
       ]
+    }
+  ],
+  "optional": [
+    {
+      "id": "instance-authority-linking-rules",
+      "version": "1.0"
     }
   ],
   "permissionSets": [


### PR DESCRIPTION
## Purpose
Move linking-rules interface dependency from "required" to optional

## Approach
Move linking-rules interface dependency from "required" to optional

#### TODOS and Open Questions
- [ ] Use GitHub checklists. When solved, check the box and explain the answer.
- [ ] Check logging.
## Learning
[MODSOURMAN-974](https://issues.folio.org/browse/MODSOURMAN-974)
