### PR TITLE
MODSOURMAN-990 Fix call number type doesn't map from MARC

### DIFF
--- a/mod-source-record-manager-server/src/main/resources/rules/marc_holdings_rules.json
+++ b/mod-source-record-manager-server/src/main/resources/rules/marc_holdings_rules.json
@@ -455,6 +455,7 @@
           "target": "callNumberTypeId",
           "description": "Call number type, defined by 1st indicator",
           "subfield": [
+            "b"
           ],
           "rules": [
             {

--- a/mod-source-record-manager-server/src/test/java/org/folio/mapping/DefaultRulesMappingTest.java
+++ b/mod-source-record-manager-server/src/test/java/org/folio/mapping/DefaultRulesMappingTest.java
@@ -2,6 +2,8 @@ package org.folio.mapping;
 
 import io.vertx.core.json.JsonObject;
 import java.io.IOException;
+import java.util.List;
+import org.folio.CallNumberType;
 import org.folio.TestUtil;
 import org.folio.processing.mapping.defaultmapper.RecordMapper;
 import org.folio.processing.mapping.defaultmapper.RecordMapperBuilder;
@@ -36,7 +38,8 @@ public class DefaultRulesMappingTest {
     JsonObject mappingRules = readJson(DEFAULT_RULES_PATH + "marc_holdings_rules.json");
 
 
-    var actualHoldings = mapper.mapRecord(parsedRecord, new MappingParameters(), mappingRules);
+    var actualHoldings = mapper.mapRecord(parsedRecord, new MappingParameters()
+      .withCallNumberTypes(getCallNumberTypeRefs()), mappingRules);
     Assert.assertEquals(expectedMappedHoldings.encode(), JsonObject.mapFrom(actualHoldings).put("id", "0").encode());
   }
 
@@ -50,6 +53,13 @@ public class DefaultRulesMappingTest {
 
     var actualAuthority = mapper.mapRecord(parsedRecord, new MappingParameters(), mappingRules);
     Assert.assertEquals(expectedMappedAuthority.encode(), JsonObject.mapFrom(actualAuthority).encode());
+  }
+
+  private List<CallNumberType> getCallNumberTypeRefs(){
+    return List.of(
+      new CallNumberType().withName("Library of Congress classification")
+        .withId("95467209-6d7b-468b-94df-0f5d7ad2747d")
+    );
   }
 
   private JsonObject readJson(String filePath) throws IOException {

--- a/mod-source-record-manager-server/src/test/resources/org/folio/mapping/mappedHoldingsRecord.json
+++ b/mod-source-record-manager-server/src/test/resources/org/folio/mapping/mappedHoldingsRecord.json
@@ -17,6 +17,7 @@
       "relationshipId": "fe19bae4-da28-472b-be90-d442e2428ead"
     }
   ],
+  "callNumberTypeId": "95467209-6d7b-468b-94df-0f5d7ad2747d",
   "callNumber": "M3 .M93 1955",
   "callNumberSuffix": "+",
   "notes": [


### PR DESCRIPTION
## Purpose
Fix bug when call number type doesn't map from MARC

## Approach
The mapping processor did not process the call-number-type rule because it requires the presence of subfields in the rule. If there are no subfields, the rule is skipped. To resolve this issue, I have added a reference to the "b" subfield, as it is required for Holdings records.
