### PR TITLE
MODSOURMAN-1011: Import An Instance With A Known Identifier

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,4 +1,5 @@
 ## 2023-xx-xx v3.7.0-SNAPSHOT
+* [MODSOURMAN-1011](https://issues.folio.org/browse/MODSOURMAN-1011) Import An Instance With A Known Identifier (new acceptInstanceId parameter)
 * [MODSOURMAN-999](https://issues.folio.org/browse/MODSOURMAN-999) Upgrade mod-source-record-manager to Java 17
 * [MODSOURMAN-974](https://issues.folio.org/browse/MODSOURMAN-974) MARC bib $9 handling | Remove $9 subfields from linkable fields
 

--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -253,7 +253,7 @@
     },
     {
       "id": "source-manager-records",
-      "version": "2.0",
+      "version": "2.1",
       "handlers": [
         {
           "methods": [

--- a/mod-source-record-manager-server/src/main/java/org/folio/rest/impl/ChangeManagerImpl.java
+++ b/mod-source-record-manager-server/src/main/java/org/folio/rest/impl/ChangeManagerImpl.java
@@ -193,14 +193,15 @@ public class ChangeManagerImpl implements ChangeManager {
   }
 
   @Override
-  public void postChangeManagerJobExecutionsRecordsById(String id, RawRecordsDto entity, Map<String, String> okapiHeaders,
+  public void postChangeManagerJobExecutionsRecordsById(String id, boolean acceptInstanceId, RawRecordsDto entity,
+                                                        Map<String, String> okapiHeaders,
                                                         Handler<AsyncResult<Response>> asyncResultHandler, Context vertxContext) {
     vertxContext.runOnContext(v -> {
       try {
         LOGGER.debug("putChangeManagerJobExecutionsJobProfileById:: jobExecutionId {}, rawRecordsId {}", id, entity.getId());
         okapiHeaders.put(CHUNK_ID_HEADER, entity.getId());
         OkapiConnectionParams params = new OkapiConnectionParams(okapiHeaders, vertxContext.owner());
-        eventDrivenChunkProcessingService.processChunk(entity, id, params)
+        eventDrivenChunkProcessingService.processChunk(entity, id, acceptInstanceId, params)
           .map(processed -> PostChangeManagerJobExecutionsRecordsByIdResponse.respond204())
           .map(Response.class::cast)
           .otherwise(ExceptionHelper::mapExceptionToResponse)

--- a/mod-source-record-manager-server/src/main/java/org/folio/services/ChangeEngineService.java
+++ b/mod-source-record-manager-server/src/main/java/org/folio/services/ChangeEngineService.java
@@ -16,8 +16,12 @@ public interface ChangeEngineService {
    * @param chunk         - {@link RawRecordsDto} chunk with list of raw records for parse
    * @param jobExecution  - JobExecution which records should be parsed
    * @param sourceChunkId - id of the JobExecutionSourceChunk
+   * @param acceptInstanceId - allow the 999ff$i field to be set and also create an instance with value in 999ff$i
    * @param params        - OkapiConnectionParams to interact with external services
    * @return - list of Records that was parsed and saved into the source-record-storage
    */
-  Future<List<Record>> parseRawRecordsChunkForJobExecution(RawRecordsDto chunk, JobExecution jobExecution, String sourceChunkId, OkapiConnectionParams params);
+  Future<List<Record>> parseRawRecordsChunkForJobExecution(RawRecordsDto chunk,
+                                                           JobExecution jobExecution, String sourceChunkId,
+                                                           boolean acceptInstanceId,
+                                                           OkapiConnectionParams params);
 }

--- a/mod-source-record-manager-server/src/main/java/org/folio/services/ChunkProcessingService.java
+++ b/mod-source-record-manager-server/src/main/java/org/folio/services/ChunkProcessingService.java
@@ -12,10 +12,11 @@ public interface ChunkProcessingService {
    *
    * @param chunk          - {@link RawRecordsDto} chunk with list of raw records
    * @param jobExecutionId - JobExecution id
+   * @param acceptInstanceId - allow the 999ff$i field to be set and also create an instance with value in 999ff$i
    * @param params         - OkapiConnectionParams to interact with external services
    * @return - true if chunk was processed correctly
    */
-  Future<Boolean> processChunk(RawRecordsDto chunk, String jobExecutionId, OkapiConnectionParams params);
+  Future<Boolean> processChunk(RawRecordsDto chunk, String jobExecutionId, boolean acceptInstanceId, OkapiConnectionParams params);
 
   Future<Boolean> processChunk(RawRecordsDto incomingChunk, JobExecution jobExecution, OkapiConnectionParams params);
 

--- a/mod-source-record-manager-server/src/main/java/org/folio/services/EventDrivenChunkProcessingServiceImpl.java
+++ b/mod-source-record-manager-server/src/main/java/org/folio/services/EventDrivenChunkProcessingServiceImpl.java
@@ -37,12 +37,12 @@ public class EventDrivenChunkProcessingServiceImpl extends AbstractChunkProcessi
   }
 
   @Override
-  protected Future<Boolean> processRawRecordsChunk(RawRecordsDto incomingChunk, JobExecutionSourceChunk sourceChunk, String jobExecutionId, OkapiConnectionParams params) {
+  protected Future<Boolean> processRawRecordsChunk(RawRecordsDto incomingChunk, JobExecutionSourceChunk sourceChunk, String jobExecutionId, boolean acceptInstanceId, OkapiConnectionParams params) {
     LOGGER.debug("processRawRecordsChunk:: Starting to process raw records chunk with id: {} for jobExecutionId: {}. Chunk size: {}.", sourceChunk.getId(), jobExecutionId, sourceChunk.getChunkSize());
     Promise<Boolean> promise = Promise.promise();
     initializeJobExecutionProgressIfNecessary(jobExecutionId, incomingChunk, params.getTenantId())
       .compose(ar -> checkAndUpdateJobExecutionStatusIfNecessary(jobExecutionId, new StatusDto().withStatus(StatusDto.Status.PARSING_IN_PROGRESS), params))
-      .compose(jobExec -> changeEngineService.parseRawRecordsChunkForJobExecution(incomingChunk, jobExec, sourceChunk.getId(), params))
+      .compose(jobExec -> changeEngineService.parseRawRecordsChunkForJobExecution(incomingChunk, jobExec, sourceChunk.getId(), acceptInstanceId, params))
       .onComplete(sendEventsAr -> updateJobExecutionIfAllSourceChunksMarkedAsError(jobExecutionId, params)
         .onComplete(updateAr -> promise.handle(sendEventsAr.map(true))));
     return promise.future();

--- a/mod-source-record-manager-server/src/main/java/org/folio/verticle/consumers/errorhandlers/ParsedRecordsDiErrorProvider.java
+++ b/mod-source-record-manager-server/src/main/java/org/folio/verticle/consumers/errorhandlers/ParsedRecordsDiErrorProvider.java
@@ -42,7 +42,8 @@ public class ParsedRecordsDiErrorProvider {
       .compose(jobExecutionOptional -> {
         if (jobExecutionOptional.isPresent()) {
           RecordsMetadata.ContentType contentType = rawRecordsDto.getRecordsMetadata().getContentType();
-          return Future.succeededFuture(changeEngineService.getParsedRecordsFromInitialRecords(rawRecordsDto.getInitialRecords(), contentType, jobExecutionOptional.get(), ERROR_SOURCE_CHUNK_ID));
+          return Future.succeededFuture(changeEngineService.getParsedRecordsFromInitialRecords(rawRecordsDto.getInitialRecords(),
+            contentType, jobExecutionOptional.get(), false, ERROR_SOURCE_CHUNK_ID));
         }
         return Future.succeededFuture(Lists.newArrayList());
       });

--- a/mod-source-record-manager-server/src/test/java/org/folio/rest/impl/changeManager/ChangeManagerAPITest.java
+++ b/mod-source-record-manager-server/src/test/java/org/folio/rest/impl/changeManager/ChangeManagerAPITest.java
@@ -1083,16 +1083,6 @@ public class ChangeManagerAPITest extends AbstractRestTest {
       .then()
       .statusCode(HttpStatus.SC_NO_CONTENT);
     async.complete();
-
-//    async = testContext.async();
-//    RestAssured.given()
-//      .spec(spec)
-//      .when()
-//      .get(JOB_EXECUTION_PATH + jobExec.getId())
-//      .then()
-//      .statusCode(HttpStatus.SC_OK)
-//      .body("status", is(CANCELLED.value()));
-//    async.complete();
   }
 
   @Test

--- a/mod-source-record-manager-server/src/test/java/org/folio/services/ChangeEngineServiceImplTest.java
+++ b/mod-source-record-manager-server/src/test/java/org/folio/services/ChangeEngineServiceImplTest.java
@@ -245,7 +245,7 @@ public class ChangeEngineServiceImplTest {
     try (var mockedStatic = Mockito.mockStatic(EventHandlingUtil.class)) {
       mockedStatic.when(() -> EventHandlingUtil.sendEventToKafka(any(), any(), any(), kafkaHeadersCaptor.capture(), any(), any()))
         .thenReturn(Future.succeededFuture(true));
-      service.parseRawRecordsChunkForJobExecution(rawRecordsDto, jobExecution, "1", okapiConnectionParams).result();
+      service.parseRawRecordsChunkForJobExecution(rawRecordsDto, jobExecution, "1", false, okapiConnectionParams).result();
     }
 
     var optionalRecordIdHeader = kafkaHeadersCaptor.getValue().stream()
@@ -342,7 +342,7 @@ public class ChangeEngineServiceImplTest {
     try (var mockedStatic = Mockito.mockStatic(EventHandlingUtil.class)) {
       mockedStatic.when(() -> EventHandlingUtil.sendEventToKafka(any(), any(), any(), kafkaHeadersCaptor.capture(), any(), any()))
         .thenReturn(Future.succeededFuture(true));
-      service.parseRawRecordsChunkForJobExecution(rawRecordsDto, jobExecution, "1", okapiConnectionParams).result();
+      service.parseRawRecordsChunkForJobExecution(rawRecordsDto, jobExecution, "1", false, okapiConnectionParams).result();
     }
 
     verify(recordsPublishingService).sendEventsWithRecords(any(), eq(jobExecution.getId()), any(), eq(DI_MARC_FOR_UPDATE_RECEIVED.value()));
@@ -365,7 +365,7 @@ public class ChangeEngineServiceImplTest {
     try (var mockedStatic = Mockito.mockStatic(EventHandlingUtil.class)) {
       mockedStatic.when(() -> EventHandlingUtil.sendEventToKafka(any(), any(), any(), kafkaHeadersCaptor.capture(), any(), any()))
         .thenReturn(Future.succeededFuture(true));
-      service.parseRawRecordsChunkForJobExecution(rawRecordsDto, jobExecution, "1", okapiConnectionParams).result();
+      service.parseRawRecordsChunkForJobExecution(rawRecordsDto, jobExecution, "1", false, okapiConnectionParams).result();
     }
 
     verify(recordsPublishingService).sendEventsWithRecords(any(), eq(jobExecution.getId()), any(), eq(DI_MARC_FOR_UPDATE_RECEIVED.value()));
@@ -392,7 +392,7 @@ public class ChangeEngineServiceImplTest {
     try (var mockedStatic = Mockito.mockStatic(EventHandlingUtil.class)) {
       mockedStatic.when(() -> EventHandlingUtil.sendEventToKafka(any(), any(), any(), kafkaHeadersCaptor.capture(), any(), any()))
         .thenReturn(Future.succeededFuture(true));
-      service.parseRawRecordsChunkForJobExecution(rawRecordsDto, jobExecution, "1", okapiConnectionParams).result();
+      service.parseRawRecordsChunkForJobExecution(rawRecordsDto, jobExecution, "1", false, okapiConnectionParams).result();
     }
 
     verify(recordsPublishingService, never()).sendEventsWithRecords(any(), any(), any(), any());
@@ -415,7 +415,7 @@ public class ChangeEngineServiceImplTest {
     try (var mockedStatic = Mockito.mockStatic(EventHandlingUtil.class)) {
       mockedStatic.when(() -> EventHandlingUtil.sendEventToKafka(any(), any(), any(), kafkaHeadersCaptor.capture(), any(), any()))
         .thenReturn(Future.succeededFuture(true));
-      service.parseRawRecordsChunkForJobExecution(rawRecordsDto, jobExecution, "1", okapiConnectionParams).result();
+      service.parseRawRecordsChunkForJobExecution(rawRecordsDto, jobExecution, "1", false, okapiConnectionParams).result();
     }
 
     verify(recordsPublishingService, never()).sendEventsWithRecords(any(), any(), any(), any());
@@ -439,7 +439,7 @@ public class ChangeEngineServiceImplTest {
     try (var mockedStatic = Mockito.mockStatic(EventHandlingUtil.class)) {
       mockedStatic.when(() -> EventHandlingUtil.sendEventToKafka(any(), any(), any(), kafkaHeadersCaptor.capture(), any(), any()))
         .thenReturn(Future.succeededFuture(true));
-      service.parseRawRecordsChunkForJobExecution(rawRecordsDto, jobExecution, "1", okapiConnectionParams).result();
+      service.parseRawRecordsChunkForJobExecution(rawRecordsDto, jobExecution, "1", false, okapiConnectionParams).result();
     }
 
     verify(recordsPublishingService, never()).sendEventsWithRecords(any(), any(), any(), any());
@@ -620,7 +620,7 @@ public class ChangeEngineServiceImplTest {
     try (var mockedStatic = Mockito.mockStatic(EventHandlingUtil.class)) {
       mockedStatic.when(() -> EventHandlingUtil.sendEventToKafka(any(), any(), any(), anyList(), any(), any()))
         .thenReturn(eventSentResult);
-      return service.parseRawRecordsChunkForJobExecution(rawRecordsDto, jobExecution, "1", okapiConnectionParams);
+      return service.parseRawRecordsChunkForJobExecution(rawRecordsDto, jobExecution, "1", false, okapiConnectionParams);
     }
   }
 }

--- a/mod-source-record-manager-server/src/test/java/org/folio/services/ChangeEngineServiceImplTest.java
+++ b/mod-source-record-manager-server/src/test/java/org/folio/services/ChangeEngineServiceImplTest.java
@@ -36,9 +36,8 @@ import io.vertx.core.json.JsonObject;
 import io.vertx.kafka.client.producer.KafkaHeader;
 
 import org.folio.MatchProfile;
-import org.folio.rest.jaxrs.model.EntityType;
-import org.folio.rest.jaxrs.model.MappingMetadataDto;
-import org.folio.rest.jaxrs.model.MappingProfile;
+import org.folio.rest.jaxrs.model.*;
+import org.folio.rest.jaxrs.model.Record;
 import org.folio.services.afterprocessing.FieldModificationService;
 import org.folio.services.validation.JobProfileSnapshotValidationService;
 import org.junit.Before;
@@ -57,15 +56,6 @@ import org.folio.dataimport.util.OkapiConnectionParams;
 import org.folio.dataimport.util.marc.MarcRecordAnalyzer;
 import org.folio.dataimport.util.marc.MarcRecordType;
 import org.folio.kafka.KafkaConfig;
-import org.folio.rest.jaxrs.model.ActionProfile;
-import org.folio.rest.jaxrs.model.InitialRecord;
-import org.folio.rest.jaxrs.model.JobExecution;
-import org.folio.rest.jaxrs.model.JobExecutionSourceChunk;
-import org.folio.rest.jaxrs.model.JobProfileInfo;
-import org.folio.rest.jaxrs.model.ProfileSnapshotWrapper;
-import org.folio.rest.jaxrs.model.RawRecordsDto;
-import org.folio.rest.jaxrs.model.Record;
-import org.folio.rest.jaxrs.model.RecordsMetadata;
 import org.folio.services.afterprocessing.HrIdFieldService;
 import org.folio.services.util.EventHandlingUtil;
 
@@ -82,6 +72,7 @@ public class ChangeEngineServiceImplTest {
     "01119cam a2200349Li 4500001001300000003000600013005001700019008004100036020001800077020001500095035002100110037002200131040002700153043001200180050002700192082001600219090002200235100003300257245002700290264003800317300002300355336002600378337002800404338002700432651006400459945004300523960006200566961001600628980003900644981002300683999006300706\u001Eocn922152790\u001EOCoLC\u001E20150927051630.4\u001E150713s2015    enk           000 f eng d\u001E  \u001Fa9780241146064\u001E  \u001Fa0241146062\u001E  \u001Fa(OCoLC)922152790\u001E  \u001Fa12370236\u001Fbybp\u001F5NU\u001E  \u001FaYDXCP\u001Fbeng\u001Ferda\u001FcYDXCP\u001E  \u001Fae-uk-en\u001E 4\u001FaPR6052.A6488\u001FbN66 2015\u001E04\u001Fa823.914\u001F223\u001E 4\u001Fa823.914\u001FcB2557\u001Fb1\u001E1 \u001FaBarker, Pat,\u001Fd1943-\u001Feauthor.\u001E10\u001FaNoonday /\u001FcPat Barker.\u001E 1\u001FaLondon :\u001FbHamish Hamilton,\u001Fc2015.\u001E  \u001Fa258 pages ;\u001Fc24 cm\u001E  \u001Fatext\u001Fbtxt\u001F2rdacontent\u001E  \u001Faunmediated\u001Fbn\u001F2rdamedia\u001E  \u001Favolume\u001Fbnc\u001F2rdacarrier\u001E 0\u001FaLondon (England)\u001FxHistory\u001FyBombardment, 1940-1941\u001FvFiction.\u001E  \u001Ffh\u001Fg1\u001Fi0000000618391828\u001Flfhgen\u001Fr3\u001Fsv\u001Ft1\u001E  \u001Fap\u001Fda\u001Fgh\u001Fim\u001Fjn\u001Fka\u001Fla\u001Fmo\u001Ftfhgen\u001Fo1\u001Fs15.57\u001Fu7ART\u001Fvukapf\u001FzGBP\u001E  \u001FbGBP\u001Fm633761\u001E  \u001Fa160128\u001Fb1899\u001Fd156\u001Fe1713\u001Ff654270\u001Fg1\u001E  \u001Faukapf\u001Fb7ART\u001Fcfhgen\u001E  \u001Fdm\u001Fea\u001Ffx\u001Fgeng\u001FiTesting with subfield i\u001FsAnd with subfield s\u001E\u001D";
   private static final String MARC_BIB_REC_WITH_FF =
     "00861cam a2200193S1 45 0001000700000002000900007003000400016008004100020035002200061035001300083099001600096245005600112500011600168500019600284600003500480610003400515610003900549999007900588\u001E304162\u001E00320061\u001EPBL\u001E020613n                      000 0 eng u\u001E  \u001Fa(Sirsi)sc99900001\u001E  \u001Fa(Sirsi)1\u001E  \u001FaSC LVF M698\u001E00\u001FaMohler, Harold S. (Lehigh Collection Vertical File)\u001E  \u001FaMaterial on this topic is contained in the Lehigh Collection Vertical File. See Special Collections for access.\u001E  \u001FaContains press releases, versions of resumes, clippings, biographical information. L-in-Life program, and memorial service program -- Documents related Hershey Food Corporation. In two parts.\u001E10\u001FaMohler, Harold S.,\u001Fd1919-1988.\u001E20\u001FaLehigh University.\u001FbTrustees.\u001E20\u001FaLehigh University.\u001FbClass of 1948.\u001Eff\u001Fi29573076-a7ee-462a-8f9b-2659ab7df23c\u001Fs7ca42730-9ba6-4bc8-98d3-f068728504c9\u001E\u001D";
+
   @Mock
   private JobExecutionSourceChunkDao jobExecutionSourceChunkDao;
   @Mock
@@ -306,6 +297,33 @@ public class ChangeEngineServiceImplTest {
   }
 
   @Test
+  public void shouldReturnMarcBibRecordWith999ByAcceptInstanceId() {
+    boolean acceptInstanceId = true;
+    RawRecordsDto rawRecordsDto = getTestRawRecordsDto(MARC_BIB_REC_WITH_FF);
+    JobExecution jobExecution = new JobExecution()
+      .withId(UUID.randomUUID().toString())
+      .withUserId(UUID.randomUUID().toString())
+      .withJobProfileSnapshotWrapper(constructCreateInstanceSnapshotWrapper())
+      .withJobProfileInfo(new JobProfileInfo().withId(UUID.randomUUID().toString())
+        .withName("test").withDataType(JobProfileInfo.DataType.MARC));
+
+    when(marcRecordAnalyzer.process(any())).thenReturn(MarcRecordType.BIB);
+    when(jobExecutionSourceChunkDao.getById(any(), any()))
+      .thenReturn(Future.succeededFuture(Optional.of(new JobExecutionSourceChunk())));
+    when(jobExecutionSourceChunkDao.update(any(), any())).thenReturn(Future.succeededFuture(new JobExecutionSourceChunk()));
+
+    Future<List<Record>> serviceFuture =
+      executeWithKafkaMock(rawRecordsDto, jobExecution, Future.succeededFuture(true), acceptInstanceId);
+
+    var actual = serviceFuture.result();
+    assertThat(actual, hasSize(1));
+    assertThat(actual.get(0).getRecordType(), equalTo(Record.RecordType.MARC_BIB));
+    assertThat(actual.get(0).getErrorRecord(), nullValue());
+    assertThat(actual.get(0).getMatchedId(), equalTo("7ca42730-9ba6-4bc8-98d3-f068728504c9"));
+    assertThat(actual.get(0).getExternalIdsHolder().getInstanceId(), equalTo("29573076-a7ee-462a-8f9b-2659ab7df23c"));
+  }
+
+  @Test
   public void shouldReturnMarcBibRecordWithIds() {
     RawRecordsDto rawRecordsDto = getTestRawRecordsDto(MARC_BIB_REC_WITH_FF);
     JobExecution jobExecution = getTestJobExecution();
@@ -520,6 +538,22 @@ public class ChangeEngineServiceImplTest {
 
   }
 
+  ProfileSnapshotWrapper constructCreateInstanceSnapshotWrapper() {
+    return new ProfileSnapshotWrapper()
+      .withId(UUID.randomUUID().toString())
+      .withContentType(JOB_PROFILE)
+      .withContent(new JsonObject())
+      .withChildSnapshotWrappers(List.of(new ProfileSnapshotWrapper()
+        .withProfileId(UUID.randomUUID().toString())
+        .withContentType(ACTION_PROFILE)
+        .withContent(new JsonObject(Json.encode(new ActionProfile()
+          .withId(UUID.randomUUID().toString())
+          .withName("Create Instance")
+          .withAction(ActionProfile.Action.CREATE)
+          .withFolioRecord(ActionProfile.FolioRecord.INSTANCE))).getMap())
+      ));
+  };
+
   private ProfileSnapshotWrapper constructCreateMarcHoldingsAndInstanceSnapshotWrapper() {
     return new ProfileSnapshotWrapper()
       .withId(UUID.randomUUID().toString())
@@ -617,10 +651,15 @@ public class ChangeEngineServiceImplTest {
 
   private Future<List<Record>> executeWithKafkaMock(RawRecordsDto rawRecordsDto, JobExecution jobExecution,
                                                     Future<Boolean> eventSentResult) {
+    return executeWithKafkaMock(rawRecordsDto, jobExecution, eventSentResult, false);
+  }
+
+  private Future<List<Record>> executeWithKafkaMock(RawRecordsDto rawRecordsDto, JobExecution jobExecution,
+                                                    Future<Boolean> eventSentResult, boolean acceptInstanceId) {
     try (var mockedStatic = Mockito.mockStatic(EventHandlingUtil.class)) {
       mockedStatic.when(() -> EventHandlingUtil.sendEventToKafka(any(), any(), any(), anyList(), any(), any()))
         .thenReturn(eventSentResult);
-      return service.parseRawRecordsChunkForJobExecution(rawRecordsDto, jobExecution, "1", false, okapiConnectionParams);
+      return service.parseRawRecordsChunkForJobExecution(rawRecordsDto, jobExecution, "1", acceptInstanceId, okapiConnectionParams);
     }
   }
 }

--- a/mod-source-record-manager-server/src/test/java/org/folio/services/ChangeEngineServiceImplTest.java
+++ b/mod-source-record-manager-server/src/test/java/org/folio/services/ChangeEngineServiceImplTest.java
@@ -298,7 +298,9 @@ public class ChangeEngineServiceImplTest {
 
   @Test
   public void shouldReturnMarcBibRecordWith999ByAcceptInstanceId() {
+
     boolean acceptInstanceId = true;
+
     RawRecordsDto rawRecordsDto = getTestRawRecordsDto(MARC_BIB_REC_WITH_FF);
     JobExecution jobExecution = new JobExecution()
       .withId(UUID.randomUUID().toString())

--- a/mod-source-record-manager-server/src/test/java/org/folio/services/EventDrivenChunkProcessingServiceImplTest.java
+++ b/mod-source-record-manager-server/src/test/java/org/folio/services/EventDrivenChunkProcessingServiceImplTest.java
@@ -214,7 +214,7 @@ public class EventDrivenChunkProcessingServiceImplTest extends AbstractRestTest 
     Async async = context.async();
     Future<Boolean> future = jobExecutionService.initializeJobExecutions(initJobExecutionsRqDto, params)
       .compose(initJobExecutionsRsDto -> jobExecutionService.setJobProfileToJobExecution(initJobExecutionsRsDto.getParentJobExecutionId(), jobProfileInfo, params))
-      .compose(jobExecution -> chunkProcessingService.processChunk(rawRecordsDto, jobExecution.getId(), params));
+      .compose(jobExecution -> chunkProcessingService.processChunk(rawRecordsDto, jobExecution.getId(), false, params));
 
     future.onComplete(ar -> {
       context.assertTrue(ar.succeeded());
@@ -242,7 +242,7 @@ public class EventDrivenChunkProcessingServiceImplTest extends AbstractRestTest 
 
     Future<Boolean> future = jobExecutionService.initializeJobExecutions(initJobExecutionsRqDto, params)
       .compose(initJobExecutionsRsDto -> jobExecutionService.setJobProfileToJobExecution(initJobExecutionsRsDto.getParentJobExecutionId(), jobProfileInfo, params))
-      .compose(jobExecution -> chunkProcessingService.processChunk(rawRecordsDto, jobExecution.getId(), params));
+      .compose(jobExecution -> chunkProcessingService.processChunk(rawRecordsDto, jobExecution.getId(), false, params));
 
     future.onComplete(ar -> {
       context.assertTrue(ar.succeeded());
@@ -266,7 +266,7 @@ public class EventDrivenChunkProcessingServiceImplTest extends AbstractRestTest 
 
     Future<Boolean> future = jobExecutionService.initializeJobExecutions(initJobExecutionsRqDto, params)
       .compose(initJobExecutionsRsDto -> jobExecutionService.setJobProfileToJobExecution(initJobExecutionsRsDto.getParentJobExecutionId(), jobProfileInfo, params))
-      .compose(jobExecution -> chunkProcessingService.processChunk(rawRecordsDto, jobExecution.getId(), params));
+      .compose(jobExecution -> chunkProcessingService.processChunk(rawRecordsDto, jobExecution.getId(), false, params));
 
     future.onComplete(ar -> {
       context.assertTrue(ar.succeeded());
@@ -294,7 +294,7 @@ public class EventDrivenChunkProcessingServiceImplTest extends AbstractRestTest 
 
     Future<Boolean> future = jobExecutionService.initializeJobExecutions(initJobExecutionsRqDto, params)
       .compose(initJobExecutionsRsDto -> jobExecutionService.setJobProfileToJobExecution(initJobExecutionsRsDto.getParentJobExecutionId(), jobProfileInfo, params))
-      .compose(jobExecution -> chunkProcessingService.processChunk(rawRecordsDto, jobExecution.getId(), params));
+      .compose(jobExecution -> chunkProcessingService.processChunk(rawRecordsDto, jobExecution.getId(), false, params));
 
     future.onComplete(ar -> {
       context.assertTrue(ar.succeeded());
@@ -322,7 +322,7 @@ public class EventDrivenChunkProcessingServiceImplTest extends AbstractRestTest 
 
     Future<Optional<JobExecution>> jobFuture = jobExecutionService.initializeJobExecutions(initJobExecutionsRqDto, params)
       .compose(initJobExecutionsRsDto -> jobExecutionService.setJobProfileToJobExecution(initJobExecutionsRsDto.getParentJobExecutionId(), jobProfileInfo, params))
-      .compose(jobExecution -> chunkProcessingService.processChunk(lastRawRecordsDto, jobExecution.getId(), params).otherwise(true).map(jobExecution))
+      .compose(jobExecution -> chunkProcessingService.processChunk(lastRawRecordsDto, jobExecution.getId(), false, params).otherwise(true).map(jobExecution))
       .compose(jobExecution -> jobExecutionService.getJobExecutionById(jobExecution.getId(), params.getTenantId()));
 
     jobFuture.onComplete(ar -> {

--- a/mod-source-record-manager-server/src/test/java/org/folio/services/RecordProcessedEventHandlingServiceImplTest.java
+++ b/mod-source-record-manager-server/src/test/java/org/folio/services/RecordProcessedEventHandlingServiceImplTest.java
@@ -222,7 +222,7 @@ public class RecordProcessedEventHandlingServiceImplTest extends AbstractRestTes
       .compose(initJobExecutionsRsDto -> jobExecutionService.setJobProfileToJobExecution(initJobExecutionsRsDto.getParentJobExecutionId(), jobProfileInfo, params))
       .compose(jobExecution -> {
         dataImportEventPayload.setJobExecutionId(jobExecution.getId());
-        return chunkProcessingService.processChunk(rawRecordsDto, jobExecution.getId(), params);
+        return chunkProcessingService.processChunk(rawRecordsDto, jobExecution.getId(), false, params);
       });
 
     // when
@@ -254,7 +254,7 @@ public class RecordProcessedEventHandlingServiceImplTest extends AbstractRestTes
       .compose(initJobExecutionsRsDto -> jobExecutionService.setJobProfileToJobExecution(initJobExecutionsRsDto.getParentJobExecutionId(), jobProfileInfo, params))
       .compose(jobExecution -> {
         dataImportEventPayload.setJobExecutionId(jobExecution.getId());
-        return chunkProcessingService.processChunk(rawRecordsDto, jobExecution.getId(), params);
+        return chunkProcessingService.processChunk(rawRecordsDto, jobExecution.getId(), false, params);
       });
 
     // when
@@ -304,7 +304,7 @@ public class RecordProcessedEventHandlingServiceImplTest extends AbstractRestTes
       .compose(initJobExecutionsRsDto -> jobExecutionService.setJobProfileToJobExecution(initJobExecutionsRsDto.getParentJobExecutionId(), jobProfileInfo, params))
       .compose(jobExecution -> {
         dataImportEventPayload.setJobExecutionId(jobExecution.getId());
-        return chunkProcessingService.processChunk(rawRecordsDto, jobExecution.getId(), params);
+        return chunkProcessingService.processChunk(rawRecordsDto, jobExecution.getId(), false, params);
       });
 
     // when
@@ -357,7 +357,7 @@ public class RecordProcessedEventHandlingServiceImplTest extends AbstractRestTes
         datImpErrorEventPayload.withJobExecutionId(jobExecution.getId());
         return datImpCompletedEventPayload.withJobExecutionId(jobExecution.getId());
       })
-      .compose(ar -> chunkProcessingService.processChunk(rawRecordsDto, datImpErrorEventPayload.getJobExecutionId(), params));
+      .compose(ar -> chunkProcessingService.processChunk(rawRecordsDto, datImpErrorEventPayload.getJobExecutionId(), false, params));
 
     // when
     Future<Optional<JobExecution>> jobFuture = future
@@ -428,7 +428,7 @@ public class RecordProcessedEventHandlingServiceImplTest extends AbstractRestTes
       .compose(initJobExecutionsRsDto -> jobExecutionService.setJobProfileToJobExecution(initJobExecutionsRsDto.getParentJobExecutionId(), jobProfileInfo, params))
       .compose(jobExecution -> {
         dataImportEventPayload.setJobExecutionId(jobExecution.getId());
-        return chunkProcessingService.processChunk(rawRecordsDto, jobExecution.getId(), params);
+        return chunkProcessingService.processChunk(rawRecordsDto, jobExecution.getId(), false, params);
       });
 
     // when

--- a/mod-source-record-manager-server/src/test/java/org/folio/verticle/consumers/errorhandlers/ParsedRecordsDiErrorProviderTest.java
+++ b/mod-source-record-manager-server/src/test/java/org/folio/verticle/consumers/errorhandlers/ParsedRecordsDiErrorProviderTest.java
@@ -6,35 +6,36 @@ import io.vertx.core.Vertx;
 import io.vertx.ext.unit.Async;
 import io.vertx.ext.unit.TestContext;
 import io.vertx.ext.unit.junit.VertxUnitRunner;
-import static junit.framework.TestCase.assertEquals;
-import static junit.framework.TestCase.assertTrue;
 import org.folio.dataimport.util.OkapiConnectionParams;
-import static org.folio.dataimport.util.RestUtil.OKAPI_URL_HEADER;
 import org.folio.rest.jaxrs.model.InitialRecord;
 import org.folio.rest.jaxrs.model.JobExecution;
 import org.folio.rest.jaxrs.model.ParsedRecord;
 import org.folio.rest.jaxrs.model.RawRecordsDto;
 import org.folio.rest.jaxrs.model.Record;
 import org.folio.rest.jaxrs.model.RecordsMetadata;
-import static org.folio.rest.util.OkapiConnectionParams.OKAPI_TENANT_HEADER;
-import static org.folio.rest.util.OkapiConnectionParams.OKAPI_TOKEN_HEADER;
 import org.folio.services.ChangeEngineServiceImpl;
 import org.folio.services.JobExecutionService;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import static org.mockito.ArgumentMatchers.anyString;
-import static org.mockito.ArgumentMatchers.eq;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
 import org.mockito.MockitoAnnotations;
 
 import java.util.HashMap;
 import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
+
+import static junit.framework.TestCase.assertEquals;
+import static junit.framework.TestCase.assertTrue;
+import static org.folio.dataimport.util.RestUtil.OKAPI_URL_HEADER;
+import static org.folio.rest.util.OkapiConnectionParams.OKAPI_TENANT_HEADER;
+import static org.folio.rest.util.OkapiConnectionParams.OKAPI_TOKEN_HEADER;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 @RunWith(VertxUnitRunner.class)
 public class ParsedRecordsDiErrorProviderTest {
@@ -66,7 +67,7 @@ public class ParsedRecordsDiErrorProviderTest {
       .withInitialRecords(Lists.newArrayList(new InitialRecord()))
       .withRecordsMetadata(new RecordsMetadata().withContentType(RecordsMetadata.ContentType.MARC_JSON));
     when(changeEngineService.getParsedRecordsFromInitialRecords(eq(rawRecordsDto.getInitialRecords()),
-      eq(rawRecordsDto.getRecordsMetadata().getContentType()), eq(jobExecution), false, anyString()))
+      eq(rawRecordsDto.getRecordsMetadata().getContentType()), eq(jobExecution), eq(false), anyString()))
         .thenReturn(Lists.newArrayList(new Record().withParsedRecord(new ParsedRecord())));
     Future<List<Record>> parserRecordsFuture = diErrorProvider.getParsedRecordsFromInitialRecords(getOkapiParams(), JOB_EXECUTION_ID, rawRecordsDto);
     parserRecordsFuture.onComplete(ar -> {

--- a/mod-source-record-manager-server/src/test/java/org/folio/verticle/consumers/errorhandlers/ParsedRecordsDiErrorProviderTest.java
+++ b/mod-source-record-manager-server/src/test/java/org/folio/verticle/consumers/errorhandlers/ParsedRecordsDiErrorProviderTest.java
@@ -66,7 +66,7 @@ public class ParsedRecordsDiErrorProviderTest {
       .withInitialRecords(Lists.newArrayList(new InitialRecord()))
       .withRecordsMetadata(new RecordsMetadata().withContentType(RecordsMetadata.ContentType.MARC_JSON));
     when(changeEngineService.getParsedRecordsFromInitialRecords(eq(rawRecordsDto.getInitialRecords()),
-      eq(rawRecordsDto.getRecordsMetadata().getContentType()), eq(jobExecution), anyString()))
+      eq(rawRecordsDto.getRecordsMetadata().getContentType()), eq(jobExecution), false, anyString()))
         .thenReturn(Lists.newArrayList(new Record().withParsedRecord(new ParsedRecord())));
     Future<List<Record>> parserRecordsFuture = diErrorProvider.getParsedRecordsFromInitialRecords(getOkapiParams(), JOB_EXECUTION_ID, rawRecordsDto);
     parserRecordsFuture.onComplete(ar -> {

--- a/ramls/change-manager.raml
+++ b/ramls/change-manager.raml
@@ -174,6 +174,11 @@ resourceTypes:
         post:
           is: [validate]
           description: "Receive chunk of raw records"
+          queryParameters:
+            acceptInstanceId:
+              type: boolean
+              required: false
+              default: false
           body:
             application/json:
               type: rawRecordsDto

--- a/ramls/change-manager.raml
+++ b/ramls/change-manager.raml
@@ -1,7 +1,7 @@
 #%RAML 1.0
 
 title: Change Manager
-version: v1.0
+version: v1.1
 protocols: [ HTTP, HTTPS ]
 baseUri: http://localhost
 


### PR DESCRIPTION
## Purpose
Instances need to be created by Data Import(DI) with a known identifier to realize ECS. For local instance that have source=MARC, DI will create the Shared Instance in the central tenant. The Shared instance needs to be created with the same identifier as the local instance that is being promoted

## Approach
This is not currently allowed in DI. A query parameter will be added to signal to DI to allow the 999ff$i field to be set and also create an instance with value in 999ff$i.
Query parameter will be accepted when initializing a data import at /change-manager/jobExecutions/<id>/records
Query parameter will be called acceptInstanceId and settable to true/false with a default of false.

## Links
[MODSOURMAN-1011](https://issues.folio.org/browse/MODSOURMAN-1011)