### PR TITLE
MODSOURMAN-1029 introduce global backpressure to kafka consumers

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,4 +1,5 @@
 ## 2023-xx-xx v3.7.0-SNAPSHOT
+* [MODSOURMAN-1029](https://issues.folio.org/browse/MODSOURMAN-1029) Introduce Global Backpressure For Kafka Consumption
 * [MODSOURMAN-1011](https://issues.folio.org/browse/MODSOURMAN-1011) Import An Instance With A Known Identifier (new acceptInstanceId parameter)
 * [MODSOURMAN-999](https://issues.folio.org/browse/MODSOURMAN-999) Upgrade mod-source-record-manager to Java 17
 * [MODSOURMAN-974](https://issues.folio.org/browse/MODSOURMAN-974) MARC bib $9 handling | Remove $9 subfields from linkable fields

--- a/mod-source-record-manager-server/src/main/java/org/folio/verticle/AbstractConsumersVerticle.java
+++ b/mod-source-record-manager-server/src/main/java/org/folio/verticle/AbstractConsumersVerticle.java
@@ -85,7 +85,7 @@ public abstract class AbstractConsumersVerticle extends AbstractVerticle {
    * Include messages from this consumer to mutate global load counts
    */
   public Boolean shouldAddToGlobalLoad() {
-    return null;
+    return true;
   }
 
   /**

--- a/mod-source-record-manager-server/src/main/java/org/folio/verticle/RawMarcChunkConsumersVerticle.java
+++ b/mod-source-record-manager-server/src/main/java/org/folio/verticle/RawMarcChunkConsumersVerticle.java
@@ -67,4 +67,13 @@ public class RawMarcChunkConsumersVerticle extends AbstractConsumersVerticle {
     return (globalLoad, localLoad, threshold) -> localLoad < 0;
   }
 
+  @Override
+  public Boolean shouldAddToGlobalLoad() {
+    /*
+    since flow control will handle back pressure for this consumer, do not include its messages in the global load
+    counts.
+     */
+    return false;
+  }
+
 }


### PR DESCRIPTION
## Purpose
Introduce global backpressure to kafka consumers for the whole application. This will limit the number of "concurrent" messages that can be processed by SRM. This will reduce contention on the database connection pool which yields timeout errors during high load.

## Approach
Update the back pressure gauge to consider the global load sensor. Also disable global load sensing for the consumer responsible for raw records processing since the Flow control service in SRM is responsible for managing raw records processing.

