### PR TITLE
MODSOURMAN-1031: Add support for a single holding

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,4 +1,5 @@
 ## 2023-xx-xx v3.7.0-SNAPSHOT
+* [MODSOURMAN-1031](https://issues.folio.org/browse/MODSOURMAN-1031) The status of holdings is not displayed in the Import log after uploading file for creating holdings
 * [MODSOURMAN-1011](https://issues.folio.org/browse/MODSOURMAN-1011) Import An Instance With A Known Identifier (new acceptInstanceId parameter)
 * [MODSOURMAN-999](https://issues.folio.org/browse/MODSOURMAN-999) Upgrade mod-source-record-manager to Java 17
 * [MODSOURMAN-974](https://issues.folio.org/browse/MODSOURMAN-974) MARC bib $9 handling | Remove $9 subfields from linkable fields


### PR DESCRIPTION
## Purpose
_Add support for a single holding which comes from mod-inventory while journaling._

## Approach
_Currently mod-inventory sends a single holding as JsonObject so SRM should handle both cases single and multiple_

## Tested
![image](https://github.com/folio-org/mod-source-record-manager/assets/138673581/8161c9b1-b63d-4c51-9da8-0295c1f300b2)

