### PR TITLE
MODSOURMAN-1039 Fix circular dependency mod-entities-links and mapping-rules.get

### DIFF
--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -75,14 +75,6 @@
       "version": "1.1"
     },
     {
-      "id": "authority-note-types",
-      "version": "1.0"
-    },
-    {
-      "id": "authority-source-files",
-      "version": "1.0"
-    },
-    {
       "id": "call-number-types",
       "version": "1.0"
     },
@@ -636,6 +628,14 @@
   "optional": [
     {
       "id": "instance-authority-linking-rules",
+      "version": "1.0"
+    },
+    {
+      "id": "authority-note-types",
+      "version": "1.0"
+    },
+    {
+      "id": "authority-source-files",
       "version": "1.0"
     }
   ],


### PR DESCRIPTION
## Purpose
 Fix circular dependency mod-entities-links and mapping-rules.get

## Approach
Make mod-entities-links interfaces optional

## Is this change testable? If not - why?

## Checklist
- [ ] I have updated NEWS.md.
- [ ] I have added javadocs to new methods.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation e.g. README.md.
- [ ] I have ran karate tests against this feature.

