### PR TITLE
MODSOURMAN-1037: Get holdings id key according to mod-inventory payload

### DIFF
--- a/mod-source-record-manager-server/src/main/java/org/folio/dao/JournalRecordDaoImpl.java
+++ b/mod-source-record-manager-server/src/main/java/org/folio/dao/JournalRecordDaoImpl.java
@@ -124,6 +124,7 @@ import static org.folio.dao.util.JournalRecordsColumns.PO_LINE_ACTION_STATUS;
 import static org.folio.dao.util.JournalRecordsColumns.PO_LINE_ENTITY_ID;
 import static org.folio.dao.util.JournalRecordsColumns.PO_LINE_ENTITY_HRID;
 import static org.folio.dao.util.JournalRecordsColumns.PO_LINE_ENTITY_ERROR;
+import static org.folio.rest.jaxrs.model.ActionStatus.UPDATED;
 import static org.folio.rest.jaxrs.model.JobLogEntryDto.SourceRecordType.MARC_HOLDINGS;
 import static org.folio.rest.persist.PostgresClient.convertToPsqlStandard;
 
@@ -356,8 +357,7 @@ public class JournalRecordDaoImpl implements JournalRecordDao {
   }
 
   private boolean isActionStatusUpdatedOrCreated(org.folio.rest.jaxrs.model.ActionStatus holdingsActionStatus) {
-    return org.folio.rest.jaxrs.model.ActionStatus.CREATED.equals(holdingsActionStatus)
-      || org.folio.rest.jaxrs.model.ActionStatus.UPDATED.equals(holdingsActionStatus);
+    return org.folio.rest.jaxrs.model.ActionStatus.CREATED.equals(holdingsActionStatus) || UPDATED.equals(holdingsActionStatus);
   }
 
   private RecordProcessingLogDto mapRowSetToRecordProcessingLogDto(RowSet<Row> resultSet) {
@@ -395,7 +395,7 @@ public class JournalRecordDaoImpl implements JournalRecordDao {
     resultSet.forEach(r -> {
       ProcessedHoldingsInfo processedHoldings = constructProcessedHoldingsInfoBasedOnEntityType(r, HOLDINGS_ACTION_STATUS, HOLDINGS_ENTITY_ID, HOLDINGS_ENTITY_HRID, HOLDINGS_PERMANENT_LOCATION_ID, HOLDINGS_ENTITY_ERROR);
       ProcessedItemInfo processedItem = constructProcessedItemInfoBasedOnEntityType(r, ITEM_ACTION_STATUS, ITEM_ENTITY_ID, ITEM_ENTITY_HRID, HOLDINGS_ENTITY_ID, ITEM_ENTITY_ERROR);
-      if (Objects.nonNull(processedHoldings.getActionStatus())) {
+      if (Objects.nonNull(processedHoldings.getActionStatus()) || processedItem.getActionStatus() == UPDATED) {
         processedHoldingsInfo.add(processedHoldings);
       }
       if (Objects.nonNull(processedItem.getActionStatus())) {

--- a/mod-source-record-manager-server/src/test/java/org/folio/services/JournalUtilTest.java
+++ b/mod-source-record-manager-server/src/test/java/org/folio/services/JournalUtilTest.java
@@ -259,7 +259,7 @@ public class JournalUtilTest {
     JsonObject itemJson = new JsonObject()
       .put("id", itemId)
       .put("hrid", itemHrid)
-      .put("holdingId", holdingsId);
+      .put("holdingsRecordId", holdingsId);
 
     JsonObject instanceJson = new JsonObject()
       .put("id", instanceId)
@@ -313,7 +313,7 @@ public class JournalUtilTest {
     JsonObject itemJson = new JsonObject()
       .put("id", itemId)
       .put("hrid", itemHrid)
-      .put("holdingId", holdingsId);
+      .put("holdingsRecordId", holdingsId);
 
     JsonObject holdingsJson = new JsonObject()
       .put("id", holdingsId)
@@ -489,7 +489,6 @@ public class JournalUtilTest {
     multipleHoldings.add(firstHoldingsAsJson);
     multipleHoldings.add(secondHoldingsAsJson);
 
-
     HashMap<String, String> context = new HashMap<>();
     context.put(HOLDINGS.value(), String.valueOf(multipleHoldings.encode()));
     context.put(MARC_BIBLIOGRAPHIC.value(), recordJson.encode());
@@ -544,7 +543,7 @@ public class JournalUtilTest {
     JsonObject firstItemJson = new JsonObject()
       .put("id", firstItemId)
       .put("hrid", firstItemHrid)
-      .put("holdingId", firstHoldingsId);
+      .put("holdingsRecordId", firstHoldingsId);
 
     JsonObject secondItemJson = new JsonObject()
       .put("id", secondItemId)
@@ -566,7 +565,6 @@ public class JournalUtilTest {
     JsonArray multipleItems = new JsonArray();
     multipleItems.add(firstItemJson);
     multipleItems.add(secondItemJson);
-
 
     HashMap<String, String> context = new HashMap<>();
     context.put(ITEM.value(), String.valueOf(multipleItems));
@@ -621,7 +619,7 @@ public class JournalUtilTest {
     JsonObject firstItemJson = new JsonObject()
       .put("id", firstItemId)
       .put("hrid", firstItemHrid)
-      .put("holdingId", holdingsId);
+      .put("holdingsRecordId", holdingsId);
 
     JsonObject secondItemJson = new JsonObject()
       .put("id", secondItemId)
@@ -698,11 +696,10 @@ public class JournalUtilTest {
     String firstErrorUUID = UUID.randomUUID().toString();
     String secondErrorUUID = UUID.randomUUID().toString();
 
-
     JsonObject itemJson = new JsonObject()
       .put("id", itemId)
       .put("hrid", itemHrid)
-      .put("holdingId", holdingsId);
+      .put("holdingsRecordId", holdingsId);
 
     JsonObject instanceJson = new JsonObject()
       .put("id", instanceId)
@@ -738,7 +735,6 @@ public class JournalUtilTest {
     context.put(INSTANCE.value(), instanceJson.encode());
     context.put(MARC_BIBLIOGRAPHIC.value(), recordJson.encode());
     context.put("ERRORS", String.valueOf(multipleErrors));
-
 
     DataImportEventPayload eventPayload = new DataImportEventPayload()
       .withEventType("DI_INVENTORY_ITEM_CREATED")
@@ -782,7 +778,6 @@ public class JournalUtilTest {
     Assert.assertEquals(holdingsId, journalRecords.get(2).getHoldingsId());
 
     Assert.assertNotNull(journalRecords.get(1).getActionDate());
-
   }
 
   @Test
@@ -794,7 +789,6 @@ public class JournalUtilTest {
     String holdingsId = UUID.randomUUID().toString();
     String firstErrorUUID = UUID.randomUUID().toString();
     String secondErrorUUID = UUID.randomUUID().toString();
-
 
     JsonObject itemJson = new JsonObject()
       .put("id", itemId)


### PR DESCRIPTION
## Purpose
_`holdingsId` should be present for every item in `relatedItemInfo`._

## Approach
_Set a proper name for holdings id key that comes from mod-inventory_

## Testing
![image](https://github.com/folio-org/mod-source-record-manager/assets/138673581/f8d668fd-5398-4f0b-a21f-ecd642d9b5e3)

