### PR TITLE
[MODINV-873] Add permissions for user tenants collection

### DIFF
--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -342,7 +342,8 @@
             "isbn-utils.convert-to-13.get",
             "instance-authority-links.instances.collection.get",
             "instance-authority-links.instances.collection.put",
-            "instance-authority.linking-rules.collection.get"
+            "instance-authority.linking-rules.collection.get",
+            "user-tenants.collection.get"
           ],
           "permissionsDesired": [
             "invoices.acquisitions-units-assignments.assign",


### PR DESCRIPTION
## Purpose
Error is 'org.folio.inventory.consortium.exceptions.ConsortiumException: Error retrieving centralTenantId by tenant id: diku, status code: 403, response message: Access for user 'cypressTestUser673.2125076239648903' (56b0edf3-9064-4bd5-9466-272de43a97de) requires permission: user-tenants.collection.get'.{}

## Approach
Added permissions for user-tenants collection