### PR TITLE
[MODSOURMAN-1041] Check for composite completion upon external status updates

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,6 @@
+{
+  "sonarlint.connectedMode.project": {
+    "connectionId": "folio-org",
+    "projectKey": "org.folio:mod-source-record-manager"
+  }
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,6 +1,0 @@
-{
-  "sonarlint.connectedMode.project": {
-    "connectionId": "folio-org",
-    "projectKey": "org.folio:mod-source-record-manager"
-  }
-}

--- a/mod-source-record-manager-server/src/main/java/org/folio/services/JobExecutionServiceImpl.java
+++ b/mod-source-record-manager-server/src/main/java/org/folio/services/JobExecutionServiceImpl.java
@@ -384,8 +384,6 @@ public class JobExecutionServiceImpl implements JobExecutionService {
 
   private RunBy buildRunByFromUserInfo(UserInfo info) {
     RunBy result = new RunBy();
-//    LOGGER.warn("BAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA");
-//    LOGGER.warn("Got UserInfo {}", info);
     if (info != null) {
       result.setFirstName(info.getFirstName());
       result.setLastName(info.getLastName());
@@ -404,23 +402,18 @@ public class JobExecutionServiceImpl implements JobExecutionService {
     Promise<UserInfo> promise = Promise.promise();
     RestUtil.doRequest(params, GET_USER_URL + userId, HttpMethod.GET, null)
       .onComplete(getUserResult -> {
-//LOGGER.warn("AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA");
-if (RestUtil.validateAsyncResult(getUserResult, promise)) {
+        if (RestUtil.validateAsyncResult(getUserResult, promise)) {
           JsonObject response = getUserResult.result().getJson();
-//LOGGER.warn("Got response {}", response.encodePrettily());
-if (!response.containsKey("totalRecords") || !response.containsKey("users")) {
-//LOGGER.warn("Bad totalRecords/users");
+          if (!response.containsKey("totalRecords") || !response.containsKey("users")) {
             promise.fail("Error, missing field(s) 'totalRecords' and/or 'users' in user response object");
           } else {
             int recordCount = response.getInteger("totalRecords");
             if (recordCount > 1) {
               String errorMessage = "There are more then one user by requested user id : " + userId;
-//LOGGER.warn(errorMessage);
               LOGGER.warn(errorMessage);
               promise.fail(errorMessage);
             } else if (recordCount == 0) {
               String errorMessage = "No user found by user id :" + userId;
-//LOGGER.warn(errorMessage);
               LOGGER.warn(errorMessage);
               promise.fail(errorMessage);
             } else {
@@ -502,7 +495,6 @@ if (!response.containsKey("totalRecords") || !response.containsKey("users")) {
       jobExecutions.stream().map(JobExecution::getId).collect(Collectors.toList()), tenantId);
     List<Future<String>> savedJobExecutionFutures = new ArrayList<>();
     for (JobExecution jobExecution : jobExecutions) {
-//      LOGGER.warn("----------> jobExecution to save: " + jobExecution);
       Future<String> savedJobExecutionFuture = jobExecutionDao.save(jobExecution, tenantId);
       savedJobExecutionFutures.add(savedJobExecutionFuture);
     }

--- a/mod-source-record-manager-server/src/main/java/org/folio/services/JobExecutionServiceImpl.java
+++ b/mod-source-record-manager-server/src/main/java/org/folio/services/JobExecutionServiceImpl.java
@@ -38,7 +38,6 @@ import org.folio.rest.jaxrs.model.Snapshot;
 import org.folio.rest.jaxrs.model.StatusDto;
 import org.folio.rest.jaxrs.model.UserInfo;
 import org.folio.rest.jaxrs.model.JobExecution.SubordinationType;
-import org.folio.rest.jaxrs.model.JobExecution.UiStatus;
 import org.folio.services.exceptions.JobDuplicateUpdateException;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;

--- a/mod-source-record-manager-server/src/main/java/org/folio/services/JobExecutionServiceImpl.java
+++ b/mod-source-record-manager-server/src/main/java/org/folio/services/JobExecutionServiceImpl.java
@@ -110,8 +110,6 @@ public class JobExecutionServiceImpl implements JobExecutionService {
       String parentJobExecutionId = StringUtils.isNotBlank(parentJobId) ? parentJobId : UUID.randomUUID().toString();
       return lookupUser(jobExecutionsRqDto.getUserId(), params)
         .compose(userInfo -> {
-//          LOGGER.warn("AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA");
-//          LOGGER.warn("uid={}, userInfo={}, username={}", jobExecutionsRqDto.getUserId(), userInfo, userInfo == null ? null : userInfo.getUserName());
           List<JobExecution> jobExecutions =
             prepareJobExecutionList(parentJobExecutionId, jobExecutionsRqDto.getFiles(), userInfo, jobExecutionsRqDto);
           List<Snapshot> snapshots = prepareSnapshotList(jobExecutions);

--- a/mod-source-record-manager-server/src/main/java/org/folio/services/JobExecutionServiceImpl.java
+++ b/mod-source-record-manager-server/src/main/java/org/folio/services/JobExecutionServiceImpl.java
@@ -38,6 +38,7 @@ import org.folio.rest.jaxrs.model.Snapshot;
 import org.folio.rest.jaxrs.model.StatusDto;
 import org.folio.rest.jaxrs.model.UserInfo;
 import org.folio.rest.jaxrs.model.JobExecution.SubordinationType;
+import org.folio.rest.jaxrs.model.JobExecution.UiStatus;
 import org.folio.services.exceptions.JobDuplicateUpdateException;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
@@ -194,7 +195,12 @@ public class JobExecutionServiceImpl implements JobExecutionService {
         }, params.getTenantId())
         .compose(jobExecution -> updateSnapshotStatus(jobExecution, params))
         .compose(jobExecution -> {
-          if (jobExecution.getSubordinationType().equals(SubordinationType.COMPOSITE_CHILD)) {
+          if (jobExecution.getSubordinationType().equals(SubordinationType.COMPOSITE_CHILD) && (
+            jobExecution.getUiStatus() == JobExecution.UiStatus.RUNNING_COMPLETE ||
+            jobExecution.getUiStatus() == JobExecution.UiStatus.CANCELLED ||
+            jobExecution.getUiStatus() == JobExecution.UiStatus.ERROR ||
+            jobExecution.getUiStatus() == JobExecution.UiStatus.DISCARDED
+          )) {
             return this.getJobExecutionById(jobExecution.getParentJobId(), params.getTenantId())
               .map(v -> v.orElseThrow(() -> new IllegalStateException("Could not find parent job execution")))
               .compose(parentExecution -> 

--- a/mod-source-record-manager-server/src/test/java/org/folio/rest/impl/AbstractRestTest.java
+++ b/mod-source-record-manager-server/src/test/java/org/folio/rest/impl/AbstractRestTest.java
@@ -539,7 +539,7 @@ public abstract class AbstractRestTest {
       result.add(
         RestAssured.given()
           .spec(spec)
-          .body(JsonObject.mapFrom(requestDto).toString())
+          .body(JsonObject.mapFrom(childRequestDto).toString())
           .when().post(JOB_EXECUTION_PATH).body().as(InitJobExecutionsRsDto.class).getJobExecutions().get(0)
       );
     }

--- a/mod-source-record-manager-server/src/test/java/org/folio/rest/impl/AbstractRestTest.java
+++ b/mod-source-record-manager-server/src/test/java/org/folio/rest/impl/AbstractRestTest.java
@@ -61,6 +61,7 @@ import org.testcontainers.containers.PostgreSQLContainer;
 import java.io.IOException;
 import java.net.URLEncoder;
 import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
@@ -509,6 +510,41 @@ public abstract class AbstractRestTest {
       .spec(spec)
       .body(JsonObject.mapFrom(requestDto).toString())
       .when().post(JOB_EXECUTION_PATH).body().as(InitJobExecutionsRsDto.class);
+  }
+
+  /** Returns list of [parent, child1, ..., childN] */
+  protected List<JobExecution> constructAndPostCompositeInitJobExecutionRqDto(String filename, int children) {
+    InitJobExecutionsRqDto requestDto = new InitJobExecutionsRqDto();
+    requestDto.getFiles().add(new File().withName(filename));
+    requestDto.setUserId(okapiUserIdHeader);
+    requestDto.setSourceType(InitJobExecutionsRqDto.SourceType.COMPOSITE);
+
+    JobExecution parent = RestAssured.given()
+      .spec(spec)
+      .body(JsonObject.mapFrom(requestDto).toString())
+      .when().post(JOB_EXECUTION_PATH).body().as(InitJobExecutionsRsDto.class).getJobExecutions().get(0);
+
+    List<JobExecution> result = new ArrayList<>();
+    result.add(parent);
+
+    for (int i = 1; i <= children; i++) {
+      InitJobExecutionsRqDto childRequestDto = new InitJobExecutionsRqDto();
+      childRequestDto.getFiles().add(new File().withName(filename + i));
+      childRequestDto.setUserId(okapiUserIdHeader);
+      childRequestDto.setSourceType(InitJobExecutionsRqDto.SourceType.COMPOSITE);
+      childRequestDto.setParentJobId(parent.getId());
+      childRequestDto.setJobPartNumber(i);
+      childRequestDto.setTotalJobParts(children);
+
+      result.add(
+        RestAssured.given()
+          .spec(spec)
+          .body(JsonObject.mapFrom(requestDto).toString())
+          .when().post(JOB_EXECUTION_PATH).body().as(InitJobExecutionsRsDto.class).getJobExecutions().get(0)
+      );
+    }
+
+    return result;
   }
 
   protected io.restassured.response.Response updateJobExecutionStatus(JobExecution jobExecution, StatusDto statusDto) {

--- a/mod-source-record-manager-server/src/test/java/org/folio/rest/impl/changeManager/ChangeManagerAPITest.java
+++ b/mod-source-record-manager-server/src/test/java/org/folio/rest/impl/changeManager/ChangeManagerAPITest.java
@@ -15,9 +15,9 @@ import io.vertx.ext.unit.TestContext;
 import io.vertx.ext.unit.junit.VertxUnitRunner;
 import net.mguenther.kafka.junit.ObserveKeyValues;
 
-import org.apache.commons.io.FileUtils;
 import org.apache.http.HttpStatus;
 import org.folio.MatchProfile;
+import org.folio.TestUtil;
 import org.folio.dao.JournalRecordDao;
 import org.folio.dao.JournalRecordDaoImpl;
 import org.folio.dao.util.PostgresClientFactory;
@@ -153,7 +153,7 @@ public class ChangeManagerAPITest extends AbstractRestTest {
 
   {
     try {
-      rawRecordsDto_2 = new JsonObject(readFileFromPath(RAW_DTO_PATH)).mapTo(RawRecordsDto.class);
+      rawRecordsDto_2 = new JsonObject(TestUtil.readFileFromPath(RAW_DTO_PATH)).mapTo(RawRecordsDto.class);
     } catch (IOException e) {
       e.printStackTrace();
     }
@@ -364,7 +364,7 @@ public class ChangeManagerAPITest extends AbstractRestTest {
     String jsonFiles;
     List<File> filesList;
     try {
-      jsonFiles = readFileFromPath(FILES_PATH);
+      jsonFiles = TestUtil.readFileFromPath(FILES_PATH);
       filesList = new ObjectMapper().readValue(jsonFiles, new TypeReference<>() {
       });
     } catch (IOException e) {
@@ -1583,7 +1583,7 @@ public class ChangeManagerAPITest extends AbstractRestTest {
       .willReturn(WireMock.serverError()));
 
     InitJobExecutionsRqDto requestDto = new InitJobExecutionsRqDto();
-    String jsonFiles = readFileFromPath(FILES_PATH);
+    String jsonFiles = TestUtil.readFileFromPath(FILES_PATH);
     List<File> filesList = new ObjectMapper().readValue(jsonFiles, new TypeReference<>() {});
 
     requestDto.getFiles().addAll(filesList.stream().limit(1).collect(Collectors.toList()));
@@ -2279,7 +2279,7 @@ public class ChangeManagerAPITest extends AbstractRestTest {
     String jsonFiles;
     List<File> filesList;
     try {
-      jsonFiles = readFileFromPath(FILES_PATH);
+      jsonFiles = TestUtil.readFileFromPath(FILES_PATH);
       filesList = new ObjectMapper().readValue(jsonFiles, new TypeReference<>() {
       });
     } catch (IOException e) {
@@ -2320,7 +2320,7 @@ public class ChangeManagerAPITest extends AbstractRestTest {
     String jsonFiles;
     List<File> filesList;
     try {
-      jsonFiles = readFileFromPath(FILES_PATH);
+      jsonFiles = TestUtil.readFileFromPath(FILES_PATH);
       filesList = new ObjectMapper().readValue(jsonFiles, new TypeReference<>() {
       });
     } catch (IOException e) {
@@ -2512,9 +2512,5 @@ public class ChangeManagerAPITest extends AbstractRestTest {
       .put(JOB_EXECUTION_PATH + jobExec.getId())
       .then()
       .statusCode(HttpStatus.SC_NOT_FOUND);
-  }
-
-  public static String readFileFromPath(String path) throws IOException {
-    return new String(FileUtils.readFileToByteArray(new java.io.File(path)));
   }
 }

--- a/mod-source-record-manager-server/src/test/java/org/folio/rest/impl/changeManager/ChangeManagerAPITest.java
+++ b/mod-source-record-manager-server/src/test/java/org/folio/rest/impl/changeManager/ChangeManagerAPITest.java
@@ -703,7 +703,7 @@ public class ChangeManagerAPITest extends AbstractRestTest {
   @Test
   public void shouldUpdateStatusOfCompositeParentMultipleChildren() {
     List<JobExecution> executions = constructAndPostCompositeInitJobExecutionRqDto("test", 2);
-    assertThat(executions.size(), is(2));
+    assertThat(executions.size(), is(3));
     JobExecution parent = executions.get(0);
     JobExecution child1 = executions.get(1);
     JobExecution child2 = executions.get(2);


### PR DESCRIPTION
# [Jira MODSOURMAN-1041](https://issues.folio.org/browse/MODSOURMAN-1041)

## Purpose
When a composite job's child completes, we may need to mark its parent as completed, too.  This was done as part of the normal processing flow [here](https://github.com/folio-org/mod-source-record-manager/blob/6f135cae9f91c1a773631c134385d0182990a816/mod-source-record-manager-server/src/main/java/org/folio/services/RecordProcessedEventHandlingServiceImpl.java#L124), however, we should also do this upon external status changes from the `status` endpoint.

## Approach
This adds similar code as what is in `RecordProcessedEventHandlingServiceImpl`: when the update status method is called, we will first check that the updated job is a composite child; if so, we'll check that its siblings have all completed; and if all those conditions apply, we'll mark the parent `COMMITTED`/`RUNNING_COMPLETE`.

## Coverage: 💯 

![image](https://github.com/folio-org/mod-source-record-manager/assets/8005215/929e47d1-3c8c-47d4-a9bd-d536d24fa4f8)

## Extra
- Cleaned up some commented-out logs left in from previous DITF work
- Added a convenience method for tests to easily create parent and children composite job executions
