### PR TITLE
MODSOURMAN-1003: Allow create action when non-matches for instance

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,4 +1,5 @@
 ## 2023-xx-xx v3.7.0-SNAPSHOT
+* [MODSOURMAN-1003](https://issues.folio.org/browse/MODSOURMAN-1003) Allow create action with non-matches for instance
 * [MODSOURMAN-1029](https://issues.folio.org/browse/MODSOURMAN-1029) Introduce Global Backpressure For Kafka Consumption
 * [MODSOURMAN-1031](https://issues.folio.org/browse/MODSOURMAN-1031) The status of holdings is not displayed in the Import log after uploading file for creating holdings
 * [MODSOURMAN-1011](https://issues.folio.org/browse/MODSOURMAN-1011) Import An Instance With A Known Identifier (new acceptInstanceId parameter)

--- a/mod-source-record-manager-server/src/test/java/org/folio/rest/impl/changeManager/ChangeManagerAPITest.java
+++ b/mod-source-record-manager-server/src/test/java/org/folio/rest/impl/changeManager/ChangeManagerAPITest.java
@@ -2028,8 +2028,7 @@ public class ChangeManagerAPITest extends AbstractRestTest {
     RecordCollection recordCollection = Json
       .decodeValue(obtainedEvent.getEventPayload(), RecordCollection.class);
     Assert.assertNull(recordCollection.getRecords().get(0).getMatchedId());
-    Assert.assertNotNull(recordCollection.getRecords().get(0).getErrorRecord());
-    Assert.assertEquals( "{\"error\":\"A new Instance was not created because the incoming record already contained a 999ff$s or 999ff$i field\"}", recordCollection.getRecords().get(0).getErrorRecord().getDescription());
+    Assert.assertNull(recordCollection.getRecords().get(0).getErrorRecord());
   }
 
   @Test

--- a/mod-source-record-manager-server/src/test/java/org/folio/verticle/consumers/RawMarcChunkConsumersVerticleTest.java
+++ b/mod-source-record-manager-server/src/test/java/org/folio/verticle/consumers/RawMarcChunkConsumersVerticleTest.java
@@ -152,7 +152,7 @@ public class RawMarcChunkConsumersVerticleTest extends AbstractRestTest {
   }
 
   @Test
-  public void shouldNotFillInInstanceIdAndInstanceHridWhenRecordContains999FieldWithInstanceId() throws InterruptedException {
+  public void shouldFillInInstanceIdAndInstanceHridWhenRecordContains999FieldWithInstanceId() throws InterruptedException {
     // given
     SendKeyValues<String, String> request = prepareWithSpecifiedRecord(JobProfileInfo.DataType.MARC, RecordsMetadata.ContentType.MARC_RAW, RAW_RECORD_WITH_999_ff_field);
 
@@ -164,7 +164,9 @@ public class RawMarcChunkConsumersVerticleTest extends AbstractRestTest {
     RecordCollection recordCollection = Json.decodeValue(obtainedEvent.getEventPayload(), RecordCollection.class);
     assertEquals(1, recordCollection.getRecords().size());
     Record record = recordCollection.getRecords().get(0);
-    assertNull(record.getExternalIdsHolder());
+    assertNotNull(record.getExternalIdsHolder());
+    assertEquals("e27a5374-0857-462e-ac84-fb4795229c7a", record.getExternalIdsHolder().getInstanceId());
+    assertEquals("1007048", record.getExternalIdsHolder().getInstanceHrid());
   }
 
   @Test


### PR DESCRIPTION
## Purpose
Allow create action when non-matches for instance

## Approach
The validation condition is updated to check whether non-match operation is processed

## Tested on rancher
<img width="1237" alt="image" src="https://github.com/folio-org/mod-source-record-manager/assets/138673581/2d4c22c5-d942-493f-a8fb-def6ebf22c4c">


## Checklist
- [ ] I have updated NEWS.md.
- [ ] I have added javadocs to new methods.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation e.g. README.md.
- [ ] I have ran karate tests against this feature.

