### PR TITLE
MODSOURMAN-1045: allow create action when non-matches for instance

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,4 +1,5 @@
 ## 2023-xx-xx v3.7.0-SNAPSHOT
+* [MODSOURMAN-1045](https://issues.folio.org/browse/MODSOURMAN-1045) Allow create action with non-matches for instance without match profile
 * [MODSOURMAN-1003](https://issues.folio.org/browse/MODSOURMAN-1003) Allow create action with non-matches for instance
 * [MODSOURMAN-1029](https://issues.folio.org/browse/MODSOURMAN-1029) Introduce Global Backpressure For Kafka Consumption
 * [MODSOURMAN-1031](https://issues.folio.org/browse/MODSOURMAN-1031) The status of holdings is not displayed in the Import log after uploading file for creating holdings

--- a/mod-source-record-manager-server/src/main/java/org/folio/services/ChangeEngineServiceImpl.java
+++ b/mod-source-record-manager-server/src/main/java/org/folio/services/ChangeEngineServiceImpl.java
@@ -11,7 +11,7 @@ import static org.folio.rest.jaxrs.model.DataImportEventTypes.DI_MARC_FOR_DELETE
 import static org.folio.rest.jaxrs.model.DataImportEventTypes.DI_MARC_FOR_UPDATE_RECEIVED;
 import static org.folio.rest.jaxrs.model.DataImportEventTypes.DI_RAW_RECORDS_CHUNK_PARSED;
 import static org.folio.rest.jaxrs.model.ProfileSnapshotWrapper.ContentType.ACTION_PROFILE;
-import static org.folio.rest.jaxrs.model.ProfileSnapshotWrapper.ReactTo.MATCH;
+import static org.folio.rest.jaxrs.model.ProfileSnapshotWrapper.ReactTo.NON_MATCH;
 import static org.folio.rest.jaxrs.model.Record.RecordType.MARC_AUTHORITY;
 import static org.folio.rest.jaxrs.model.Record.RecordType.MARC_BIB;
 import static org.folio.rest.jaxrs.model.Record.RecordType.MARC_HOLDING;
@@ -300,7 +300,7 @@ public class ChangeEngineServiceImpl implements ChangeEngineService {
     for (ProfileSnapshotWrapper childWrapper : profileSnapshot.getChildSnapshotWrappers()) {
       if (childWrapper.getContentType() == ProfileSnapshotWrapper.ContentType.ACTION_PROFILE
         && actionProfileMatches(childWrapper, List.of(FolioRecord.INSTANCE), Action.CREATE)) {
-        return childWrapper.getReactTo() == MATCH;
+        return childWrapper.getReactTo() != NON_MATCH;
       } else if (containsCreateInstanceActionWithMatch(childWrapper)) {
         return true;
       }

--- a/mod-source-record-manager-server/src/test/java/org/folio/rest/impl/AbstractRestTest.java
+++ b/mod-source-record-manager-server/src/test/java/org/folio/rest/impl/AbstractRestTest.java
@@ -181,6 +181,12 @@ public abstract class AbstractRestTest {
     .withIncomingRecordType(EntityType.MARC_HOLDINGS)
     .withExistingRecordType(EntityType.HOLDINGS);
 
+  private final MappingProfile marcInstanceMappingProfile = new MappingProfile()
+    .withId(UUID.randomUUID().toString())
+    .withName("Create MARC-Instance ")
+    .withIncomingRecordType(EntityType.MARC_BIBLIOGRAPHIC)
+    .withExistingRecordType(EntityType.INSTANCE);
+
   private final ActionProfile actionMarcAuthorityCreateProfile = new ActionProfile()
     .withId(UUID.randomUUID().toString())
     .withName("Create MARC-Holdings ")
@@ -253,6 +259,22 @@ public abstract class AbstractRestTest {
         .withProfileId(UUID.randomUUID().toString())
         .withContentType(MAPPING_PROFILE)
         .withContent(marcHoldingsMappingProfile)))));
+
+  protected ProfileSnapshotWrapper profileCreateMarcInstanceSnapshotWrapperResponse = new ProfileSnapshotWrapper()
+    .withId(UUID.randomUUID().toString())
+    .withProfileId(jobProfile.getId())
+    .withContentType(JOB_PROFILE)
+    .withContent(new JsonObject())
+    .withChildSnapshotWrappers(Collections.singletonList(new ProfileSnapshotWrapper()
+      .withProfileId(UUID.randomUUID().toString())
+      .withContentType(ACTION_PROFILE)
+      .withReactTo(ProfileSnapshotWrapper.ReactTo.NON_MATCH)
+      .withContent(actionProfile)
+      .withChildSnapshotWrappers(Collections.singletonList(new ProfileSnapshotWrapper()
+        .withProfileId(UUID.randomUUID().toString())
+        .withContentType(MAPPING_PROFILE)
+        .withContent(marcInstanceMappingProfile)
+      ))));
 
   protected ProfileSnapshotWrapper profileMarcAuthoritySnapshotWrapperResponse = new ProfileSnapshotWrapper()
     .withId(UUID.randomUUID().toString())

--- a/mod-source-record-manager-server/src/test/java/org/folio/verticle/consumers/RawMarcChunkConsumersVerticleTest.java
+++ b/mod-source-record-manager-server/src/test/java/org/folio/verticle/consumers/RawMarcChunkConsumersVerticleTest.java
@@ -152,7 +152,7 @@ public class RawMarcChunkConsumersVerticleTest extends AbstractRestTest {
   }
 
   @Test
-  public void shouldFillInInstanceIdAndInstanceHridWhenRecordContains999FieldWithInstanceId() throws InterruptedException {
+  public void shouldNotFillInInstanceIdAndInstanceHridWhenRecordContains999FieldWithInstanceId() throws InterruptedException {
     // given
     SendKeyValues<String, String> request = prepareWithSpecifiedRecord(JobProfileInfo.DataType.MARC, RecordsMetadata.ContentType.MARC_RAW, RAW_RECORD_WITH_999_ff_field);
 
@@ -164,9 +164,7 @@ public class RawMarcChunkConsumersVerticleTest extends AbstractRestTest {
     RecordCollection recordCollection = Json.decodeValue(obtainedEvent.getEventPayload(), RecordCollection.class);
     assertEquals(1, recordCollection.getRecords().size());
     Record record = recordCollection.getRecords().get(0);
-    assertNotNull(record.getExternalIdsHolder());
-    assertEquals("e27a5374-0857-462e-ac84-fb4795229c7a", record.getExternalIdsHolder().getInstanceId());
-    assertEquals("1007048", record.getExternalIdsHolder().getInstanceHrid());
+    assertNull(record.getExternalIdsHolder());
   }
 
   @Test


### PR DESCRIPTION
## Purpose
Allow create action when non-matches for instance without match profile

## Approach
In cases when there is no a match profile `reactTo` is `null` therefore it should be handled properly to construct `ParsedResult` with errors for such a case.

## Tested on Rancher
<img width="1108" alt="image" src="https://github.com/folio-org/mod-source-record-manager/assets/138673581/c9fc3cd2-21c6-4c17-a500-7549cffdced5">


[MODSOURMAN-1045](https://issues.folio.org/browse/MODSOURMAN-1045)

