### PR TITLE
MODSOURMAN-1014: Upgrade folio-kafka-wrapper to 3.0.0 version

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -7,6 +7,7 @@
 * [MODSOURMAN-999](https://issues.folio.org/browse/MODSOURMAN-999) Upgrade mod-source-record-manager to Java 17
 * [MODSOURMAN-974](https://issues.folio.org/browse/MODSOURMAN-974) MARC bib $9 handling | Remove $9 subfields from linkable fields
 * [MODSOURMAN-971](https://issues.folio.org/browse/MODSOURMAN-971) Adjust journal records population to create multiple journal records for each Holdings/Item
+* [MODSOURMAN-1014](https://issues.folio.org/browse/MODSOURMAN-1014) Upgrade folio-kafka-wrapper to 3.0.0 version
 
 ## 2023-03-xo v3.6.1-SNAPSHOT
 * [MODSOURMAN-957](https://issues.folio.org/browse/MODSOURMAN-957) The '1' number of SRS MARC and Instance are displayed in cells in the row with the 'Updated' row header at the individual import job's log


### PR DESCRIPTION
## Purpose
Upgrade folio-kafka-wrapper to 3.0.0 version
## Approach
Upgrade the version of folio-kafka-wrapper to 3.0.0. Check out the readme at https://github.com/folio-org/folio-kafka-wrapper/blob/master/README.md for usage.

Acceptance Criteria
- kafka records are built using KafkaProducerRecordBuilder
- topic names are generated using KafkaTopicNameHelper