### PR TITLE
MODSOURMAN-1064: Default log configuration is way too verbose

### DIFF
--- a/mod-source-record-manager-server/src/main/resources/log4j2-json.properties
+++ b/mod-source-record-manager-server/src/main/resources/log4j2-json.properties
@@ -34,23 +34,23 @@ logger.folio_kafka.level = debug
 logger.folio_kafka.additivity = false
 logger.folio_kafka.appenderRef.stdout.ref = STDOUT
 
-rootLogger.level = debug
-rootLogger.appenderRefs = debug
+rootLogger.level = info
+rootLogger.appenderRefs = info
 rootLogger.appenderRef.stdout.ref = STDOUT
 
-#logger.cql2pgjson.name = org.folio.rest.persist.cql
-#logger.cql2pgjson.level = OFF
+logger.cql2pgjson.name = org.folio.rest.persist.cql
+logger.cql2pgjson.level = OFF
 
 logger.folio_rest.name = org.folio.rest
-logger.folio_rest.level = debug
+logger.folio_rest.level = WARN
 logger.folio_rest.appenderRef.stdout.ref = STDOUT
 
 logger.folio_persist.name = org.folio.rest.persist
-logger.folio_persist.level = debug
+logger.folio_persist.level = ERROR
 logger.folio_persist.appenderRef.stdout.ref = STDOUT
 
 #disable ProducerConfig/ConsumerConfig messages in log
 logger.kafka.name = org.apache.kafka
-logger.kafka.level = debug
+logger.kafka.level = warn
 logger.kafka.additivity = false
 logger.kafka.appenderRef.stdout.ref = STDOUT

--- a/mod-source-record-manager-server/src/main/resources/log4j2.properties
+++ b/mod-source-record-manager-server/src/main/resources/log4j2.properties
@@ -18,23 +18,23 @@ logger.folio_kafka.level = debug
 logger.folio_kafka.additivity = false
 logger.folio_kafka.appenderRef.stdout.ref = STDOUT
 
-rootLogger.level = debug
-rootLogger.appenderRefs = debug
+rootLogger.level = info
+rootLogger.appenderRefs = info
 rootLogger.appenderRef.stdout.ref = STDOUT
 
-#logger.cql2pgjson.name = org.folio.rest.persist.cql
-#logger.cql2pgjson.level = OFF
+logger.cql2pgjson.name = org.folio.rest.persist.cql
+logger.cql2pgjson.level = OFF
 
 logger.folio_rest.name = org.folio.rest
-logger.folio_rest.level = debug
+logger.folio_rest.level = WARN
 logger.folio_rest.appenderRef.stdout.ref = STDOUT
 
 logger.folio_persist.name = org.folio.rest.persist
-logger.folio_persist.level = debug
+logger.folio_persist.level = ERROR
 logger.folio_persist.appenderRef.stdout.ref = STDOUT
 
 #disable ProducerConfig/ConsumerConfig messages in log
 logger.kafka.name = org.apache.kafka
-logger.kafka.level = debug
+logger.kafka.level = warn
 logger.kafka.additivity = false
 logger.kafka.appenderRef.stdout.ref = STDOUT


### PR DESCRIPTION
## Purpose
Default log configuration is way too verbose

## Approach
Returned INFO level except DEBUG

[MODSOURMAN-1064](https://issues.folio.org/browse/MODSOURMAN-1064)