### PR TITLE
MODSOURMAN-1082 fix log details not shown for errors occurred prior to matching

### DIFF
--- a/mod-source-record-manager-server/src/main/java/org/folio/services/journal/JournalUtil.java
+++ b/mod-source-record-manager-server/src/main/java/org/folio/services/journal/JournalUtil.java
@@ -99,10 +99,14 @@ public class JournalUtil {
       if ((actionType == JournalRecord.ActionType.MATCH || actionType == JournalRecord.ActionType.NON_MATCH)
         && (entityType == HOLDINGS || entityType == ITEM)) {
         List<JournalRecord> resultedJournalRecords = new ArrayList<>();
-        if (isNotBlank(eventPayloadContext.get(NOT_MATCHED_NUMBER))) {
-          int notMatchedNumber = Integer.parseInt(eventPayloadContext.get(NOT_MATCHED_NUMBER));
+
+        String notMatchedNumberField = eventPayloadContext.get(NOT_MATCHED_NUMBER);
+        boolean isNotMatchedNumberPresent = isNotBlank(notMatchedNumberField);
+
+        if (isNotMatchedNumberPresent || actionType == JournalRecord.ActionType.NON_MATCH) {
+          int notMatchedNumber = isNotMatchedNumberPresent ? Integer.parseInt(notMatchedNumberField) : 1;
           for (int i = 0; i < notMatchedNumber; i++) {
-            resultedJournalRecords.add(constructBlankJournalRecord(record, entityType, actionStatus)
+            resultedJournalRecords.add(constructBlankJournalRecord(record, entityType, actionStatus, journalRecord.getError())
               .withEntityType(entityType));
           }
         }
@@ -250,7 +254,7 @@ public class JournalUtil {
   }
 
   private static JournalRecord constructBlankJournalRecord(Record record, JournalRecord.EntityType entityType,
-                                                           JournalRecord.ActionStatus actionStatus) {
+                                                           JournalRecord.ActionStatus actionStatus, String error) {
     return new JournalRecord()
       .withJobExecutionId(record.getSnapshotId())
       .withSourceId(record.getId())
@@ -258,6 +262,7 @@ public class JournalUtil {
       .withEntityType(entityType)
       .withActionType(JournalRecord.ActionType.NON_MATCH)
       .withActionDate(new Date())
-      .withActionStatus(actionStatus);
+      .withActionStatus(actionStatus)
+      .withError(error);
   }
 }


### PR DESCRIPTION
## Purpose
[MODSOURMAN-1082](https://issues.folio.org/browse/MODSOURMAN-1082)
Fix issue with log details not shown for errors occurred prior to matching

## Approach
Log details were not shown because journal records were not saved for case when error happened prior to matching. Handled this case and now the log details and errors are shown, ex.:

![image](https://github.com/folio-org/mod-source-record-manager/assets/11651407/aa00280c-a3f2-4bea-a75d-123d26128c5d)

