### PR TITLE
MODSOURMAN-1066 Fix hanging of the job with parsing errors for update scenarios

### DIFF
--- a/mod-source-record-manager-server/src/main/java/org/folio/verticle/consumers/errorhandlers/RawMarcChunksErrorHandler.java
+++ b/mod-source-record-manager-server/src/main/java/org/folio/verticle/consumers/errorhandlers/RawMarcChunksErrorHandler.java
@@ -114,7 +114,7 @@ public class RawMarcChunksErrorHandler implements ProcessRecordErrorHandler<Stri
   private void sendDiError(Throwable throwable, String jobExecutionId, OkapiConnectionParams okapiParams, Record record) {
     HashMap<String, String> context = new HashMap<>();
     context.put(ERROR_KEY, throwable.getMessage());
-    if (record != null) {
+    if (record != null && record.getRecordType() != null) {
       context.put(RecordConversionUtil.getEntityType(record).value(), Json.encode(record));
     }
 


### PR DESCRIPTION
## Purpose
Jobs with parsing errors fail for Update scenarios, because Error payload cannot be constructed if RecordType is undefined

## Approach
Make sure DI_ERROR event is sent even if RecordType is undefined

## Note
For scenarios when records are first saved in SRS, RecordType is defaulted to MARC_BIB. Not sure that's how it is supposed to be, but since we are removing the step of saving records in SRS, I don't think we should change it at this point
