### PR TITLE
MODSOURMAN-1030: The number of updated records is not correct displayed in the 'SRS Marc' column in the 'Log summary' table

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,7 @@
+## 2023-xx-xx v3.8.0-SNAPSHOT
+* [MODSOURMAN-1030](https://issues.folio.org/browse/MODSOURMAN-1030) The number of updated records is not correct displayed in the 'SRS Marc' column in the 'Log summary' table
+
+
 ## 2023-10-13 v3.7.0
 * [MODSOURMAN-1045](https://issues.folio.org/browse/MODSOURMAN-1045) Allow create action with non-matches for instance without match profile
 * [MODSOURMAN-1003](https://issues.folio.org/browse/MODSOURMAN-1003) Allow create action with non-matches for instance

--- a/mod-source-record-manager-server/src/main/resources/templates/db_scripts/create_get_job_execution_summary_function.sql
+++ b/mod-source-record-manager-server/src/main/resources/templates/db_scripts/create_get_job_execution_summary_function.sql
@@ -18,7 +18,7 @@ BEGIN
       journal_records.job_execution_id,
       COUNT(DISTINCT(source_id)) FILTER (WHERE action_status = 'ERROR') AS total_errors,
       COUNT(DISTINCT(source_id)) FILTER (WHERE entity_type IN ('MARC_BIBLIOGRAPHIC', 'MARC_HOLDINGS', 'MARC_AUTHORITY') AND action_type = 'CREATE' AND action_status = 'COMPLETED') AS total_created_source_records,
-      COUNT(DISTINCT(source_id)) FILTER (WHERE entity_type IN ('MARC_BIBLIOGRAPHIC', 'MARC_HOLDINGS', 'MARC_AUTHORITY') AND action_type IN ('UPDATE', 'MODIFY') AND action_status = 'COMPLETED') AS total_updated_source_records,
+      COUNT(DISTINCT(source_id)) FILTER (WHERE entity_type IN ('MARC_BIBLIOGRAPHIC', 'MARC_HOLDINGS', 'MARC_AUTHORITY') AND action_type = 'UPDATE' AND action_status = 'COMPLETED') AS total_updated_source_records,
       COUNT(*) FILTER (WHERE entity_type IN ('MARC_BIBLIOGRAPHIC', 'MARC_HOLDINGS', 'MARC_AUTHORITY') AND ((action_type = 'NON_MATCH' AND action_type_max = 'NON_MATCH') OR action_status = 'ERROR')) AS total_discarded_source_records,
       COUNT(*) FILTER (WHERE entity_type IN ('MARC_BIBLIOGRAPHIC', 'MARC_HOLDINGS', 'MARC_AUTHORITY') AND action_status = 'ERROR') AS total_source_records_errors,
 
@@ -55,12 +55,12 @@ BEGIN
 	    INNER JOIN (SELECT entity_id as entity_id_max, entity_type as entity_type_max, action_status as action_status_max,(array_agg(id ORDER BY array_position(array['CREATE', 'UPDATE', 'MODIFY', 'NON_MATCH'], action_type)))[1] as id
         FROM journal_records
         WHERE journal_records.job_execution_id = job_id
-			  group by entity_id, entity_type, action_status) AS actions
+			  GROUP BY id, entity_id, entity_type, action_status) AS actions
       ON actions.id = journal_records.id
       INNER JOIN (SELECT (array_agg(action_type ORDER BY array_position(array['CREATE', 'UPDATE', 'MODIFY', 'NON_MATCH'], action_type)))[1] as action_type_max, source_id as source_id_max, entity_type as entity_type_max
         FROM journal_records
         WHERE journal_records.job_execution_id = job_id
-        group by entity_type_max, source_id_max) AS action_type_by_source
+        GROUP BY entity_type_max, source_id_max) AS action_type_by_source
       ON action_type_by_source.source_id_max = journal_records.source_id AND action_type_by_source.entity_type_max = journal_records.entity_type
     GROUP BY (journal_records.job_execution_id);
 END;

--- a/mod-source-record-manager-server/src/main/resources/templates/db_scripts/schema.json
+++ b/mod-source-record-manager-server/src/main/resources/templates/db_scripts/schema.json
@@ -185,7 +185,7 @@
     {
       "run": "after",
       "snippetPath": "create_get_job_execution_summary_function.sql",
-      "fromModuleVersion": "mod-source-record-manager-3.6.1"
+      "fromModuleVersion": "mod-source-record-manager-3.8.0"
     },
     {
       "run": "after",

--- a/mod-source-record-manager-server/src/test/java/org/folio/rest/impl/metadataProvider/MetadataProviderJobExecutionAPITest.java
+++ b/mod-source-record-manager-server/src/test/java/org/folio/rest/impl/metadataProvider/MetadataProviderJobExecutionAPITest.java
@@ -1014,10 +1014,8 @@ public class MetadataProviderJobExecutionAPITest extends AbstractRestTest {
     Async async = context.async();
     JobExecution createdJobExecution = constructAndPostInitJobExecutionRqDto(1).getJobExecutions().get(0);
     String sourceRecordId = UUID.randomUUID().toString();
-    String recordTitle = "test title";
 
     Future<JournalRecord> future = Future.succeededFuture()
-      .compose(v -> createJournalRecord(createdJobExecution.getId(), sourceRecordId, null, null, recordTitle, 0, CREATE, MARC_BIBLIOGRAPHIC, COMPLETED, null))
       .compose(v -> createJournalRecord(createdJobExecution.getId(), sourceRecordId, null, null, null, 0, UPDATE, MARC_BIBLIOGRAPHIC, COMPLETED, null))
       .onFailure(context::fail);
 
@@ -1028,8 +1026,8 @@ public class MetadataProviderJobExecutionAPITest extends AbstractRestTest {
         .get(GET_JOB_EXECUTION_SUMMARY_PATH + "/" + createdJobExecution.getId())
         .then()
         .statusCode(HttpStatus.SC_OK)
-        .body("sourceRecordSummary.totalCreatedEntities", is(1))
-        .body("sourceRecordSummary.totalUpdatedEntities", is(0))
+        .body("sourceRecordSummary.totalCreatedEntities", is(0))
+        .body("sourceRecordSummary.totalUpdatedEntities", is(1))
         .body("sourceRecordSummary.totalDiscardedEntities", is(0))
         .body("sourceRecordSummary.totalErrors", is(0))
         .body("totalErrors", is(0));
@@ -1039,7 +1037,40 @@ public class MetadataProviderJobExecutionAPITest extends AbstractRestTest {
   }
 
   @Test
-  public void shouldReturnUpdatedSourceRecordSummaryWhenRecordWasModified(TestContext context) {
+  public void shouldReturnEightUpdatedSourceRecordSummaryWhenRecordWasUpdated(TestContext context) {
+    Async async = context.async();
+    JobExecution createdJobExecution = constructAndPostInitJobExecutionRqDto(1).getJobExecutions().get(0);
+
+    Future<JournalRecord> future = Future.succeededFuture()
+      .compose(v -> createJournalRecord(createdJobExecution.getId(), UUID.randomUUID().toString(), null, null, null, 0, UPDATE, MARC_BIBLIOGRAPHIC, COMPLETED, null))
+      .compose(v -> createJournalRecord(createdJobExecution.getId(), UUID.randomUUID().toString(), null, null, null, 1, UPDATE, MARC_BIBLIOGRAPHIC, COMPLETED, null))
+      .compose(v -> createJournalRecord(createdJobExecution.getId(), UUID.randomUUID().toString(), null, null, null, 2, UPDATE, MARC_BIBLIOGRAPHIC, COMPLETED, null))
+      .compose(v -> createJournalRecord(createdJobExecution.getId(), UUID.randomUUID().toString(), null, null, null, 3, UPDATE, MARC_BIBLIOGRAPHIC, COMPLETED, null))
+      .compose(v -> createJournalRecord(createdJobExecution.getId(), UUID.randomUUID().toString(), null, null, null, 4, UPDATE, MARC_BIBLIOGRAPHIC, COMPLETED, null))
+      .compose(v -> createJournalRecord(createdJobExecution.getId(), UUID.randomUUID().toString(), null, null, null, 5, UPDATE, MARC_BIBLIOGRAPHIC, COMPLETED, null))
+      .compose(v -> createJournalRecord(createdJobExecution.getId(), UUID.randomUUID().toString(), null, null, null, 6, UPDATE, MARC_BIBLIOGRAPHIC, COMPLETED, null))
+      .compose(v -> createJournalRecord(createdJobExecution.getId(), UUID.randomUUID().toString(), null, null, null, 7, UPDATE, MARC_BIBLIOGRAPHIC, COMPLETED, null))
+      .onFailure(context::fail);
+
+    future.onComplete(ar -> context.verify(v -> {
+      RestAssured.given()
+        .spec(spec)
+        .when()
+        .get(GET_JOB_EXECUTION_SUMMARY_PATH + "/" + createdJobExecution.getId())
+        .then()
+        .statusCode(HttpStatus.SC_OK)
+        .body("sourceRecordSummary.totalCreatedEntities", is(0))
+        .body("sourceRecordSummary.totalUpdatedEntities", is(8))
+        .body("sourceRecordSummary.totalDiscardedEntities", is(0))
+        .body("sourceRecordSummary.totalErrors", is(0))
+        .body("totalErrors", is(0));
+
+      async.complete();
+    }));
+  }
+
+  @Test
+  public void shouldNotReturnUpdatedSourceRecordSummaryWhenRecordWasModified(TestContext context) {
     Async async = context.async();
     JobExecution createdJobExecution = constructAndPostInitJobExecutionRqDto(1).getJobExecutions().get(0);
     String sourceRecordId = UUID.randomUUID().toString();


### PR DESCRIPTION
## Purpose
The number of updated records is not correct displayed in the 'SRS Marc' column in the 'Log summary' table
## Approach
Change the script function which creates get_job_execution_summary, so all journal records with action status 'UPDATE' can be viewed.

Step of reproducing this issue: [MODSOURMAN-1030](https://issues.folio.org/browse/MODSOURMAN-1030).