### PR TITLE
MODSOURMAN-1022: remove step of initial saving of incoming records to SRS

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -2,6 +2,7 @@
 * [MODSOURMAN-1030](https://issues.folio.org/browse/MODSOURMAN-1030) The number of updated records is not correct displayed in the 'SRS Marc' column in the 'Log summary' table
 * [MODSOURMAN-1020](https://issues.folio.org/browse/MODSOURMAN-1020) Add table to save incoming records for DI logs
 * [MODSOURMAN-1021](https://issues.folio.org/browse/MODSOURMAN-1021) Provide endpoint for getting parsed content for DI log
+* [MODSOURMAN-1022](https://issues.folio.org/browse/MODSOURMAN-1022) Remove step of initial saving of incoming records to SRS
 
 ## 2023-10-13 v3.7.0
 * [MODSOURMAN-1045](https://issues.folio.org/browse/MODSOURMAN-1045) Allow create action with non-matches for instance without match profile

--- a/mod-source-record-manager-server/src/main/java/org/folio/services/ChangeEngineServiceImpl.java
+++ b/mod-source-record-manager-server/src/main/java/org/folio/services/ChangeEngineServiceImpl.java
@@ -7,6 +7,8 @@ import static org.apache.commons.lang3.StringUtils.isNotBlank;
 
 import static org.folio.rest.RestVerticle.MODULE_SPECIFIC_ARGS;
 import static org.folio.rest.jaxrs.model.DataImportEventTypes.DI_ERROR;
+import static org.folio.rest.jaxrs.model.DataImportEventTypes.DI_INCOMING_EDIFACT_RECORD_PARSED;
+import static org.folio.rest.jaxrs.model.DataImportEventTypes.DI_INCOMING_MARC_BIB_RECORD_PARSED;
 import static org.folio.rest.jaxrs.model.DataImportEventTypes.DI_MARC_FOR_DELETE_RECEIVED;
 import static org.folio.rest.jaxrs.model.DataImportEventTypes.DI_MARC_FOR_UPDATE_RECEIVED;
 import static org.folio.rest.jaxrs.model.DataImportEventTypes.DI_RAW_RECORDS_CHUNK_PARSED;
@@ -72,6 +74,7 @@ import org.folio.rest.jaxrs.model.ActionProfile;
 import org.folio.rest.jaxrs.model.ActionProfile.Action;
 import org.folio.rest.jaxrs.model.ActionProfile.FolioRecord;
 import org.folio.rest.jaxrs.model.DataImportEventPayload;
+import org.folio.rest.jaxrs.model.DataImportEventTypes;
 import org.folio.rest.jaxrs.model.EntityType;
 import org.folio.rest.jaxrs.model.ErrorRecord;
 import org.folio.rest.jaxrs.model.ExternalIdsHolder;
@@ -177,47 +180,93 @@ public class ChangeEngineServiceImpl implements ChangeEngineService {
         .map(parsedRecords))
       .onSuccess(parsedRecords -> {
         fillParsedRecordsWithAdditionalFields(parsedRecords);
-
-        if (updateMarcActionExists(jobExecution) || updateInstanceActionExists(jobExecution) || isCreateOrUpdateItemOrHoldingsActionExists(jobExecution, parsedRecords)) {
-          hrIdFieldService.move001valueTo035Field(parsedRecords);
-          updateRecords(parsedRecords, jobExecution, params)
-            .onSuccess(ar -> promise.complete(parsedRecords))
-            .onFailure(promise::fail);
-        } else if (deleteMarcActionExists(jobExecution)) {
-          deleteRecords(parsedRecords, jobExecution, params)
-            .onSuccess(ar -> promise.complete(parsedRecords))
-            .onFailure(promise::fail);
-        } else {
-          saveRecords(params, jobExecution, parsedRecords)
-            .onComplete(postAr -> {
-              if (postAr.failed()) {
-                StatusDto statusDto = new StatusDto()
-                  .withStatus(StatusDto.Status.ERROR)
-                  .withErrorStatus(StatusDto.ErrorStatus.RECORD_UPDATE_ERROR);
-                jobExecutionService.updateJobExecutionStatus(jobExecution.getId(), statusDto, params)
-                  .onComplete(r -> {
-                    if (r.failed()) {
-                      LOGGER.warn("parseRawRecordsChunkForJobExecution:: Error during update jobExecution and snapshot status", r.cause());
-                    }
-                  });
-                jobExecutionSourceChunkDao.getById(sourceChunkId, params.getTenantId())
-                  .compose(optional -> optional
-                    .map(sourceChunk -> jobExecutionSourceChunkDao
-                      .update(sourceChunk.withState(JobExecutionSourceChunk.State.ERROR), params.getTenantId()))
-                    .orElseThrow(() -> new NotFoundException(String.format(
-                      "Couldn't update failed jobExecutionSourceChunk status to ERROR, jobExecutionSourceChunk with id %s was not found",
-                      sourceChunkId))))
-                  .onComplete(ar -> promise.fail(postAr.cause()));
-              } else {
-                promise.complete(parsedRecords);
-              }
-            });
-        }
+        processRecords(parsedRecords, jobExecution, params, sourceChunkId, promise);
       }).onFailure(th -> {
         LOGGER.warn("parseRawRecordsChunkForJobExecution:: Error parsing records: {}", th.getMessage());
         promise.fail(th);
       });
     return promise.future();
+  }
+
+  private void processRecords(List<Record> parsedRecords, JobExecution jobExecution, OkapiConnectionParams params,
+                              String sourceChunkId, Promise<List<Record>> promise) {
+    switch (getAction(parsedRecords, jobExecution)) {
+      case UPDATE_RECORD -> {
+        hrIdFieldService.move001valueTo035Field(parsedRecords);
+        updateRecords(parsedRecords, jobExecution, params)
+          .onSuccess(ar -> promise.complete(parsedRecords)).onFailure(promise::fail);
+      }
+      case DELETE_RECORD -> deleteRecords(parsedRecords, jobExecution, params)
+        .onSuccess(ar -> promise.complete(parsedRecords)).onFailure(promise::fail);
+      case SEND_ERROR -> sendEvents(parsedRecords, jobExecution, params, DI_ERROR)
+        .onSuccess(ar -> promise.complete(parsedRecords)).onFailure(promise::fail);
+      case SEND_MARC_BIB -> sendEvents(parsedRecords, jobExecution, params, DI_INCOMING_MARC_BIB_RECORD_PARSED)
+        .onSuccess(ar -> promise.complete(parsedRecords)).onFailure(promise::fail);
+      case SEND_EDIFACT -> sendEvents(parsedRecords, jobExecution, params, DI_INCOMING_EDIFACT_RECORD_PARSED)
+        .onSuccess(ar -> promise.complete(parsedRecords)).onFailure(promise::fail);
+      default -> saveRecords(jobExecution, sourceChunkId, params, parsedRecords, promise);
+    }
+  }
+
+  private ActionType getAction(List<Record> parsedRecords, JobExecution jobExecution) {
+    if (updateMarcActionExists(jobExecution) || updateInstanceActionExists(jobExecution)
+      || isCreateOrUpdateItemOrHoldingsActionExists(jobExecution, parsedRecords)) {
+      return ActionType.UPDATE_RECORD;
+    }
+    if (deleteMarcActionExists(jobExecution)) {
+      return ActionType.DELETE_RECORD;
+    }
+    if (parsedRecords.isEmpty()) {
+      return ActionType.SAVE_RECORD;
+    }
+    RecordType recordType = parsedRecords.get(0).getRecordType();
+    if (recordType == RecordType.MARC_BIB) {
+      return ActionType.SEND_MARC_BIB;
+    }
+    if (recordType == RecordType.EDIFACT) {
+      return ActionType.SEND_EDIFACT;
+    }
+    if (recordType == null) {
+      return ActionType.SEND_ERROR;
+    }
+    return ActionType.SAVE_RECORD;
+  }
+
+  private enum ActionType {
+    UPDATE_RECORD, DELETE_RECORD, SEND_ERROR, SEND_MARC_BIB, SEND_EDIFACT, SAVE_RECORD
+  }
+
+  private void saveRecords(JobExecution jobExecution, String sourceChunkId, OkapiConnectionParams params, List<Record> parsedRecords, Promise<List<Record>> promise) {
+    saveRecords(params, jobExecution, parsedRecords)
+      .onComplete(postAr -> {
+        if (postAr.failed()) {
+          StatusDto statusDto = new StatusDto()
+            .withStatus(StatusDto.Status.ERROR)
+            .withErrorStatus(StatusDto.ErrorStatus.RECORD_UPDATE_ERROR);
+          jobExecutionService.updateJobExecutionStatus(jobExecution.getId(), statusDto, params)
+            .onComplete(r -> {
+              if (r.failed()) {
+                LOGGER.warn("parseRawRecordsChunkForJobExecution:: Error during update jobExecution with id '{}' and snapshot status",
+                  jobExecution.getId(), r.cause());
+              }
+            });
+          jobExecutionSourceChunkDao.getById(sourceChunkId, params.getTenantId())
+            .compose(optional -> optional
+              .map(sourceChunk -> jobExecutionSourceChunkDao
+                .update(sourceChunk.withState(JobExecutionSourceChunk.State.ERROR), params.getTenantId()))
+              .orElseThrow(() -> new NotFoundException(String.format(
+                "Couldn't update failed jobExecutionSourceChunk status to ERROR, jobExecutionSourceChunk with id %s was not found, jobExecutionId: %s",
+                sourceChunkId, jobExecution.getId()))))
+            .onComplete(ar -> promise.fail(postAr.cause()));
+        } else {
+          promise.complete(parsedRecords);
+        }
+      });
+  }
+
+  private Future<Boolean> sendEvents(List<Record> records, JobExecution jobExecution, OkapiConnectionParams params, DataImportEventTypes eventType) {
+    LOGGER.info("sendEvents:: Sending events with type: {}, jobExecutionId: {}", eventType.value(), jobExecution.getId());
+    return recordsPublishingService.sendEventsWithRecords(records, jobExecution.getId(), params, eventType.value());
   }
 
   private void saveIncomingAndJournalRecords(List<Record> parsedRecords, String tenantId) {
@@ -738,6 +787,7 @@ public class ChangeEngineServiceImpl implements ChangeEngineService {
     if (CollectionUtils.isEmpty(parsedRecords)) {
       return Future.succeededFuture();
     }
+    LOGGER.info("saveRecords:: Saving records in SRS, amount: {}, jobExecutionId: {}", parsedRecords.size(), jobExecution.getId());
     RecordCollection recordCollection = new RecordCollection()
       .withRecords(parsedRecords)
       .withTotalRecords(parsedRecords.size());

--- a/mod-source-record-manager-server/src/main/java/org/folio/verticle/consumers/StoredRecordChunksKafkaHandler.java
+++ b/mod-source-record-manager-server/src/main/java/org/folio/verticle/consumers/StoredRecordChunksKafkaHandler.java
@@ -35,7 +35,6 @@ import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.stereotype.Component;
 
 import javax.ws.rs.NotFoundException;
-import java.util.Arrays;
 import java.util.Date;
 import java.util.LinkedHashMap;
 import java.util.List;
@@ -45,10 +44,10 @@ import java.util.stream.Collectors;
 
 import static java.lang.String.format;
 import static org.apache.commons.lang3.ObjectUtils.allNotNull;
-import static org.folio.rest.jaxrs.model.DataImportEventTypes.DI_EDIFACT_RECORD_CREATED;
+import static org.folio.rest.jaxrs.model.DataImportEventTypes.DI_INCOMING_EDIFACT_RECORD_PARSED;
 import static org.folio.rest.jaxrs.model.DataImportEventTypes.DI_MARC_BIB_FOR_ORDER_CREATED;
 import static org.folio.rest.jaxrs.model.DataImportEventTypes.DI_SRS_MARC_AUTHORITY_RECORD_CREATED;
-import static org.folio.rest.jaxrs.model.DataImportEventTypes.DI_SRS_MARC_BIB_RECORD_CREATED;
+import static org.folio.rest.jaxrs.model.DataImportEventTypes.DI_INCOMING_MARC_BIB_RECORD_PARSED;
 import static org.folio.rest.jaxrs.model.DataImportEventTypes.DI_SRS_MARC_HOLDING_RECORD_CREATED;
 import static org.folio.rest.jaxrs.model.JournalRecord.ActionStatus.COMPLETED;
 import static org.folio.rest.jaxrs.model.JournalRecord.ActionType.CREATE;
@@ -70,10 +69,10 @@ public class StoredRecordChunksKafkaHandler implements AsyncRecordHandler<String
   public static final String CREATE_ACTION = "CREATE";
 
   private static final Map<RecordType, DataImportEventTypes> RECORD_TYPE_TO_EVENT_TYPE = Map.of(
-    MARC_BIB, DI_SRS_MARC_BIB_RECORD_CREATED,
+    MARC_BIB, DI_INCOMING_MARC_BIB_RECORD_PARSED,
     MARC_AUTHORITY, DI_SRS_MARC_AUTHORITY_RECORD_CREATED,
     MARC_HOLDING, DI_SRS_MARC_HOLDING_RECORD_CREATED,
-    EDIFACT, DI_EDIFACT_RECORD_CREATED
+    EDIFACT, DI_INCOMING_EDIFACT_RECORD_PARSED
   );
 
   private RecordsPublishingService recordsPublishingService;
@@ -124,7 +123,7 @@ public class StoredRecordChunksKafkaHandler implements AsyncRecordHandler<String
                 // we only know record type by inspecting the records, assuming records are homogeneous type and defaulting to previous static value
                 DataImportEventTypes eventType = !storedRecords.isEmpty() && RECORD_TYPE_TO_EVENT_TYPE.containsKey(storedRecords.get(0).getRecordType())
                   ? RECORD_TYPE_TO_EVENT_TYPE.get(storedRecords.get(0).getRecordType())
-                  : DI_SRS_MARC_BIB_RECORD_CREATED;
+                  : DI_INCOMING_MARC_BIB_RECORD_PARSED;
 
                 LOGGER.debug("handle:: RecordsBatchResponse has been received, starting processing chunkId: {} chunkNumber: {} jobExecutionId: {}", chunkId, chunkNumber, jobExecutionId);
                 saveCreatedRecordsInfoToDataImportLog(storedRecords, okapiConnectionParams.getTenantId());

--- a/mod-source-record-manager-server/src/test/java/org/folio/rest/impl/changeManager/ChangeManagerAPITest.java
+++ b/mod-source-record-manager-server/src/test/java/org/folio/rest/impl/changeManager/ChangeManagerAPITest.java
@@ -74,6 +74,8 @@ import static com.github.tomakehurst.wiremock.client.WireMock.verify;
 import static java.util.Arrays.asList;
 import static java.util.Collections.emptyList;
 import static java.util.Collections.singletonList;
+import static org.folio.rest.jaxrs.model.DataImportEventTypes.DI_INCOMING_MARC_BIB_RECORD_PARSED;
+import static org.folio.rest.jaxrs.model.DataImportEventTypes.DI_ERROR;
 import static org.folio.rest.jaxrs.model.DataImportEventTypes.DI_MARC_FOR_UPDATE_RECEIVED;
 import static org.folio.rest.jaxrs.model.DataImportEventTypes.DI_RAW_RECORDS_CHUNK_PARSED;
 import static org.folio.rest.jaxrs.model.ProfileSnapshotWrapper.ContentType.ACTION_PROFILE;
@@ -91,6 +93,10 @@ import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.not;
 import static org.hamcrest.Matchers.notNullValue;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertNotNull;
 
 /**
  * REST tests for ChangeManager to manager JobExecution entities initialization
@@ -1760,21 +1766,17 @@ public class ChangeManagerAPITest extends AbstractRestTest {
       .then()
       .statusCode(HttpStatus.SC_NO_CONTENT);
 
-    String topicToObserve = formatToKafkaTopicName(DI_RAW_RECORDS_CHUNK_PARSED.value());
-    List<String> observedValues = kafkaCluster.observeValues(ObserveKeyValues.on(topicToObserve, 1)
+    String topicToObserve = formatToKafkaTopicName(DI_INCOMING_MARC_BIB_RECORD_PARSED.value());
+    List<String> observedValues = kafkaCluster.observeValues(ObserveKeyValues.on(topicToObserve, 3)
       .observeFor(30, TimeUnit.SECONDS)
       .build());
 
-    Event obtainedEvent = Json.decodeValue(observedValues.get(0), Event.class);
-    assertEquals(DI_RAW_RECORDS_CHUNK_PARSED.value(), obtainedEvent.getEventType());
-
-    RecordCollection processedRecords = Json
-      .decodeValue(obtainedEvent.getEventPayload(), RecordCollection.class);
-    assertEquals(3, processedRecords.getRecords().size());
-
-    assertEquals(4, processedRecords.getRecords().get(0).getOrder().intValue());
-    assertEquals(5, processedRecords.getRecords().get(1).getOrder().intValue());
-    assertEquals(6, processedRecords.getRecords().get(2).getOrder().intValue());
+    Event obtainedEvent = Json.decodeValue(observedValues.get(2), Event.class);
+    assertEquals(DI_INCOMING_MARC_BIB_RECORD_PARSED.value(), obtainedEvent.getEventType());
+    DataImportEventPayload eventPayload = Json.decodeValue(obtainedEvent.getEventPayload(), DataImportEventPayload.class);
+    assertNotNull(eventPayload.getContext());
+    JsonObject record = new JsonObject(eventPayload.getContext().get("MARC_BIBLIOGRAPHIC"));
+    assertNotEquals(0, record.getInteger("order").intValue());
   }
 
   @Test
@@ -2139,19 +2141,21 @@ public class ChangeManagerAPITest extends AbstractRestTest {
       .statusCode(HttpStatus.SC_NO_CONTENT);
     async.complete();
 
-    String topicToObserve = formatToKafkaTopicName(DI_RAW_RECORDS_CHUNK_PARSED.value());
-    List<String> observedValues = kafkaCluster.observeValues(ObserveKeyValues.on(topicToObserve, 1)
+    String topicToObserve = formatToKafkaTopicName(DI_ERROR.value());
+    List<String> observedValues = kafkaCluster.observeValues(ObserveKeyValues.on(topicToObserve, 2)
       .observeFor(30, TimeUnit.SECONDS)
       .build());
 
-    Event obtainedEvent = Json.decodeValue(observedValues.get(5), Event.class);
-    assertEquals(DI_RAW_RECORDS_CHUNK_PARSED.value(), obtainedEvent.getEventType());
-    RecordCollection recordCollection = Json
-      .decodeValue(obtainedEvent.getEventPayload(), RecordCollection.class);
-    Assert.assertNull(recordCollection.getRecords().get(0).getMatchedId());
-    Assert.assertNotNull(recordCollection.getRecords().get(0).getErrorRecord());
-    Assert.assertEquals("{\"error\":\"A new Instance was not created because the incoming record already contained a 999ff$s or 999ff$i field\"}",
-      recordCollection.getRecords().get(0).getErrorRecord().getDescription());
+    Event obtainedEvent = Json.decodeValue(observedValues.get(1), Event.class);
+    assertEquals(DI_ERROR.value(), obtainedEvent.getEventType());
+    DataImportEventPayload eventPayload = Json.decodeValue(obtainedEvent.getEventPayload(), DataImportEventPayload.class);
+
+    assertNotNull(eventPayload.getContext());
+    JsonObject record = new JsonObject(eventPayload.getContext().get("MARC_BIBLIOGRAPHIC"));
+    assertNull(record.getString("matchedId"));
+    assertFalse(record.getJsonObject("errorRecord").isEmpty());
+    assertEquals("A new Instance was not created because the incoming record already contained a 999ff$s or 999ff$i field",
+      new JsonObject(eventPayload.getContext().get("ERROR")).getString("error"));
   }
 
   @Test
@@ -2195,15 +2199,16 @@ public class ChangeManagerAPITest extends AbstractRestTest {
       .statusCode(HttpStatus.SC_NO_CONTENT);
     async.complete();
 
-    String topicToObserve = formatToKafkaTopicName(DI_RAW_RECORDS_CHUNK_PARSED.value());
+    String topicToObserve = formatToKafkaTopicName(DI_INCOMING_MARC_BIB_RECORD_PARSED.value());
     List<String> observedValues = kafkaCluster.observeValues(
-      ObserveKeyValues.on(topicToObserve, 1).observeFor(30, TimeUnit.SECONDS).build());
+      ObserveKeyValues.on(topicToObserve, 57).observeFor(30, TimeUnit.SECONDS).build());
 
-    Event obtainedEvent = Json.decodeValue(observedValues.get(0), Event.class);
-    assertEquals(DI_RAW_RECORDS_CHUNK_PARSED.value(), obtainedEvent.getEventType());
-    RecordCollection recordCollection = Json.decodeValue(obtainedEvent.getEventPayload(), RecordCollection.class);
-    Assert.assertNull(recordCollection.getRecords().get(0).getMatchedId());
-    Assert.assertNull(recordCollection.getRecords().get(0).getErrorRecord());
+    Event obtainedEvent = Json.decodeValue(observedValues.get(56), Event.class);
+    assertEquals(DI_INCOMING_MARC_BIB_RECORD_PARSED.value(), obtainedEvent.getEventType());
+    DataImportEventPayload eventPayload = Json.decodeValue(obtainedEvent.getEventPayload(), DataImportEventPayload.class);
+    JsonObject record = new JsonObject(eventPayload.getContext().get("MARC_BIBLIOGRAPHIC"));
+    assertNull(record.getString("matchedId"));
+    assertNull(record.getJsonObject("errorRecord"));
   }
 
   @Test
@@ -2214,8 +2219,7 @@ public class ChangeManagerAPITest extends AbstractRestTest {
     assertThat(createdJobExecutions.size(), is(1));
     JobExecution jobExec = createdJobExecutions.get(0);
 
-
-    WireMock.stubFor(WireMock.get("/data-import-profiles/jobProfiles/"+ DEFAULT_MARC_AUTHORITY_JOB_PROFILE_ID +"?withRelations=false&")
+    WireMock.stubFor(WireMock.get("/data-import-profiles/jobProfiles/" + DEFAULT_MARC_AUTHORITY_JOB_PROFILE_ID + "?withRelations=false&")
       .willReturn(WireMock.ok().withBody(Json.encode(new JobProfile().withId(DEFAULT_MARC_AUTHORITY_JOB_PROFILE_ID).withName("Default - Create SRS MARC Authority")))));
 
     WireMock.stubFor(post(RECORDS_SERVICE_URL)
@@ -2249,17 +2253,17 @@ public class ChangeManagerAPITest extends AbstractRestTest {
     async.complete();
 
     String topicToObserve = formatToKafkaTopicName(DI_RAW_RECORDS_CHUNK_PARSED.value());
-    List<String> observedValues = kafkaCluster.observeValues(ObserveKeyValues.on(topicToObserve, 3)
+    List<String> observedValues = kafkaCluster.observeValues(ObserveKeyValues.on(topicToObserve, 1)
       .observeFor(30, TimeUnit.SECONDS)
       .build());
 
-    Event obtainedEvent = Json.decodeValue(observedValues.get(3), Event.class);
+    Event obtainedEvent = Json.decodeValue(observedValues.get(0), Event.class);
     assertEquals(DI_RAW_RECORDS_CHUNK_PARSED.value(), obtainedEvent.getEventType());
-    RecordCollection recordCollection = Json
-      .decodeValue(obtainedEvent.getEventPayload(), RecordCollection.class);
-    Assert.assertNull(recordCollection.getRecords().get(0).getMatchedId());
-    Assert.assertNotNull(recordCollection.getRecords().get(0).getErrorRecord());
-    Assert.assertEquals( "{\"error\":\"A new MARC-Authority was not created because the incoming record already contained a 999ff$s or 999ff$i field\"}", recordCollection.getRecords().get(0).getErrorRecord().getDescription());
+    RecordCollection recordCollection = Json.decodeValue(obtainedEvent.getEventPayload(), RecordCollection.class);
+    assertNull(recordCollection.getRecords().get(0).getMatchedId());
+    assertNotNull(recordCollection.getRecords().get(0).getErrorRecord());
+    assertEquals("{\"error\":\"A new MARC-Authority was not created because the incoming record already contained a 999ff$s or 999ff$i field\"}",
+      recordCollection.getRecords().get(0).getErrorRecord().getDescription());
   }
 
   @Test
@@ -2296,16 +2300,15 @@ public class ChangeManagerAPITest extends AbstractRestTest {
       .statusCode(HttpStatus.SC_NO_CONTENT);
     async.complete();
 
-    String topicToObserve = formatToKafkaTopicName(DI_RAW_RECORDS_CHUNK_PARSED.value());
-    List<String> observedValues = kafkaCluster.observeValues(ObserveKeyValues.on(topicToObserve, 3)
-      .observeFor(30, TimeUnit.SECONDS)
-      .build());
+    String topicToObserve = formatToKafkaTopicName(DI_ERROR.value());
+    List<String> observedValues = kafkaCluster.observeValues(ObserveKeyValues.on(topicToObserve, 1)
+      .observeFor(30, TimeUnit.SECONDS).build());
 
-    Event obtainedEvent = Json.decodeValue(observedValues.get(2), Event.class);
-    assertEquals(DI_RAW_RECORDS_CHUNK_PARSED.value(), obtainedEvent.getEventType());
-    RecordCollection recordCollection = Json.decodeValue(obtainedEvent.getEventPayload(), RecordCollection.class);
-    assertEquals(1, recordCollection.getRecords().size());
-    MatcherAssert.assertThat(recordCollection.getRecords().get(0).getErrorRecord().getDescription(), containsString("Error during analyze leader line for determining record type"));
+    Event obtainedEvent = Json.decodeValue(observedValues.get(0), Event.class);
+    assertEquals(DI_ERROR.value(), obtainedEvent.getEventType());
+    DataImportEventPayload eventPayload = Json.decodeValue(obtainedEvent.getEventPayload(), DataImportEventPayload.class);
+    MatcherAssert.assertThat(new JsonObject(eventPayload.getContext().get("ERROR")).getString("message"),
+      containsString("Error during analyze leader line for determining record type for record with id"));
   }
 
   @Test
@@ -2316,8 +2319,7 @@ public class ChangeManagerAPITest extends AbstractRestTest {
     assertThat(createdJobExecutions.size(), is(1));
     JobExecution jobExec = createdJobExecutions.get(0);
 
-
-    WireMock.stubFor(WireMock.get("/data-import-profiles/jobProfiles/"+ DEFAULT_MARC_HOLDINGS_JOB_PROFILE_ID +"?withRelations=false&")
+    WireMock.stubFor(WireMock.get("/data-import-profiles/jobProfiles/" + DEFAULT_MARC_HOLDINGS_JOB_PROFILE_ID + "?withRelations=false&")
       .willReturn(WireMock.ok().withBody(Json.encode(new JobProfile().withId(DEFAULT_MARC_HOLDINGS_JOB_PROFILE_ID).withName("Default - Create Holdings and SRS MARC Holdings")))));
 
     WireMock.stubFor(post(RECORDS_SERVICE_URL)
@@ -2351,17 +2353,17 @@ public class ChangeManagerAPITest extends AbstractRestTest {
     async.complete();
 
     String topicToObserve = formatToKafkaTopicName(DI_RAW_RECORDS_CHUNK_PARSED.value());
-    List<String> observedValues = kafkaCluster.observeValues(ObserveKeyValues.on(topicToObserve, 7)
+    List<String> observedValues = kafkaCluster.observeValues(ObserveKeyValues.on(topicToObserve, 2)
       .observeFor(30, TimeUnit.SECONDS)
       .build());
 
-    Event obtainedEvent = Json.decodeValue(observedValues.get(7), Event.class);
+    Event obtainedEvent = Json.decodeValue(observedValues.get(1), Event.class);
     assertEquals(DI_RAW_RECORDS_CHUNK_PARSED.value(), obtainedEvent.getEventType());
-    RecordCollection recordCollection = Json
-      .decodeValue(obtainedEvent.getEventPayload(), RecordCollection.class);
-    Assert.assertNull(recordCollection.getRecords().get(0).getMatchedId());
-    Assert.assertNotNull(recordCollection.getRecords().get(0).getErrorRecord());
-    Assert.assertEquals( "{\"error\":\"A new MARC-Holding was not created because the incoming record already contained a 999ff$s or 999ff$i field\"}", recordCollection.getRecords().get(0).getErrorRecord().getDescription());
+    RecordCollection recordCollection = Json.decodeValue(obtainedEvent.getEventPayload(), RecordCollection.class);
+    assertNull(recordCollection.getRecords().get(0).getMatchedId());
+    assertNotNull(recordCollection.getRecords().get(0).getErrorRecord());
+    assertEquals("{\"error\":\"A new MARC-Holding was not created because the incoming record already contained a 999ff$s or 999ff$i field\"}",
+      recordCollection.getRecords().get(0).getErrorRecord().getDescription());
   }
 
   @Test

--- a/mod-source-record-manager-server/src/test/java/org/folio/services/ChangeEngineServiceImplTest.java
+++ b/mod-source-record-manager-server/src/test/java/org/folio/services/ChangeEngineServiceImplTest.java
@@ -6,6 +6,7 @@ import io.vertx.core.json.Json;
 import io.vertx.core.json.JsonObject;
 import io.vertx.kafka.client.producer.KafkaHeader;
 import org.folio.MatchProfile;
+import org.folio.TestUtil;
 import org.folio.dao.JobExecutionSourceChunkDao;
 import org.folio.dataimport.util.OkapiConnectionParams;
 import org.folio.dataimport.util.marc.MarcRecordAnalyzer;
@@ -38,12 +39,14 @@ import org.mockito.Mockito;
 import org.mockito.junit.MockitoJUnitRunner;
 import org.springframework.test.util.ReflectionTestUtils;
 
+import java.io.IOException;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 
+import static org.folio.rest.jaxrs.model.DataImportEventTypes.DI_INCOMING_MARC_BIB_RECORD_PARSED;
 import static org.folio.rest.jaxrs.model.DataImportEventTypes.DI_MARC_FOR_UPDATE_RECEIVED;
 import static org.folio.rest.jaxrs.model.ProfileSnapshotWrapper.ContentType.ACTION_PROFILE;
 import static org.folio.rest.jaxrs.model.ProfileSnapshotWrapper.ContentType.JOB_PROFILE;
@@ -62,6 +65,7 @@ import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
@@ -79,6 +83,7 @@ public class ChangeEngineServiceImplTest {
     "01119cam a2200349Li 4500001001300000003000600013005001700019008004100036020001800077020001500095035002100110037002200131040002700153043001200180050002700192082001600219090002200235100003300257245002700290264003800317300002300355336002600378337002800404338002700432651006400459945004300523960006200566961001600628980003900644981002300683999006300706\u001Eocn922152790\u001EOCoLC\u001E20150927051630.4\u001E150713s2015    enk           000 f eng d\u001E  \u001Fa9780241146064\u001E  \u001Fa0241146062\u001E  \u001Fa(OCoLC)922152790\u001E  \u001Fa12370236\u001Fbybp\u001F5NU\u001E  \u001FaYDXCP\u001Fbeng\u001Ferda\u001FcYDXCP\u001E  \u001Fae-uk-en\u001E 4\u001FaPR6052.A6488\u001FbN66 2015\u001E04\u001Fa823.914\u001F223\u001E 4\u001Fa823.914\u001FcB2557\u001Fb1\u001E1 \u001FaBarker, Pat,\u001Fd1943-\u001Feauthor.\u001E10\u001FaNoonday /\u001FcPat Barker.\u001E 1\u001FaLondon :\u001FbHamish Hamilton,\u001Fc2015.\u001E  \u001Fa258 pages ;\u001Fc24 cm\u001E  \u001Fatext\u001Fbtxt\u001F2rdacontent\u001E  \u001Faunmediated\u001Fbn\u001F2rdamedia\u001E  \u001Favolume\u001Fbnc\u001F2rdacarrier\u001E 0\u001FaLondon (England)\u001FxHistory\u001FyBombardment, 1940-1941\u001FvFiction.\u001E  \u001Ffh\u001Fg1\u001Fi0000000618391828\u001Flfhgen\u001Fr3\u001Fsv\u001Ft1\u001E  \u001Fap\u001Fda\u001Fgh\u001Fim\u001Fjn\u001Fka\u001Fla\u001Fmo\u001Ftfhgen\u001Fo1\u001Fs15.57\u001Fu7ART\u001Fvukapf\u001FzGBP\u001E  \u001FbGBP\u001Fm633761\u001E  \u001Fa160128\u001Fb1899\u001Fd156\u001Fe1713\u001Ff654270\u001Fg1\u001E  \u001Faukapf\u001Fb7ART\u001Fcfhgen\u001E  \u001Fdm\u001Fea\u001Ffx\u001Fgeng\u001FiTesting with subfield i\u001FsAnd with subfield s\u001E\u001D";
   private static final String MARC_BIB_REC_WITH_FF =
     "00861cam a2200193S1 45 0001000700000002000900007003000400016008004100020035002200061035001300083099001600096245005600112500011600168500019600284600003500480610003400515610003900549999007900588\u001E304162\u001E00320061\u001EPBL\u001E020613n                      000 0 eng u\u001E  \u001Fa(Sirsi)sc99900001\u001E  \u001Fa(Sirsi)1\u001E  \u001FaSC LVF M698\u001E00\u001FaMohler, Harold S. (Lehigh Collection Vertical File)\u001E  \u001FaMaterial on this topic is contained in the Lehigh Collection Vertical File. See Special Collections for access.\u001E  \u001FaContains press releases, versions of resumes, clippings, biographical information. L-in-Life program, and memorial service program -- Documents related Hershey Food Corporation. In two parts.\u001E10\u001FaMohler, Harold S.,\u001Fd1919-1988.\u001E20\u001FaLehigh University.\u001FbTrustees.\u001E20\u001FaLehigh University.\u001FbClass of 1948.\u001Eff\u001Fi29573076-a7ee-462a-8f9b-2659ab7df23c\u001Fs7ca42730-9ba6-4bc8-98d3-f068728504c9\u001E\u001D";
+  private static final String RAW_EDIFACT_RECORD_PATH = "src/test/resources/records/edifact/565751us20210122.edi";
 
   @Mock
   private JobExecutionSourceChunkDao jobExecutionSourceChunkDao;
@@ -298,6 +303,8 @@ public class ChangeEngineServiceImplTest {
     when(jobExecutionSourceChunkDao.getById(any(), any()))
       .thenReturn(Future.succeededFuture(Optional.of(new JobExecutionSourceChunk())));
     when(jobExecutionSourceChunkDao.update(any(), any())).thenReturn(Future.succeededFuture(new JobExecutionSourceChunk()));
+    when(recordsPublishingService.sendEventsWithRecords(any(), any(), any(), any()))
+      .thenReturn(Future.succeededFuture());
 
     Future<List<Record>> serviceFuture = executeWithKafkaMock(rawRecordsDto, jobExecution, Future.succeededFuture(true));
 
@@ -308,8 +315,34 @@ public class ChangeEngineServiceImplTest {
   }
 
   @Test
-  public void shouldReturnMarcBibRecordWith999ByAcceptInstanceId() {
+  public void shouldReturnEdifactRecord() throws IOException {
+    RawRecordsDto rawRecordsDto = new RawRecordsDto()
+      .withId(UUID.randomUUID().toString())
+      .withRecordsMetadata(new RecordsMetadata().withContentType(RecordsMetadata.ContentType.EDIFACT_RAW))
+      .withInitialRecords(Collections.singletonList(new InitialRecord().withRecord(TestUtil.readFileFromPath(RAW_EDIFACT_RECORD_PATH))));
+    JobExecution jobExecution = new JobExecution()
+      .withId(UUID.randomUUID().toString())
+      .withUserId(UUID.randomUUID().toString())
+      .withJobProfileSnapshotWrapper(new ProfileSnapshotWrapper())
+      .withJobProfileInfo(new JobProfileInfo().withId(UUID.randomUUID().toString())
+        .withName("test").withDataType(JobProfileInfo.DataType.EDIFACT));
 
+    when(jobExecutionSourceChunkDao.getById(any(), any()))
+      .thenReturn(Future.succeededFuture(Optional.of(new JobExecutionSourceChunk())));
+    when(jobExecutionSourceChunkDao.update(any(), any())).thenReturn(Future.succeededFuture(new JobExecutionSourceChunk()));
+    when(recordsPublishingService.sendEventsWithRecords(any(), any(), any(), any()))
+      .thenReturn(Future.succeededFuture());
+
+    Future<List<Record>> serviceFuture = executeWithKafkaMock(rawRecordsDto, jobExecution, Future.succeededFuture(true));
+
+    var actual = serviceFuture.result();
+    assertThat(actual, hasSize(1));
+    assertThat(actual.get(0).getRecordType(), equalTo(Record.RecordType.EDIFACT));
+    assertThat(actual.get(0).getErrorRecord(), nullValue());
+  }
+
+  @Test
+  public void shouldReturnMarcBibRecordWith999ByAcceptInstanceId() {
     RawRecordsDto rawRecordsDto = getTestRawRecordsDto(MARC_BIB_REC_WITH_FF);
     JobExecution jobExecution = new JobExecution()
       .withId(UUID.randomUUID().toString())
@@ -318,15 +351,15 @@ public class ChangeEngineServiceImplTest {
       .withJobProfileInfo(new JobProfileInfo().withId(UUID.randomUUID().toString())
         .withName("test").withDataType(JobProfileInfo.DataType.MARC));
 
-    boolean acceptInstanceId = true;
-
     when(marcRecordAnalyzer.process(any())).thenReturn(MarcRecordType.BIB);
     when(jobExecutionSourceChunkDao.getById(any(), any()))
       .thenReturn(Future.succeededFuture(Optional.of(new JobExecutionSourceChunk())));
     when(jobExecutionSourceChunkDao.update(any(), any())).thenReturn(Future.succeededFuture(new JobExecutionSourceChunk()));
+    when(recordsPublishingService.sendEventsWithRecords(any(), any(), any(), any()))
+      .thenReturn(Future.succeededFuture());
 
     Future<List<Record>> serviceFuture =
-      executeWithKafkaMock(rawRecordsDto, jobExecution, Future.succeededFuture(true), acceptInstanceId);
+      executeWithKafkaMock(rawRecordsDto, jobExecution, Future.succeededFuture(true), true);
 
     var actual = serviceFuture.result();
     assertThat(actual, hasSize(1));
@@ -345,6 +378,8 @@ public class ChangeEngineServiceImplTest {
     when(jobExecutionSourceChunkDao.getById(any(), any()))
       .thenReturn(Future.succeededFuture(Optional.of(new JobExecutionSourceChunk())));
     when(jobExecutionSourceChunkDao.update(any(), any())).thenReturn(Future.succeededFuture(new JobExecutionSourceChunk()));
+    when(recordsPublishingService.sendEventsWithRecords(any(), any(), any(), any()))
+      .thenReturn(Future.succeededFuture());
 
     Future<List<Record>> serviceFuture = executeWithKafkaMock(rawRecordsDto, jobExecution, Future.succeededFuture(true));
 
@@ -419,7 +454,6 @@ public class ChangeEngineServiceImplTest {
       .thenReturn(Future.succeededFuture(Optional.of(new JobExecutionSourceChunk())));
     when(jobExecutionSourceChunkDao.update(any(), any())).thenReturn(Future.succeededFuture(new JobExecutionSourceChunk()));
 
-
     try (var mockedStatic = Mockito.mockStatic(EventHandlingUtil.class)) {
       mockedStatic.when(() -> EventHandlingUtil.sendEventToKafka(any(), any(), any(), kafkaHeadersCaptor.capture(), any(), any()))
         .thenReturn(Future.succeededFuture(true));
@@ -449,7 +483,7 @@ public class ChangeEngineServiceImplTest {
       service.parseRawRecordsChunkForJobExecution(rawRecordsDto, jobExecution, "1", false, okapiConnectionParams).result();
     }
 
-    verify(recordsPublishingService, never()).sendEventsWithRecords(any(), any(), any(), any());
+    verify(recordsPublishingService, times(1)).sendEventsWithRecords(any(), any(), any(), eq(DI_INCOMING_MARC_BIB_RECORD_PARSED.value()));
   }
 
   @Test
@@ -548,7 +582,6 @@ public class ChangeEngineServiceImplTest {
     when(jobExecutionSourceChunkDao.getById(any(), any()))
       .thenReturn(Future.succeededFuture(Optional.of(new JobExecutionSourceChunk())));
     when(jobExecutionSourceChunkDao.update(any(), any())).thenReturn(Future.succeededFuture(new JobExecutionSourceChunk()));
-
   }
 
   ProfileSnapshotWrapper constructCreateInstanceSnapshotWrapper() {
@@ -565,7 +598,7 @@ public class ChangeEngineServiceImplTest {
           .withAction(ActionProfile.Action.CREATE)
           .withFolioRecord(ActionProfile.FolioRecord.INSTANCE))).getMap())
       ));
-  };
+  }
 
   private ProfileSnapshotWrapper constructCreateMarcHoldingsAndInstanceSnapshotWrapper() {
     return new ProfileSnapshotWrapper()

--- a/mod-source-record-manager-server/src/test/java/org/folio/verticle/consumers/DataImportJournalConsumerVerticleTest.java
+++ b/mod-source-record-manager-server/src/test/java/org/folio/verticle/consumers/DataImportJournalConsumerVerticleTest.java
@@ -9,7 +9,6 @@ import io.vertx.ext.unit.junit.VertxUnitRunner;
 import io.vertx.kafka.client.consumer.KafkaConsumerRecord;
 import io.vertx.kafka.client.consumer.impl.KafkaConsumerRecordImpl;
 import org.apache.kafka.clients.consumer.ConsumerRecord;
-import org.apache.kafka.common.header.internals.RecordHeader;
 import org.folio.ActionProfile;
 import org.folio.DataImportEventPayload;
 import org.folio.dao.JobExecutionDaoImpl;
@@ -30,11 +29,9 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
-import java.io.IOException;
 import java.util.HashMap;
 import java.util.List;
 import java.util.UUID;
-import java.util.concurrent.ExecutionException;
 
 import static org.folio.kafka.KafkaTopicNameHelper.getDefaultNameSpace;
 import static org.folio.rest.jaxrs.model.DataImportEventTypes.*;
@@ -127,7 +124,7 @@ public class DataImportJournalConsumerVerticleTest extends AbstractRestTest {
   }
 
   @Test
-  public void testJournalMarcBibRecordUpdatedAction(TestContext context) throws IOException {
+  public void testJournalMarcBibRecordUpdatedAction(TestContext context) {
     Async async = context.async();
 
     // given
@@ -155,7 +152,7 @@ public class DataImportJournalConsumerVerticleTest extends AbstractRestTest {
   }
 
   @Test
-  public void testJournalMarcHoldingsRecordCreatedAction(TestContext context) throws IOException {
+  public void testJournalMarcHoldingsRecordCreatedAction(TestContext context) {
     Async async = context.async();
 
     // given
@@ -183,7 +180,7 @@ public class DataImportJournalConsumerVerticleTest extends AbstractRestTest {
   }
 
   @Test
-  public void testJournalCompletedAction(TestContext context) throws IOException, ExecutionException, InterruptedException {
+  public void testJournalCompletedAction(TestContext context) {
     Async async = context.async();
 
     // given
@@ -222,7 +219,7 @@ public class DataImportJournalConsumerVerticleTest extends AbstractRestTest {
   }
 
   @Test
-  public void testJournalErrorAction(TestContext context) throws IOException, ExecutionException, InterruptedException {
+  public void testJournalErrorAction(TestContext context) {
     Async async = context.async();
 
     // given
@@ -244,7 +241,7 @@ public class DataImportJournalConsumerVerticleTest extends AbstractRestTest {
         .withId(UUID.randomUUID().toString())
         .withContentType(ACTION_PROFILE)
         .withContent(JsonObject.mapFrom(new ActionProfile().withFolioRecord(ActionProfile.FolioRecord.HOLDINGS))))
-      .withEventsChain(List.of(DI_SRS_MARC_BIB_RECORD_CREATED.value(), DI_INVENTORY_HOLDING_CREATED.value()));
+      .withEventsChain(List.of(DI_INCOMING_MARC_BIB_RECORD_PARSED.value(), DI_INVENTORY_HOLDING_CREATED.value()));
 
     // when
     KafkaConsumerRecord<String, String> kafkaConsumerRecord = buildKafkaConsumerRecord(eventPayload);
@@ -260,7 +257,7 @@ public class DataImportJournalConsumerVerticleTest extends AbstractRestTest {
   }
 
   @Test
-  public void testJournalRecordMappingError(TestContext context) throws IOException, ExecutionException, InterruptedException {
+  public void testJournalRecordMappingError(TestContext context) {
     Async async = context.async();
 
     // given

--- a/mod-source-record-manager-server/src/test/java/org/folio/verticle/consumers/StoredRecordChunkConsumersVerticleTest.java
+++ b/mod-source-record-manager-server/src/test/java/org/folio/verticle/consumers/StoredRecordChunkConsumersVerticleTest.java
@@ -41,7 +41,7 @@ import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.folio.rest.jaxrs.model.DataImportEventTypes.DI_ERROR;
 import static org.folio.rest.jaxrs.model.DataImportEventTypes.DI_MARC_BIB_FOR_ORDER_CREATED;
 import static org.folio.rest.jaxrs.model.DataImportEventTypes.DI_PARSED_RECORDS_CHUNK_SAVED;
-import static org.folio.rest.jaxrs.model.DataImportEventTypes.DI_SRS_MARC_BIB_RECORD_CREATED;
+import static org.folio.rest.jaxrs.model.DataImportEventTypes.DI_INCOMING_MARC_BIB_RECORD_PARSED;
 import static org.folio.rest.jaxrs.model.Record.RecordType.MARC_BIB;
 import static org.folio.rest.util.OkapiConnectionParams.OKAPI_TENANT_HEADER;
 import static org.folio.rest.util.OkapiConnectionParams.OKAPI_TOKEN_HEADER;
@@ -126,7 +126,7 @@ public class StoredRecordChunkConsumersVerticleTest extends AbstractRestTest {
     kafkaCluster.send(request);
 
     // then
-    List<String> successValues = observeValuesAndFilterByLeader("00116nam  22000731a 4700", DI_SRS_MARC_BIB_RECORD_CREATED, 3);
+    List<String> successValues = observeValuesAndFilterByLeader("00116nam  22000731a 4700", DI_INCOMING_MARC_BIB_RECORD_PARSED, 3);
     assertEquals(3, successValues.size());
 
     List<String> diErrorValues = observeValuesAndFilterByLeader("13113c7m a2200553Ii 4800", DI_ERROR, 7);
@@ -146,10 +146,10 @@ public class StoredRecordChunkConsumersVerticleTest extends AbstractRestTest {
     kafkaCluster.send(request);
 
     // then
-    List<String> observedValues = observeValuesAndFilterByLeader("00115nam  22000731a 4500", DI_SRS_MARC_BIB_RECORD_CREATED, 1);
+    List<String> observedValues = observeValuesAndFilterByLeader("00115nam  22000731a 4500", DI_INCOMING_MARC_BIB_RECORD_PARSED, 1);
     Event obtainedEvent = Json.decodeValue(observedValues.get(0), Event.class);
     DataImportEventPayload eventPayload = Json.decodeValue(obtainedEvent.getEventPayload(), DataImportEventPayload.class);
-    assertEquals(DI_SRS_MARC_BIB_RECORD_CREATED.value(), eventPayload.getEventType());
+    assertEquals(DI_INCOMING_MARC_BIB_RECORD_PARSED.value(), eventPayload.getEventType());
     assertEquals(TENANT_ID, eventPayload.getTenant());
     assertNotNull(eventPayload.getContext().get(EntityType.MARC_BIBLIOGRAPHIC.value()));
     assertNotNull(eventPayload.getContext().get(JOB_PROFILE_SNAPSHOT_ID));
@@ -169,10 +169,10 @@ public class StoredRecordChunkConsumersVerticleTest extends AbstractRestTest {
     kafkaCluster.send(request);
 
     // then
-    List<String> observedValues = observeValuesAndFilterByLeader("00115nam  22000731a 4500", DI_SRS_MARC_BIB_RECORD_CREATED, 1);
+    List<String> observedValues = observeValuesAndFilterByLeader("00115nam  22000731a 4500", DI_INCOMING_MARC_BIB_RECORD_PARSED, 1);
     Event obtainedEvent = Json.decodeValue(observedValues.get(0), Event.class);
     DataImportEventPayload eventPayload = Json.decodeValue(obtainedEvent.getEventPayload(), DataImportEventPayload.class);
-    assertEquals(DI_SRS_MARC_BIB_RECORD_CREATED.value(), eventPayload.getEventType());
+    assertEquals(DI_INCOMING_MARC_BIB_RECORD_PARSED.value(), eventPayload.getEventType());
   }
 
   @Test

--- a/mod-source-record-manager-server/src/test/java/org/folio/verticle/consumers/util/MarcImportEventsHandlerTest.java
+++ b/mod-source-record-manager-server/src/test/java/org/folio/verticle/consumers/util/MarcImportEventsHandlerTest.java
@@ -11,7 +11,7 @@ import static org.folio.rest.jaxrs.model.DataImportEventTypes.DI_ORDER_CREATED;
 import static org.folio.rest.jaxrs.model.DataImportEventTypes.DI_ORDER_CREATED_READY_FOR_POST_PROCESSING;
 import static org.folio.rest.jaxrs.model.DataImportEventTypes.DI_PENDING_ORDER_CREATED;
 import static org.folio.rest.jaxrs.model.DataImportEventTypes.DI_SRS_MARC_AUTHORITY_RECORD_CREATED;
-import static org.folio.rest.jaxrs.model.DataImportEventTypes.DI_SRS_MARC_BIB_RECORD_CREATED;
+import static org.folio.rest.jaxrs.model.DataImportEventTypes.DI_INCOMING_MARC_BIB_RECORD_PARSED;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.mockito.ArgumentMatchers.any;
@@ -300,7 +300,7 @@ public class MarcImportEventsHandlerTest {
     payloadContext.put("HOLDINGS","[{\"instanceId\":\"946c4945-b711-4e67-bfb9-83fa30be6332\",\"hrid\":\"ho001\",\"id\":\"946c4945-b711-4e67-bfb9-83fa37be6312\"},{\"instanceId\":\"946c4945-b711-4e67-bfb9-83fa30be6331\",\"hrid\":\"ho002\",\"id\":\"946c4945-b111-4e67-bfb9-83fa30be6312\"}]");
     payloadContext.put("NOT_MATCHED_NUMBER","3");
     return new DataImportEventPayload()
-      .withEventsChain(List.of(DI_SRS_MARC_BIB_RECORD_CREATED.value()))
+      .withEventsChain(List.of(DI_INCOMING_MARC_BIB_RECORD_PARSED.value()))
       .withEventType(DI_INVENTORY_HOLDING_MATCHED.value())
       .withContext(payloadContext);
   }
@@ -315,7 +315,7 @@ public class MarcImportEventsHandlerTest {
     payloadContext.put("ITEM","[{\"holdingsRecordId\":\"946c4945-b711-4e67-bfb9-83fa30be633c\",\"hrid\":\"it001\",\"id\":\"946c4945-b711-4e67-bfb9-83fa30be4312\"},{\"holdingsRecordId\":\"946c4945-b711-4e67-bfb9-83fa30be633b\",\"hrid\":\"it002\",\"id\":\"946c4945-b711-4e67-bfb9-83fa30be6312\"}]");
     payloadContext.put("NOT_MATCHED_NUMBER","5");
     return new DataImportEventPayload()
-      .withEventsChain(List.of(DI_SRS_MARC_BIB_RECORD_CREATED.value()))
+      .withEventsChain(List.of(DI_INCOMING_MARC_BIB_RECORD_PARSED.value()))
       .withEventType(DI_INVENTORY_ITEM_MATCHED.value())
       .withContext(payloadContext);
   }


### PR DESCRIPTION
## Purpose
Remove step of initial saving of incoming records to SRS

## Approach
Removing step of initial saving of incoming records to SRS and using `RecordsPublishingServiceImpl` to send events into `DI_INCOMING_EDIFACT_RECORD_PARSED` and `DI_INCOMING_MARC_BIB_RECORD_PARSED` topics


[MODSOURMAN-1022](https://issues.folio.org/browse/MODSOURMAN-1022)
