### PR TITLE
[MODSOURMAN-1043] Improper behavior in multiples for holdings when update action on match and create on non-match

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,6 @@
 ## 2023-xx-xx v3.8.0-SNAPSHOT
 * [MODSOURMAN-1030](https://issues.folio.org/browse/MODSOURMAN-1030) The number of updated records is not correct displayed in the 'SRS Marc' column in the 'Log summary' table
+* [MODSOURMAN-1043](https://issues.folio.org/browse/MODSOURMAN-1043) Improper behavior in multiples for holdings when update action on match and create on non-match
 
 
 ## 2023-10-13 v3.7.0

--- a/mod-source-record-manager-server/src/main/resources/templates/db_scripts/schema.json
+++ b/mod-source-record-manager-server/src/main/resources/templates/db_scripts/schema.json
@@ -255,7 +255,7 @@
     {
       "run": "after",
       "snippetPath": "create_get_record_processing_log_function.sql",
-      "fromModuleVersion": "mod-source-record-manager-3.7.0"
+      "fromModuleVersion": "mod-source-record-manager-3.8.0"
     },
     {
       "run": "after",


### PR DESCRIPTION
## Purpose
Improper behavior in multiples for holdings when update action on match and create on non-match
## Approach
Fix the function script get_record_processing_log, so it can properly show the matched and non-matched holdings and items and.

[MODSOURMAN-1043](https://issues.folio.org/browse/MODSOURMAN-1043)