### PR TITLE
MODSOURMAN-1091: Fixed improper behavior during instance subscription in MARC Bib Modify action

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -3,6 +3,7 @@
 * [MODSOURMAN-976](https://issues.folio.org/browse/MODSOURMAN-976) Incorrect error counts
 * [MODSOURMAN-1093](https://issues.folio.org/browse/MODSOURMAN-1093) EventHandlingUtil hangs forever on error
 * [MODSOURMAN-1043](https://issues.folio.org/browse/MODSOURMAN-1043) Improper behavior in multiples for holdings when update action on match and create on non-match
+* [MODSOURMAN-1091](https://issues.folio.org/browse/MODSOURMAN-1091) The '1' number of Instance is displayed in cell in the row with the 'Updated' row header at the individual import job's log
 
 
 ## 2023-10-13 v3.7.0

--- a/mod-source-record-manager-server/src/main/java/org/folio/verticle/DataImportJournalConsumersVerticle.java
+++ b/mod-source-record-manager-server/src/main/java/org/folio/verticle/DataImportJournalConsumersVerticle.java
@@ -23,7 +23,6 @@ import static org.folio.rest.jaxrs.model.DataImportEventTypes.DI_ORDER_CREATED_R
 import static org.folio.rest.jaxrs.model.DataImportEventTypes.DI_SRS_MARC_AUTHORITY_RECORD_CREATED;
 import static org.folio.rest.jaxrs.model.DataImportEventTypes.DI_SRS_MARC_AUTHORITY_RECORD_NOT_MATCHED;
 import static org.folio.rest.jaxrs.model.DataImportEventTypes.DI_SRS_MARC_BIB_RECORD_MODIFIED;
-import static org.folio.rest.jaxrs.model.DataImportEventTypes.DI_SRS_MARC_BIB_RECORD_MODIFIED_READY_FOR_POST_PROCESSING;
 import static org.folio.rest.jaxrs.model.DataImportEventTypes.DI_SRS_MARC_BIB_RECORD_NOT_MATCHED;
 import static org.folio.rest.jaxrs.model.DataImportEventTypes.DI_SRS_MARC_HOLDINGS_RECORD_MATCHED;
 import static org.folio.rest.jaxrs.model.DataImportEventTypes.DI_SRS_MARC_HOLDINGS_RECORD_NOT_MATCHED;
@@ -63,7 +62,6 @@ public class DataImportJournalConsumersVerticle extends AbstractConsumersVerticl
       DI_SRS_MARC_HOLDINGS_RECORD_MATCHED.value(),
       DI_INVENTORY_INSTANCE_CREATED.value(),
       DI_INVENTORY_INSTANCE_UPDATED.value(),
-      DI_SRS_MARC_BIB_RECORD_MODIFIED_READY_FOR_POST_PROCESSING.value(),
       DI_INVENTORY_INSTANCE_NOT_MATCHED.value(),
       DI_INVENTORY_HOLDING_CREATED.value(),
       DI_INVENTORY_HOLDING_UPDATED.value(),


### PR DESCRIPTION
## Purpose
The '1' number of Instance is displayed in cell in the row with the 'Updated' row header at the individual import job's log
## Approach
Removed DI_SRS_MARC_BIB_RECORD_MODIFIED_READY_FOR_POST_PROCESSING subscription.

[MODSOURMAN-1091](https://issues.folio.org/browse/MODSOURMAN-1091)