### PR TITLE
MODSOURMAN-1085 MARC record with a 100 tag without a $a is being discarded on import.

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,4 +1,5 @@
 ## 2023-xx-xx v3.8.0-SNAPSHOT
+* [MODSOURMAN-1085](https://issues.folio.org/browse/MODSOURMAN-1085) MARC record with a 100 tag without a $a is being discarded on import.
 * [MODSOURMAN-1030](https://issues.folio.org/browse/MODSOURMAN-1030) The number of updated records is not correct displayed in the 'SRS Marc' column in the 'Log summary' table
 * [MODSOURMAN-976](https://issues.folio.org/browse/MODSOURMAN-976) Incorrect error counts
 * [MODSOURMAN-1093](https://issues.folio.org/browse/MODSOURMAN-1093) EventHandlingUtil hangs forever on error

--- a/mod-source-record-manager-server/src/main/resources/rules/marc_bib_rules.json
+++ b/mod-source-record-manager-server/src/main/resources/rules/marc_bib_rules.json
@@ -1114,6 +1114,37 @@
     {
       "entity": [
         {
+          "target": "contributors.name",
+          "description": "Personal Name",
+          "subfield": [
+            "a",
+            "b",
+            "c",
+            "d",
+            "f",
+            "g",
+            "j",
+            "k",
+            "l",
+            "n",
+            "p",
+            "q",
+            "t",
+            "u"
+          ],
+          "requiredSubfield": ["a"],
+          "applyRulesOnConcatenatedData": true,
+          "rules": [
+            {
+              "conditions": [
+                {
+                  "type": "trim_punctuation"
+                }
+              ]
+            }
+          ]
+        },
+        {
           "target": "contributors.authorityId",
           "description": "Authority ID that controlling the contributor",
           "applyRulesOnConcatenatedData": true,
@@ -1181,10 +1212,16 @@
               "value": "true"
             }
           ]
-        },
+        }
+      ]
+    }
+  ],
+  "110": [
+    {
+      "entity": [
         {
           "target": "contributors.name",
-          "description": "Personal Name",
+          "description": "Corporate Name",
           "subfield": [
             "a",
             "b",
@@ -1192,12 +1229,10 @@
             "d",
             "f",
             "g",
-            "j",
             "k",
             "l",
             "n",
             "p",
-            "q",
             "t",
             "u"
           ],
@@ -1212,13 +1247,7 @@
               ]
             }
           ]
-        }
-      ]
-    }
-  ],
-  "110": [
-    {
-      "entity": [
+        },
         {
           "target": "contributors.authorityId",
           "description": "Authority ID that controlling the contributor",
@@ -1287,10 +1316,16 @@
               "value": "true"
             }
           ]
-        },
+        }
+      ]
+    }
+  ],
+  "111": [
+    {
+      "entity": [
         {
           "target": "contributors.name",
-          "description": "Corporate Name",
+          "description": "Meeting Name",
           "subfield": [
             "a",
             "b",
@@ -1316,13 +1351,7 @@
               ]
             }
           ]
-        }
-      ]
-    }
-  ],
-  "111": [
-    {
-      "entity": [
+        },
         {
           "target": "contributors.authorityId",
           "description": "Authority ID that controlling the contributor",
@@ -1389,35 +1418,6 @@
             {
               "conditions": [],
               "value": "true"
-            }
-          ]
-        },
-        {
-          "target": "contributors.name",
-          "description": "Meeting Name",
-          "subfield": [
-            "a",
-            "b",
-            "c",
-            "d",
-            "f",
-            "g",
-            "k",
-            "l",
-            "n",
-            "p",
-            "t",
-            "u"
-          ],
-          "requiredSubfield": ["a"],
-          "applyRulesOnConcatenatedData": true,
-          "rules": [
-            {
-              "conditions": [
-                {
-                  "type": "trim_punctuation"
-                }
-              ]
             }
           ]
         }

--- a/mod-source-record-manager-server/src/main/resources/rules/marc_bib_rules.json
+++ b/mod-source-record-manager-server/src/main/resources/rules/marc_bib_rules.json
@@ -1201,6 +1201,7 @@
             "t",
             "u"
           ],
+          "requiredSubfield": ["a"],
           "applyRulesOnConcatenatedData": true,
           "rules": [
             {
@@ -1304,6 +1305,7 @@
             "t",
             "u"
           ],
+          "requiredSubfield": ["a"],
           "applyRulesOnConcatenatedData": true,
           "rules": [
             {
@@ -1407,6 +1409,7 @@
             "t",
             "u"
           ],
+          "requiredSubfield": ["a"],
           "applyRulesOnConcatenatedData": true,
           "rules": [
             {

--- a/mod-source-record-manager-server/src/test/resources/org/folio/services/marc_bib_rules.json
+++ b/mod-source-record-manager-server/src/test/resources/org/folio/services/marc_bib_rules.json
@@ -1114,6 +1114,37 @@
     {
       "entity": [
         {
+          "target": "contributors.name",
+          "description": "Personal Name",
+          "subfield": [
+            "a",
+            "b",
+            "c",
+            "d",
+            "f",
+            "g",
+            "j",
+            "k",
+            "l",
+            "n",
+            "p",
+            "q",
+            "t",
+            "u"
+          ],
+          "requiredSubfield": ["a"],
+          "applyRulesOnConcatenatedData": true,
+          "rules": [
+            {
+              "conditions": [
+                {
+                  "type": "trim_punctuation"
+                }
+              ]
+            }
+          ]
+        },
+        {
           "target": "contributors.authorityId",
           "description": "Authority ID that controlling the contributor",
           "applyRulesOnConcatenatedData": true,
@@ -1181,10 +1212,16 @@
               "value": "true"
             }
           ]
-        },
+        }
+      ]
+    }
+  ],
+  "110": [
+    {
+      "entity": [
         {
           "target": "contributors.name",
-          "description": "Personal Name",
+          "description": "Corporate Name",
           "subfield": [
             "a",
             "b",
@@ -1192,12 +1229,10 @@
             "d",
             "f",
             "g",
-            "j",
             "k",
             "l",
             "n",
             "p",
-            "q",
             "t",
             "u"
           ],
@@ -1212,13 +1247,7 @@
               ]
             }
           ]
-        }
-      ]
-    }
-  ],
-  "110": [
-    {
-      "entity": [
+        },
         {
           "target": "contributors.authorityId",
           "description": "Authority ID that controlling the contributor",
@@ -1287,10 +1316,16 @@
               "value": "true"
             }
           ]
-        },
+        }
+      ]
+    }
+  ],
+  "111": [
+    {
+      "entity": [
         {
           "target": "contributors.name",
-          "description": "Corporate Name",
+          "description": "Meeting Name",
           "subfield": [
             "a",
             "b",
@@ -1316,13 +1351,7 @@
               ]
             }
           ]
-        }
-      ]
-    }
-  ],
-  "111": [
-    {
-      "entity": [
+        },
         {
           "target": "contributors.authorityId",
           "description": "Authority ID that controlling the contributor",
@@ -1389,35 +1418,6 @@
             {
               "conditions": [],
               "value": "true"
-            }
-          ]
-        },
-        {
-          "target": "contributors.name",
-          "description": "Meeting Name",
-          "subfield": [
-            "a",
-            "b",
-            "c",
-            "d",
-            "f",
-            "g",
-            "k",
-            "l",
-            "n",
-            "p",
-            "t",
-            "u"
-          ],
-          "requiredSubfield": ["a"],
-          "applyRulesOnConcatenatedData": true,
-          "rules": [
-            {
-              "conditions": [
-                {
-                  "type": "trim_punctuation"
-                }
-              ]
             }
           ]
         }

--- a/mod-source-record-manager-server/src/test/resources/org/folio/services/marc_bib_rules.json
+++ b/mod-source-record-manager-server/src/test/resources/org/folio/services/marc_bib_rules.json
@@ -1201,6 +1201,7 @@
             "t",
             "u"
           ],
+          "requiredSubfield": ["a"],
           "applyRulesOnConcatenatedData": true,
           "rules": [
             {
@@ -1304,6 +1305,7 @@
             "t",
             "u"
           ],
+          "requiredSubfield": ["a"],
           "applyRulesOnConcatenatedData": true,
           "rules": [
             {
@@ -1407,6 +1409,7 @@
             "t",
             "u"
           ],
+          "requiredSubfield": ["a"],
           "applyRulesOnConcatenatedData": true,
           "rules": [
             {


### PR DESCRIPTION
## Purpose
 MARC record with a 100 tag without a $a is being discarded on import. [MODSOURMAN-1085](https://issues.folio.org/browse/MODSOURMAN-1085) 

## Approach
mark a subfield as requiredSubfield

## Is this change testable? If not - why?
tests were fixed, test case was added into di-processing-core

## Learning
currently in requiredField section the logical relation between subfields are "and". 

## Checklist
- [x] I have updated NEWS.md.
- [ ] I have added javadocs to new methods.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation e.g. README.md.
- [ ] I have ran karate tests against this feature.

