### PR TITLE
fix(dependencies): Bump authority-source-files interface dependency version

### DIFF
--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -637,7 +637,7 @@
     },
     {
       "id": "authority-source-files",
-      "version": "1.0"
+      "version": "2.0"
     }
   ],
   "permissionSets": [


### PR DESCRIPTION
## Purpose
Bump authority-source-files interface dependency version from 1.0 to 2.0

## Is this change testable? If not - why?
platform-complete build now shouldn't fail


## Checklist
- [ ] I have updated NEWS.md.
- [ ] I have added javadocs to new methods.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation e.g. README.md.
- [ ] I have ran karate tests against this feature.

