### PR TITLE
MODSOURMAN-1108 MARC authority record is not created when use Job profile with match profile and action only on no-match branch

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -5,7 +5,7 @@
 * [MODSOURMAN-1093](https://issues.folio.org/browse/MODSOURMAN-1093) EventHandlingUtil hangs forever on error
 * [MODSOURMAN-1043](https://issues.folio.org/browse/MODSOURMAN-1043) Improper behavior in multiples for holdings when update action on match and create on non-match
 * [MODSOURMAN-1091](https://issues.folio.org/browse/MODSOURMAN-1091) The '1' number of Instance is displayed in cell in the row with the 'Updated' row header at the individual import job's log
-
+* [MODSOURMAN-1108](https://issues.folio.org/browse/MODSOURMAN-1108) MARC authority record is not created when use Job profile with match profile and action only on no-match branch
 
 ## 2023-10-13 v3.7.0
 * [MODSOURMAN-1045](https://issues.folio.org/browse/MODSOURMAN-1045) Allow create action with non-matches for instance without match profile

--- a/mod-source-record-manager-server/src/main/java/org/folio/services/ChangeEngineServiceImpl.java
+++ b/mod-source-record-manager-server/src/main/java/org/folio/services/ChangeEngineServiceImpl.java
@@ -165,7 +165,8 @@ public class ChangeEngineServiceImpl implements ChangeEngineService {
       .onSuccess(parsedRecords -> {
         fillParsedRecordsWithAdditionalFields(parsedRecords);
 
-        if (isMarcAuthorityMatchProfile(jobExecution)) {
+        if (updateMarcActionExists(jobExecution) || updateInstanceActionExists(jobExecution)
+          || isCreateOrUpdateItemOrHoldingsActionExists(jobExecution, parsedRecords) || isMarcAuthorityMatchProfile(jobExecution)) {
           hrIdFieldService.move001valueTo035Field(parsedRecords);
           updateRecords(parsedRecords, jobExecution, params)
             .onSuccess(ar -> promise.complete(parsedRecords))

--- a/mod-source-record-manager-server/src/test/java/org/folio/rest/impl/changeManager/ChangeManagerAPITest.java
+++ b/mod-source-record-manager-server/src/test/java/org/folio/rest/impl/changeManager/ChangeManagerAPITest.java
@@ -1,5 +1,35 @@
 package org.folio.rest.impl.changeManager;
 
+import static com.github.tomakehurst.wiremock.client.WireMock.created;
+import static com.github.tomakehurst.wiremock.client.WireMock.deleteRequestedFor;
+import static com.github.tomakehurst.wiremock.client.WireMock.get;
+import static com.github.tomakehurst.wiremock.client.WireMock.getRequestedFor;
+import static com.github.tomakehurst.wiremock.client.WireMock.okJson;
+import static com.github.tomakehurst.wiremock.client.WireMock.post;
+import static com.github.tomakehurst.wiremock.client.WireMock.serverError;
+import static com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo;
+import static com.github.tomakehurst.wiremock.client.WireMock.verify;
+import static java.util.Arrays.asList;
+import static java.util.Collections.emptyList;
+import static java.util.Collections.singletonList;
+import static org.folio.rest.jaxrs.model.DataImportEventTypes.DI_MARC_FOR_UPDATE_RECEIVED;
+import static org.folio.rest.jaxrs.model.DataImportEventTypes.DI_RAW_RECORDS_CHUNK_PARSED;
+import static org.folio.rest.jaxrs.model.ProfileSnapshotWrapper.ContentType.ACTION_PROFILE;
+import static org.folio.rest.jaxrs.model.ProfileSnapshotWrapper.ContentType.JOB_PROFILE;
+import static org.folio.rest.jaxrs.model.ProfileSnapshotWrapper.ContentType.MATCH_PROFILE;
+import static org.folio.rest.jaxrs.model.StatusDto.Status.CANCELLED;
+import static org.folio.rest.jaxrs.model.StatusDto.Status.COMMITTED;
+import static org.folio.rest.jaxrs.model.StatusDto.Status.ERROR;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.empty;
+import static org.hamcrest.Matchers.everyItem;
+import static org.hamcrest.Matchers.greaterThanOrEqualTo;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.not;
+import static org.hamcrest.Matchers.notNullValue;
+import static org.junit.Assert.assertEquals;
+
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.github.tomakehurst.wiremock.client.WireMock;
@@ -13,8 +43,16 @@ import io.vertx.core.json.JsonObject;
 import io.vertx.ext.unit.Async;
 import io.vertx.ext.unit.TestContext;
 import io.vertx.ext.unit.junit.VertxUnitRunner;
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.Date;
+import java.util.EnumSet;
+import java.util.List;
+import java.util.Set;
+import java.util.UUID;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
 import net.mguenther.kafka.junit.ObserveKeyValues;
-
 import org.apache.http.HttpStatus;
 import org.folio.MatchProfile;
 import org.folio.TestUtil;
@@ -52,46 +90,6 @@ import org.mockito.InjectMocks;
 import org.mockito.MockitoAnnotations;
 import org.mockito.Spy;
 
-import java.io.IOException;
-import java.util.Arrays;
-import java.util.Date;
-import java.util.EnumSet;
-import java.util.List;
-import java.util.Set;
-import java.util.UUID;
-import java.util.concurrent.TimeUnit;
-import java.util.stream.Collectors;
-
-import static com.github.tomakehurst.wiremock.client.WireMock.created;
-import static com.github.tomakehurst.wiremock.client.WireMock.deleteRequestedFor;
-import static com.github.tomakehurst.wiremock.client.WireMock.get;
-import static com.github.tomakehurst.wiremock.client.WireMock.getRequestedFor;
-import static com.github.tomakehurst.wiremock.client.WireMock.okJson;
-import static com.github.tomakehurst.wiremock.client.WireMock.post;
-import static com.github.tomakehurst.wiremock.client.WireMock.serverError;
-import static com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo;
-import static com.github.tomakehurst.wiremock.client.WireMock.verify;
-import static java.util.Arrays.asList;
-import static java.util.Collections.emptyList;
-import static java.util.Collections.singletonList;
-import static org.folio.rest.jaxrs.model.DataImportEventTypes.DI_MARC_FOR_UPDATE_RECEIVED;
-import static org.folio.rest.jaxrs.model.DataImportEventTypes.DI_RAW_RECORDS_CHUNK_PARSED;
-import static org.folio.rest.jaxrs.model.ProfileSnapshotWrapper.ContentType.ACTION_PROFILE;
-import static org.folio.rest.jaxrs.model.ProfileSnapshotWrapper.ContentType.JOB_PROFILE;
-import static org.folio.rest.jaxrs.model.ProfileSnapshotWrapper.ContentType.MATCH_PROFILE;
-import static org.folio.rest.jaxrs.model.StatusDto.Status.CANCELLED;
-import static org.folio.rest.jaxrs.model.StatusDto.Status.COMMITTED;
-import static org.folio.rest.jaxrs.model.StatusDto.Status.ERROR;
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.containsString;
-import static org.hamcrest.Matchers.empty;
-import static org.hamcrest.Matchers.everyItem;
-import static org.hamcrest.Matchers.greaterThanOrEqualTo;
-import static org.hamcrest.Matchers.is;
-import static org.hamcrest.Matchers.not;
-import static org.hamcrest.Matchers.notNullValue;
-import static org.junit.Assert.assertEquals;
-
 /**
  * REST tests for ChangeManager to manager JobExecution entities initialization
  */
@@ -104,14 +102,22 @@ public class ChangeManagerAPITest extends AbstractRestTest {
   private static final String JOB_PROFILE_PATH = "/jobProfile";
   private static final String RAW_DTO_PATH = "src/test/resources/org/folio/rest/rawRecordsDto.json";
 
-  private static final String CORRECT_RAW_RECORD_1 = "01240cas a2200397   450000100070000000500170000700800410002401000170006502200140008203500260009603500220012203500110014403500190015504000440017405000150021808200110023322200420024424500430028626000470032926500380037630000150041431000220042932100250045136200230047657000290049965000330052865000450056165500420060670000450064885300180069386300230071190200160073490500210075094800370077195000340080836683220141106221425.0750907c19509999enkqr p       0   a0eng d  a   58020553   a0022-0469  a(CStRLIN)NYCX1604275S  a(NIC)notisABP6388  a366832  a(OCoLC)1604275  dCtYdMBTIdCtYdMBTIdNICdCStRLINdNIC0 aBR140b.J6  a270.0504aThe Journal of ecclesiastical history04aThe Journal of ecclesiastical history.  aLondon,bCambridge University Press [etc.]  a32 East 57th St., New York, 10022  av.b25 cm.  aQuarterly,b1970-  aSemiannual,b1950-690 av. 1-   Apr. 1950-  aEditor:   C. W. Dugmore. 0aChurch historyxPeriodicals. 7aChurch history2fast0(OCoLC)fst00860740 7aPeriodicals2fast0(OCoLC)fst014116411 aDugmore, C. W.q(Clifford William),eed.0381av.i(year)4081a1-49i1950-1998  apfndbLintz  a19890510120000.02 a20141106bmdbatcheltsxaddfast  lOLINaBR140b.J86h01/01/01 N01542ccm a2200361   ";
-  private static final String CORRECT_RAW_RECORD_2 = "01314nam  22003851a 4500001001100000003000800011005001700019006001800036007001500054008004100069020003200110020003500142040002100177050002000198082001500218100002000233245008900253250001200342260004900354300002300403490002400426500002400450504006200474505009200536650003200628650001400660700002500674710001400699776004000713830001800753856009400771935001500865980003400880981001400914\u001Eybp7406411\u001ENhCcYBP\u001E20120404100627.6\u001Em||||||||d|||||||\u001Ecr||n|||||||||\u001E120329s2011    sz a    ob    001 0 eng d\u001E  \u001Fa2940447241 (electronic bk.)\u001E  \u001Fa9782940447244 (electronic bk.)\u001E  \u001FaNhCcYBP\u001FcNhCcYBP\u001E 4\u001FaZ246\u001Fb.A43 2011\u001E04\u001Fa686.22\u001F222\u001E1 \u001FaAmbrose, Gavin.\u001E14\u001FaThe fundamentals of typography\u001Fh[electronic resource] /\u001FcGavin Ambrose, Paul Harris.\u001E  \u001Fa2nd ed.\u001E  \u001FaLausanne ;\u001FaWorthing :\u001FbAVA Academia,\u001Fc2011.\u001E  \u001Fa1 online resource.\u001E1 \u001FaAVA Academia series\u001E  \u001FaPrevious ed.: 2006.\u001E  \u001FaIncludes bibliographical references (p. [200]) and index.\u001E0 \u001FaType and language -- A few basics -- Letterforms -- Words and paragraphs -- Using type.\u001E 0\u001FaGraphic design (Typography)\u001E 0\u001FaPrinting.\u001E1 \u001FaHarris, Paul,\u001Fd1971-\u001E2 \u001FaEBSCOhost\u001E  \u001FcOriginal\u001Fz9782940411764\u001Fz294041176X\u001E 0\u001FaAVA academia.\u001E40\u001Fuhttp://search.ebscohost.com/login.aspx?direct=true&scope=site&db=nlebk&db=nlabk&AN=430135\u001E  \u001Fa.o13465259\u001E  \u001Fa130307\u001Fb7107\u001Fe7107\u001Ff243965\u001Fg1\u001E  \u001FbOM\u001Fcnlnet\u001E\u001D\n";
-  private static final String CORRECT_RAW_RECORD_3 = "03401nam  22004091i 4500001001200000003000800012005001700020006001800037007001500055008004100070020003200111020003500143020004300178020004000221040002100261050002700282082001900309245016200328300002300490500004700513504005100560505178700611588004702398650003702445650004502482650002902527650003602556700005502592700006102647710002302708730001902731776005902750856011902809935001502928980003402943981001402977\u001Eybp10134220\u001ENhCcYBP\u001E20130220102526.4\u001Em||||||||d|||||||\u001Ecr||n|||||||||\u001E130220s2013    ncu     ob    001 0 eng d\u001E  \u001Fa1476601852 (electronic bk.)\u001E  \u001Fa9781476601854 (electronic bk.)\u001E  \u001Fz9780786471140 (softcover : alk. paper)\u001E  \u001Fz078647114X (softcover : alk. paper)\u001E  \u001FaNhCcYBP\u001FcNhCcYBP\u001E 4\u001FaPN1995.9.V46\u001FbG37 2013\u001E04\u001Fa791.43/656\u001F223\u001E00\u001FaGame on, Hollywood!\u001Fh[electronic resource] :\u001Fbessays on the intersection of video games and cinema /\u001Fcedited by Gretchen Papazian and Joseph Michael Sommers.\u001E  \u001Fa1 online resource.\u001E  \u001FaDescription based on print version record.\u001E  \u001FaIncludes bibliographical references and index.\u001E0 \u001FaIntroduction: manifest narrativity-video games, movies, and art and adaptation / Gretchen Papazian and Joseph Michael Sommers -- The rules of engagement: watching, playing and other narrative processes. Playing the Buffyverse, playing the gothic: genre, gender and cross-media interactivity in Buffy the vampire slayer: chaos bleeds / Katrin Althans -- Dead eye: the spectacle of torture porn in Dead rising / Deborah Mellamphy -- Playing (with) the western: classical Hollywood genres in modern video games / Jason W. Buel -- Game-to-film adaptation and how Prince of Persia: the sands of time negotiates the difference between player and audience / Ben S. Bunting, Jr -- Translation between forms of interactivity: how to build the better adaptation / Marcus Schulzke -- The terms of the tale: time, place and other ideologically constructed conditions. -- Playing (in) the city: the warriors and images of urban disorder / Aubrey Anable -- When did Dante become a scythe-wielding badass? modeling adaption and shifting gender convention in Dante's Inferno / Denise A. Ayo -- \"Some of this happened to the other fellow\": remaking Goldeneye with Daniel Craig / David McGowan -- Zombie stripper geishas in the new global economy: racism and sexism in video games / Stewart Chang -- Stories, stories everywhere (and nowhere just the same): transmedia texts. \"My name is Alan Wake. I'm a writer.\": crafting narrative complexity in the age of transmedia storytelling / Michael Fuchs -- Millions of voices: Star wars, digital games, fictional worlds and franchise canon / Felan Parker -- The hype man as racial stereotype, parody and ghost in Afro samurai / Treaandrea M. Russworm -- Epic nostalgia: narrative play and transmedia storytelling in Disney epic Mickey / Lisa K. Dusenberry.\u001E  \u001FaDescription based on print version record.\u001E 0\u001FaMotion pictures and video games.\u001E 0\u001FaFilm adaptations\u001FxHistory and criticism.\u001E 0\u001FaVideo games\u001FxAuthorship.\u001E 0\u001FaConvergence (Telecommunication)\u001E1 \u001FaPapazian, Gretchen,\u001Fd1968-\u001Feeditor of compilation.\u001E1 \u001FaSommers, Joseph Michael,\u001Fd1976-\u001Feeditor of  compilation.\u001E2 \u001FaEbooks Corporation\u001E0 \u001FaEbook Library.\u001E08\u001FcOriginal\u001Fz9780786471140\u001Fz078647114X\u001Fw(DLC)  2012051432\u001E40\u001FzConnect to e-book on Ebook Library\u001Fuhttp://qut.eblib.com.au.AU/EBLWeb/patron/?target=patron&extendedid=P_1126326_0\u001E  \u001Fa.o13465405\u001E  \u001Fa130307\u001Fb6000\u001Fe6000\u001Ff243967\u001Fg1\u001E  \u001FbOM\u001Fcnlnet\u001E\u001D";
-  private static final String CORRECT_MARC_HOLDINGS_RAW_RECORD = "00182cx  a22000851  4500001000900000004000800009005001700017008003300034852002900067\u001E10245123\u001E9928371\u001E20170607135730.0\u001E1706072u    8   4001uu   0901128\u001E0 \u001Fbfine\u001FhN7433.3\u001Fi.B87 2014\u001E\u001D";
-  private static final String RAW_RECORD_WITH_999_ff_s_SUBFIELD = "00948nam a2200241 a 4500001000800000003000400008005001700012008004100029035002100070035002000091040002300111041001300134100002300147245007900170260005800249300002400307440007100331650003600402650005500438650006900493655006500562999007900627\u001E1007048\u001EICU\u001E19950912000000.0\u001E891218s1983    wyu      d    00010 eng d\u001E  \u001Fa(ICU)BID12424550\u001E  \u001Fa(OCoLC)16105467\u001E  \u001FaPAU\u001FcPAU\u001Fdm/c\u001FdICU\u001E0 \u001Faeng\u001Faarp\u001E1 \u001FaSalzmann, Zdeněk\u001E10\u001FaDictionary of contemporary Arapaho usage /\u001Fccompiled by Zdeněk Salzmann.\u001E0 \u001FaWind River, Wyoming :\u001FbWind River Reservation,\u001Fc1983.\u001E  \u001Fav, 231 p. ;\u001Fc28 cm.\u001E 0\u001FaArapaho language and culture instructional materials series\u001Fvno. 4\u001E 0\u001FaArapaho language\u001FxDictionaries.\u001E 0\u001FaIndians of North America\u001FxLanguages\u001FxDictionaries.\u001E 7\u001FaArapaho language.\u001F2fast\u001F0http://id.worldcat.org/fast/fst00812722\u001E 7\u001FaDictionaries.\u001F2fast\u001F0http://id.worldcat.org/fast/fst01423826\u001Eff\u001Fie27a5374-0857-462e-ac84-fb4795229c7a\u001Fse27a5374-0857-462e-ac84-fb4795229c7a\u001E\u001D";
-  private static final String MARC_AUTHORITY_RAW_RECORD_WITH_999_s_SUBFIELD = "01107cz  a2200253n  4500001000800000005001700008008004100025010001700066035002300083035002100106040004300127100002200170375000900192377000800201400002400209400003700233400003000270400004400300667004700344670006800391670009400459670022100553999007900774\u001E1000649\u001E20171119085041.0\u001E850103n| azannaabn          |b aaa      \u001E  \u001Fan  84234537 \u001E  \u001Fa(OCoLC)oca01249182\u001E  \u001Fa(DLC)n  84234537\u001E  \u001FaDLC\u001Fbeng\u001Ferda\u001FcDLC\u001FdDLC\u001FdCoU\u001FdDLC\u001FdInU\u001E1 \u001FaEimermacher, Karl\u001E  \u001Famale\u001E  \u001Fager\u001E1 \u001FaAĭmermakher, Karl\u001E1 \u001FaАймермахер, Карл\u001E1 \u001FaAĭmermakher, K.\u001Fq(Karl)\u001E1 \u001FaАймермахер, К.\u001Fq(Карл)\u001E  \u001FaNon-Latin script references not evaluated.\u001E  \u001FaSidur, V. Vadim Sidur, 1980?:\u001Fbp. 3 of cover (Karl Eimermacher)\u001E  \u001FaV tiskakh ideologii, 1992:\u001Fbt.p. verso (Karla Aĭmermakhera) colophon (K. Aĭmermakher)\u001E  \u001FaGoogle, 01-31-02\u001Fbruhr-uni-bochum.de/lirsk/whowho.htm (Prof. Dr. Dr. hc. Karl Eimermacher; Geb. 1938; Institutsleiter und Landesbeauftragter für die Hochschulkontakte des Landes NRW zu den europäischen U-Staaten)\u001Eff\u001Fs9df3f407-434b-4260-bfe3-3791c607a1cd\u001Fi92e3bde3-d49f-4a25-867b-2fc257bee318\u001E\u001D";
-  private static final String RAW_RECORD_WITH_INVALID_LEADER = "01342nhm a2200289 a 4500005001700000008004100017035002000058040001300078041000800091043001200099245003000111260005600141300002100197336008000218337007100298338006900369350001500438500007900453530004900532650008200581651006500663650007900728650006300807651006600870856009600936035002001032\u001E20020829132600.0\u001E850404m19839999ctu     ab    00000dmul d\u001E  \u001Fa(ICU)BID8683551\u001E  \u001FaICU\u001FcICU\u001E0 \u001Famul\u001E  \u001Fan-us---\u001E04\u001FaThe Immigrant in America.\u001E0 \u001FaWoodbridge, Conn. :\u001FbResearch Publications,\u001Fc[1983-\u001E  \u001Fareels. ;\u001Fc35 mm.\u001E  \u001Faunspecified\u001Fbzzz\u001F2rdacontent\u001F0http://id.loc.gov/vocabulary/contentTypes/zzz\u001E  \u001Faunmediated\u001Fbn\u001F2rdamedia\u001F0http://id.loc.gov/vocabulary/mediaTypes/n\u001E  \u001Favolume\u001Fbnc\u001F2rdacarrier\u001F0http://id.loc.gov/vocabulary/carriers/nc\u001E  \u001Fa$17,000.00\u001E  \u001FaAccompanying guide to the collection on microfilm has call no. JV6455.I56.\u001E  \u001FaSearch guide also available on the Internet.\u001E 0\u001FaNoncitizens\u001FzUnited States\u001F0http://id.loc.gov/authorities/subjects/sh85003551\u001E 0\u001FaUnited States\u001FxEmigration and immigration\u001FxBio-bibliography.\u001E 7\u001FaEmigration and immigration.\u001F2fast\u001F0http://id.worldcat.org/fast/fst00908690\u001E 7\u001FaImmigrants.\u001F2fast\u001F0http://id.worldcat.org/fast/fst00967712\u001E 7\u001FaUnited States.\u001F2fast\u001F0http://id.worldcat.org/fast/fst01204155\u001E41\u001FzSelect search guide from pull down menu at:\u001Fuhttp://microformguides.gale.com/SearchForm.asp\u001E  \u001Fa(OCoLC)43567633\u001E\u001D";
-  private static final String MARC_HOLDINGS_RAW_RECORD_WITH_999_ff_s_SUBFIELD =  "00476cy  a22001454  4500001000700000004001400007005001700021008003300038014001700071014001400088852009600102866002700198868002600225999007900251\u001E445553\u001Ein00000000278\u001E20171018085818.0\u001E9301234u    8   1   uu          \u001E1 \u001FaABP6388CU001\u001E0 \u001F9000442923\u001E01\u001FbKU/CC/DI/A\u001FhBR140\u001Fi.J86\u001Fxdbe=c\u001FzCurrent issues in Periodicals Room\u001FxCHECK-IN RECORD CREATED\u001E41\u001F80\u001Fav.54-68 (2003-2017)\u001E41\u001F80\u001Fav.1/50 (1950/1999)\u001Eff\u001Fsa88255be-9669-4100-9ad3-25d21827c9bc\u001Fided3fee0-4b2f-41fb-b740-aaf1ffc3e772\u001E\u001D";
+  private static final String CORRECT_RAW_RECORD_1 =
+    "01240cas a2200397   450000100070000000500170000700800410002401000170006502200140008203500260009603500220012203500110014403500190015504000440017405000150021808200110023322200420024424500430028626000470032926500380037630000150041431000220042932100250045136200230047657000290049965000330052865000450056165500420060670000450064885300180069386300230071190200160073490500210075094800370077195000340080836683220141106221425.0750907c19509999enkqr p       0   a0eng d  a   58020553   a0022-0469  a(CStRLIN)NYCX1604275S  a(NIC)notisABP6388  a366832  a(OCoLC)1604275  dCtYdMBTIdCtYdMBTIdNICdCStRLINdNIC0 aBR140b.J6  a270.0504aThe Journal of ecclesiastical history04aThe Journal of ecclesiastical history.  aLondon,bCambridge University Press [etc.]  a32 East 57th St., New York, 10022  av.b25 cm.  aQuarterly,b1970-  aSemiannual,b1950-690 av. 1-   Apr. 1950-  aEditor:   C. W. Dugmore. 0aChurch historyxPeriodicals. 7aChurch history2fast0(OCoLC)fst00860740 7aPeriodicals2fast0(OCoLC)fst014116411 aDugmore, C. W.q(Clifford William),eed.0381av.i(year)4081a1-49i1950-1998  apfndbLintz  a19890510120000.02 a20141106bmdbatcheltsxaddfast  lOLINaBR140b.J86h01/01/01 N01542ccm a2200361   ";
+  private static final String CORRECT_RAW_RECORD_2 =
+    "01314nam  22003851a 4500001001100000003000800011005001700019006001800036007001500054008004100069020003200110020003500142040002100177050002000198082001500218100002000233245008900253250001200342260004900354300002300403490002400426500002400450504006200474505009200536650003200628650001400660700002500674710001400699776004000713830001800753856009400771935001500865980003400880981001400914\u001Eybp7406411\u001ENhCcYBP\u001E20120404100627.6\u001Em||||||||d|||||||\u001Ecr||n|||||||||\u001E120329s2011    sz a    ob    001 0 eng d\u001E  \u001Fa2940447241 (electronic bk.)\u001E  \u001Fa9782940447244 (electronic bk.)\u001E  \u001FaNhCcYBP\u001FcNhCcYBP\u001E 4\u001FaZ246\u001Fb.A43 2011\u001E04\u001Fa686.22\u001F222\u001E1 \u001FaAmbrose, Gavin.\u001E14\u001FaThe fundamentals of typography\u001Fh[electronic resource] /\u001FcGavin Ambrose, Paul Harris.\u001E  \u001Fa2nd ed.\u001E  \u001FaLausanne ;\u001FaWorthing :\u001FbAVA Academia,\u001Fc2011.\u001E  \u001Fa1 online resource.\u001E1 \u001FaAVA Academia series\u001E  \u001FaPrevious ed.: 2006.\u001E  \u001FaIncludes bibliographical references (p. [200]) and index.\u001E0 \u001FaType and language -- A few basics -- Letterforms -- Words and paragraphs -- Using type.\u001E 0\u001FaGraphic design (Typography)\u001E 0\u001FaPrinting.\u001E1 \u001FaHarris, Paul,\u001Fd1971-\u001E2 \u001FaEBSCOhost\u001E  \u001FcOriginal\u001Fz9782940411764\u001Fz294041176X\u001E 0\u001FaAVA academia.\u001E40\u001Fuhttp://search.ebscohost.com/login.aspx?direct=true&scope=site&db=nlebk&db=nlabk&AN=430135\u001E  \u001Fa.o13465259\u001E  \u001Fa130307\u001Fb7107\u001Fe7107\u001Ff243965\u001Fg1\u001E  \u001FbOM\u001Fcnlnet\u001E\u001D\n";
+  private static final String CORRECT_RAW_RECORD_3 =
+    "03401nam  22004091i 4500001001200000003000800012005001700020006001800037007001500055008004100070020003200111020003500143020004300178020004000221040002100261050002700282082001900309245016200328300002300490500004700513504005100560505178700611588004702398650003702445650004502482650002902527650003602556700005502592700006102647710002302708730001902731776005902750856011902809935001502928980003402943981001402977\u001Eybp10134220\u001ENhCcYBP\u001E20130220102526.4\u001Em||||||||d|||||||\u001Ecr||n|||||||||\u001E130220s2013    ncu     ob    001 0 eng d\u001E  \u001Fa1476601852 (electronic bk.)\u001E  \u001Fa9781476601854 (electronic bk.)\u001E  \u001Fz9780786471140 (softcover : alk. paper)\u001E  \u001Fz078647114X (softcover : alk. paper)\u001E  \u001FaNhCcYBP\u001FcNhCcYBP\u001E 4\u001FaPN1995.9.V46\u001FbG37 2013\u001E04\u001Fa791.43/656\u001F223\u001E00\u001FaGame on, Hollywood!\u001Fh[electronic resource] :\u001Fbessays on the intersection of video games and cinema /\u001Fcedited by Gretchen Papazian and Joseph Michael Sommers.\u001E  \u001Fa1 online resource.\u001E  \u001FaDescription based on print version record.\u001E  \u001FaIncludes bibliographical references and index.\u001E0 \u001FaIntroduction: manifest narrativity-video games, movies, and art and adaptation / Gretchen Papazian and Joseph Michael Sommers -- The rules of engagement: watching, playing and other narrative processes. Playing the Buffyverse, playing the gothic: genre, gender and cross-media interactivity in Buffy the vampire slayer: chaos bleeds / Katrin Althans -- Dead eye: the spectacle of torture porn in Dead rising / Deborah Mellamphy -- Playing (with) the western: classical Hollywood genres in modern video games / Jason W. Buel -- Game-to-film adaptation and how Prince of Persia: the sands of time negotiates the difference between player and audience / Ben S. Bunting, Jr -- Translation between forms of interactivity: how to build the better adaptation / Marcus Schulzke -- The terms of the tale: time, place and other ideologically constructed conditions. -- Playing (in) the city: the warriors and images of urban disorder / Aubrey Anable -- When did Dante become a scythe-wielding badass? modeling adaption and shifting gender convention in Dante's Inferno / Denise A. Ayo -- \"Some of this happened to the other fellow\": remaking Goldeneye with Daniel Craig / David McGowan -- Zombie stripper geishas in the new global economy: racism and sexism in video games / Stewart Chang -- Stories, stories everywhere (and nowhere just the same): transmedia texts. \"My name is Alan Wake. I'm a writer.\": crafting narrative complexity in the age of transmedia storytelling / Michael Fuchs -- Millions of voices: Star wars, digital games, fictional worlds and franchise canon / Felan Parker -- The hype man as racial stereotype, parody and ghost in Afro samurai / Treaandrea M. Russworm -- Epic nostalgia: narrative play and transmedia storytelling in Disney epic Mickey / Lisa K. Dusenberry.\u001E  \u001FaDescription based on print version record.\u001E 0\u001FaMotion pictures and video games.\u001E 0\u001FaFilm adaptations\u001FxHistory and criticism.\u001E 0\u001FaVideo games\u001FxAuthorship.\u001E 0\u001FaConvergence (Telecommunication)\u001E1 \u001FaPapazian, Gretchen,\u001Fd1968-\u001Feeditor of compilation.\u001E1 \u001FaSommers, Joseph Michael,\u001Fd1976-\u001Feeditor of  compilation.\u001E2 \u001FaEbooks Corporation\u001E0 \u001FaEbook Library.\u001E08\u001FcOriginal\u001Fz9780786471140\u001Fz078647114X\u001Fw(DLC)  2012051432\u001E40\u001FzConnect to e-book on Ebook Library\u001Fuhttp://qut.eblib.com.au.AU/EBLWeb/patron/?target=patron&extendedid=P_1126326_0\u001E  \u001Fa.o13465405\u001E  \u001Fa130307\u001Fb6000\u001Fe6000\u001Ff243967\u001Fg1\u001E  \u001FbOM\u001Fcnlnet\u001E\u001D";
+  private static final String CORRECT_MARC_HOLDINGS_RAW_RECORD =
+    "00182cx  a22000851  4500001000900000004000800009005001700017008003300034852002900067\u001E10245123\u001E9928371\u001E20170607135730.0\u001E1706072u    8   4001uu   0901128\u001E0 \u001Fbfine\u001FhN7433.3\u001Fi.B87 2014\u001E\u001D";
+  private static final String RAW_RECORD_WITH_999_ff_s_SUBFIELD =
+    "00948nam a2200241 a 4500001000800000003000400008005001700012008004100029035002100070035002000091040002300111041001300134100002300147245007900170260005800249300002400307440007100331650003600402650005500438650006900493655006500562999007900627\u001E1007048\u001EICU\u001E19950912000000.0\u001E891218s1983    wyu      d    00010 eng d\u001E  \u001Fa(ICU)BID12424550\u001E  \u001Fa(OCoLC)16105467\u001E  \u001FaPAU\u001FcPAU\u001Fdm/c\u001FdICU\u001E0 \u001Faeng\u001Faarp\u001E1 \u001FaSalzmann, Zdeněk\u001E10\u001FaDictionary of contemporary Arapaho usage /\u001Fccompiled by Zdeněk Salzmann.\u001E0 \u001FaWind River, Wyoming :\u001FbWind River Reservation,\u001Fc1983.\u001E  \u001Fav, 231 p. ;\u001Fc28 cm.\u001E 0\u001FaArapaho language and culture instructional materials series\u001Fvno. 4\u001E 0\u001FaArapaho language\u001FxDictionaries.\u001E 0\u001FaIndians of North America\u001FxLanguages\u001FxDictionaries.\u001E 7\u001FaArapaho language.\u001F2fast\u001F0http://id.worldcat.org/fast/fst00812722\u001E 7\u001FaDictionaries.\u001F2fast\u001F0http://id.worldcat.org/fast/fst01423826\u001Eff\u001Fie27a5374-0857-462e-ac84-fb4795229c7a\u001Fse27a5374-0857-462e-ac84-fb4795229c7a\u001E\u001D";
+  private static final String MARC_AUTHORITY_RAW_RECORD_WITH_999_s_SUBFIELD =
+    "01107cz  a2200253n  4500001000800000005001700008008004100025010001700066035002300083035002100106040004300127100002200170375000900192377000800201400002400209400003700233400003000270400004400300667004700344670006800391670009400459670022100553999007900774\u001E1000649\u001E20171119085041.0\u001E850103n| azannaabn          |b aaa      \u001E  \u001Fan  84234537 \u001E  \u001Fa(OCoLC)oca01249182\u001E  \u001Fa(DLC)n  84234537\u001E  \u001FaDLC\u001Fbeng\u001Ferda\u001FcDLC\u001FdDLC\u001FdCoU\u001FdDLC\u001FdInU\u001E1 \u001FaEimermacher, Karl\u001E  \u001Famale\u001E  \u001Fager\u001E1 \u001FaAĭmermakher, Karl\u001E1 \u001FaАймермахер, Карл\u001E1 \u001FaAĭmermakher, K.\u001Fq(Karl)\u001E1 \u001FaАймермахер, К.\u001Fq(Карл)\u001E  \u001FaNon-Latin script references not evaluated.\u001E  \u001FaSidur, V. Vadim Sidur, 1980?:\u001Fbp. 3 of cover (Karl Eimermacher)\u001E  \u001FaV tiskakh ideologii, 1992:\u001Fbt.p. verso (Karla Aĭmermakhera) colophon (K. Aĭmermakher)\u001E  \u001FaGoogle, 01-31-02\u001Fbruhr-uni-bochum.de/lirsk/whowho.htm (Prof. Dr. Dr. hc. Karl Eimermacher; Geb. 1938; Institutsleiter und Landesbeauftragter für die Hochschulkontakte des Landes NRW zu den europäischen U-Staaten)\u001Eff\u001Fs9df3f407-434b-4260-bfe3-3791c607a1cd\u001Fi92e3bde3-d49f-4a25-867b-2fc257bee318\u001E\u001D";
+  private static final String RAW_RECORD_WITH_INVALID_LEADER =
+    "01342nhm a2200289 a 4500005001700000008004100017035002000058040001300078041000800091043001200099245003000111260005600141300002100197336008000218337007100298338006900369350001500438500007900453530004900532650008200581651006500663650007900728650006300807651006600870856009600936035002001032\u001E20020829132600.0\u001E850404m19839999ctu     ab    00000dmul d\u001E  \u001Fa(ICU)BID8683551\u001E  \u001FaICU\u001FcICU\u001E0 \u001Famul\u001E  \u001Fan-us---\u001E04\u001FaThe Immigrant in America.\u001E0 \u001FaWoodbridge, Conn. :\u001FbResearch Publications,\u001Fc[1983-\u001E  \u001Fareels. ;\u001Fc35 mm.\u001E  \u001Faunspecified\u001Fbzzz\u001F2rdacontent\u001F0http://id.loc.gov/vocabulary/contentTypes/zzz\u001E  \u001Faunmediated\u001Fbn\u001F2rdamedia\u001F0http://id.loc.gov/vocabulary/mediaTypes/n\u001E  \u001Favolume\u001Fbnc\u001F2rdacarrier\u001F0http://id.loc.gov/vocabulary/carriers/nc\u001E  \u001Fa$17,000.00\u001E  \u001FaAccompanying guide to the collection on microfilm has call no. JV6455.I56.\u001E  \u001FaSearch guide also available on the Internet.\u001E 0\u001FaNoncitizens\u001FzUnited States\u001F0http://id.loc.gov/authorities/subjects/sh85003551\u001E 0\u001FaUnited States\u001FxEmigration and immigration\u001FxBio-bibliography.\u001E 7\u001FaEmigration and immigration.\u001F2fast\u001F0http://id.worldcat.org/fast/fst00908690\u001E 7\u001FaImmigrants.\u001F2fast\u001F0http://id.worldcat.org/fast/fst00967712\u001E 7\u001FaUnited States.\u001F2fast\u001F0http://id.worldcat.org/fast/fst01204155\u001E41\u001FzSelect search guide from pull down menu at:\u001Fuhttp://microformguides.gale.com/SearchForm.asp\u001E  \u001Fa(OCoLC)43567633\u001E\u001D";
+  private static final String MARC_HOLDINGS_RAW_RECORD_WITH_999_ff_s_SUBFIELD =
+    "00476cy  a22001454  4500001000700000004001400007005001700021008003300038014001700071014001400088852009600102866002700198868002600225999007900251\u001E445553\u001Ein00000000278\u001E20171018085818.0\u001E9301234u    8   1   uu          \u001E1 \u001FaABP6388CU001\u001E0 \u001F9000442923\u001E01\u001FbKU/CC/DI/A\u001FhBR140\u001Fi.J86\u001Fxdbe=c\u001FzCurrent issues in Periodicals Room\u001FxCHECK-IN RECORD CREATED\u001E41\u001F80\u001Fav.54-68 (2003-2017)\u001E41\u001F80\u001Fav.1/50 (1950/1999)\u001Eff\u001Fsa88255be-9669-4100-9ad3-25d21827c9bc\u001Fided3fee0-4b2f-41fb-b740-aaf1ffc3e772\u001E\u001D";
   private static final String DEFAULT_INSTANCE_JOB_PROFILE_ID = "22fafcc3-f582-493d-88b0-3c538480cd83";
   private static final String DEFAULT_MARC_HOLDINGS_JOB_PROFILE_ID = "80898dee-449f-44dd-9c8e-37d5eb469b1d";
 
@@ -203,14 +209,20 @@ public class ChangeManagerAPITest extends AbstractRestTest {
   @Before
   public void setUp() {
     MockitoAnnotations.initMocks(this);
-    WireMock.stubFor(WireMock.get("/data-import-profiles/jobProfiles/"+ DEFAULT_INSTANCE_JOB_PROFILE_ID +"?withRelations=false&")
-      .willReturn(WireMock.ok().withBody(Json.encode(new JobProfile().withId(DEFAULT_INSTANCE_JOB_PROFILE_ID).withName("Default job profile")))));
-    WireMock.stubFor(WireMock.get("/data-import-profiles/jobProfiles/"+ DEFAULT_MARC_HOLDINGS_JOB_PROFILE_ID +"?withRelations=false&")
-      .willReturn(WireMock.ok().withBody(Json.encode(new JobProfile().withId(DEFAULT_MARC_HOLDINGS_JOB_PROFILE_ID).withName("Default - Create Holdings and SRS MARC Holdings")))));
-    WireMock.stubFor(WireMock.get("/data-import-profiles/jobProfiles/"+JOB_PROFILE_ID+"?withRelations=false&")
-      .willReturn(WireMock.ok().withBody(Json.encode(new JobProfile().withId(JOB_PROFILE_ID).withName("not default job profile")))));
+    WireMock.stubFor(
+      WireMock.get("/data-import-profiles/jobProfiles/" + DEFAULT_INSTANCE_JOB_PROFILE_ID + "?withRelations=false&")
+        .willReturn(WireMock.ok().withBody(
+          Json.encode(new JobProfile().withId(DEFAULT_INSTANCE_JOB_PROFILE_ID).withName("Default job profile")))));
+    WireMock.stubFor(WireMock.get(
+        "/data-import-profiles/jobProfiles/" + DEFAULT_MARC_HOLDINGS_JOB_PROFILE_ID + "?withRelations=false&")
+      .willReturn(WireMock.ok().withBody(Json.encode(new JobProfile().withId(DEFAULT_MARC_HOLDINGS_JOB_PROFILE_ID)
+        .withName("Default - Create Holdings and SRS MARC Holdings")))));
+    WireMock.stubFor(WireMock.get("/data-import-profiles/jobProfiles/" + JOB_PROFILE_ID + "?withRelations=false&")
+      .willReturn(WireMock.ok()
+        .withBody(Json.encode(new JobProfile().withId(JOB_PROFILE_ID).withName("not default job profile")))));
     WireMock.stubFor(WireMock.post("/source-storage/batch/verified-records")
-      .willReturn(WireMock.ok().withBody(Json.encode(new JsonObject("{\"invalidMarcBibIds\" : [ \"111111\", \"222222\" ]}")))));
+      .willReturn(
+        WireMock.ok().withBody(Json.encode(new JsonObject("{\"invalidMarcBibIds\" : [ \"111111\", \"222222\" ]}")))));
     WireMock.stubFor(WireMock.get("/linking-rules/instance-authority")
       .willReturn(WireMock.ok().withBody(Json.encode(emptyList()))));
   }
@@ -435,7 +447,8 @@ public class ChangeManagerAPITest extends AbstractRestTest {
     JobExecution singleParent = createdJobExecutions.get(0);
     assertThat(singleParent.getSubordinationType(), is(JobExecution.SubordinationType.PARENT_SINGLE));
 
-    singleParent.setJobProfileInfo(new JobProfileInfo().withId(DEFAULT_INSTANCE_JOB_PROFILE_ID).withName("Marc jobs profile"));
+    singleParent.setJobProfileInfo(
+      new JobProfileInfo().withId(DEFAULT_INSTANCE_JOB_PROFILE_ID).withName("Marc jobs profile"));
     RestAssured.given()
       .spec(spec)
       .body(JsonObject.mapFrom(singleParent).toString())
@@ -493,7 +506,8 @@ public class ChangeManagerAPITest extends AbstractRestTest {
     List<JobExecution> createdJobExecutions = response.getJobExecutions();
     assertThat(createdJobExecutions.size(), is(26));
     JobExecution multipleParent = createdJobExecutions.stream()
-      .filter(jobExec -> jobExec.getSubordinationType().equals(JobExecution.SubordinationType.PARENT_MULTIPLE)).findFirst().get();
+      .filter(jobExec -> jobExec.getSubordinationType().equals(JobExecution.SubordinationType.PARENT_MULTIPLE))
+      .findFirst().get();
 
     RestAssured.given()
       .spec(spec)
@@ -514,7 +528,8 @@ public class ChangeManagerAPITest extends AbstractRestTest {
     List<JobExecution> createdJobExecutions = response.getJobExecutions();
     assertThat(createdJobExecutions.size(), is(26));
     JobExecution multipleParent = createdJobExecutions.stream()
-      .filter(jobExec -> jobExec.getSubordinationType().equals(JobExecution.SubordinationType.PARENT_MULTIPLE)).findFirst().get();
+      .filter(jobExec -> jobExec.getSubordinationType().equals(JobExecution.SubordinationType.PARENT_MULTIPLE))
+      .findFirst().get();
 
     RestAssured.given()
       .spec(spec)
@@ -885,7 +900,8 @@ public class ChangeManagerAPITest extends AbstractRestTest {
     List<JobExecution> createdJobExecutions = response.getJobExecutions();
     assertThat(createdJobExecutions.size(), is(4));
     JobExecution parent = createdJobExecutions.stream()
-      .filter(jobExec -> jobExec.getSubordinationType().equals(JobExecution.SubordinationType.PARENT_MULTIPLE)).findFirst().get();
+      .filter(jobExec -> jobExec.getSubordinationType().equals(JobExecution.SubordinationType.PARENT_MULTIPLE))
+      .findFirst().get();
 
     StatusDto status = new StatusDto().withStatus(StatusDto.Status.PARSING_IN_PROGRESS);
     RestAssured.given()
@@ -913,9 +929,11 @@ public class ChangeManagerAPITest extends AbstractRestTest {
     List<JobExecution> createdJobExecutions = response.getJobExecutions();
     assertThat(createdJobExecutions.size(), is(3));
     JobExecution multipleParent = createdJobExecutions.stream()
-      .filter(jobExec -> jobExec.getSubordinationType().equals(JobExecution.SubordinationType.PARENT_MULTIPLE)).findFirst().get();
+      .filter(jobExec -> jobExec.getSubordinationType().equals(JobExecution.SubordinationType.PARENT_MULTIPLE))
+      .findFirst().get();
 
-    multipleParent.setJobProfileInfo(new JobProfileInfo().withId(DEFAULT_INSTANCE_JOB_PROFILE_ID).withName("Marc jobs profile"));
+    multipleParent.setJobProfileInfo(
+      new JobProfileInfo().withId(DEFAULT_INSTANCE_JOB_PROFILE_ID).withName("Marc jobs profile"));
     RestAssured.given()
       .spec(spec)
       .body(JsonObject.mapFrom(multipleParent).toString())
@@ -942,7 +960,8 @@ public class ChangeManagerAPITest extends AbstractRestTest {
     List<JobExecution> createdJobExecutions = response.getJobExecutions();
     assertThat(createdJobExecutions.size(), is(3));
     JobExecution multipleParent = createdJobExecutions.stream()
-      .filter(jobExec -> jobExec.getSubordinationType().equals(JobExecution.SubordinationType.PARENT_MULTIPLE)).findFirst().get();
+      .filter(jobExec -> jobExec.getSubordinationType().equals(JobExecution.SubordinationType.PARENT_MULTIPLE))
+      .findFirst().get();
 
     multipleParent.setStatus(JobExecution.Status.PARSING_IN_PROGRESS);
     RestAssured.given()
@@ -1078,7 +1097,8 @@ public class ChangeManagerAPITest extends AbstractRestTest {
     assertThat(createdJobExecutions.size(), is(1));
     JobExecution jobExec = createdJobExecutions.get(0);
 
-    JobProfileInfo jobProfile = new JobProfileInfo().withId(DEFAULT_INSTANCE_JOB_PROFILE_ID).withName("Default job profile");
+    JobProfileInfo jobProfile =
+      new JobProfileInfo().withId(DEFAULT_INSTANCE_JOB_PROFILE_ID).withName("Default job profile");
     RestAssured.given()
       .spec(spec)
       .body(JsonObject.mapFrom(jobProfile).toString())
@@ -1260,7 +1280,8 @@ public class ChangeManagerAPITest extends AbstractRestTest {
     List<JobExecution> createdJobExecutions = response.getJobExecutions();
     assertThat(createdJobExecutions.size(), is(1));
     JobExecution jobExec = createdJobExecutions.get(0);
-    WireMock.stubFor(post(RECORDS_SERVICE_URL).willReturn(created().withTransformers(RequestToResponseTransformer.NAME)));
+    WireMock.stubFor(
+      post(RECORDS_SERVICE_URL).willReturn(created().withTransformers(RequestToResponseTransformer.NAME)));
 
     Async async = testContext.async();
     RestAssured.given()
@@ -1347,7 +1368,8 @@ public class ChangeManagerAPITest extends AbstractRestTest {
     List<JobExecution> createdJobExecutions = response.getJobExecutions();
     assertThat(createdJobExecutions.size(), is(1));
     JobExecution jobExec = createdJobExecutions.get(0);
-    WireMock.stubFor(post(RECORDS_SERVICE_URL).willReturn(created().withTransformers(RequestToResponseTransformer.NAME)));
+    WireMock.stubFor(
+      post(RECORDS_SERVICE_URL).willReturn(created().withTransformers(RequestToResponseTransformer.NAME)));
 
     // Do mock services to return failed response
     WireMock.stubFor(get(IDENTIFIER_TYPES_URL).willReturn(serverError()));
@@ -1519,7 +1541,7 @@ public class ChangeManagerAPITest extends AbstractRestTest {
     WireMock.stubFor(post(RECORDS_SERVICE_URL)
       .willReturn(created().withTransformers(RequestToResponseTransformer.NAME)));
 
-   Async async = testContext.async();
+    Async async = testContext.async();
     RestAssured.given()
       .spec(spec)
       .body(jobExec)
@@ -1605,7 +1627,8 @@ public class ChangeManagerAPITest extends AbstractRestTest {
     JobExecution singleParent = createdJobExecutions.get(0);
     assertThat(singleParent.getSubordinationType(), is(JobExecution.SubordinationType.PARENT_SINGLE));
 
-    singleParent.setJobProfileInfo(new JobProfileInfo().withId(DEFAULT_INSTANCE_JOB_PROFILE_ID).withName("Marc jobs profile"));
+    singleParent.setJobProfileInfo(
+      new JobProfileInfo().withId(DEFAULT_INSTANCE_JOB_PROFILE_ID).withName("Marc jobs profile"));
     RestAssured.given()
       .spec(spec)
       .body(JsonObject.mapFrom(singleParent).toString())
@@ -1622,7 +1645,7 @@ public class ChangeManagerAPITest extends AbstractRestTest {
 
     InitJobExecutionsRqDto requestDto = new InitJobExecutionsRqDto();
     String jsonFiles = TestUtil.readFileFromPath(FILES_PATH);
-    List<File> filesList = new ObjectMapper().readValue(jsonFiles, new TypeReference<>() {});
+    List<File> filesList = new ObjectMapper().readValue(jsonFiles, new TypeReference<>() { });
 
     requestDto.getFiles().addAll(filesList.stream().limit(1).collect(Collectors.toList()));
     requestDto.setUserId(okapiUserIdHeader);
@@ -1637,7 +1660,8 @@ public class ChangeManagerAPITest extends AbstractRestTest {
   }
 
   @Test
-  public void shouldNotPostRecordsToRecordsStorageWhenJobProfileSnapshotContainsUpdateMarcActionProfile(TestContext testContext) {
+  public void shouldNotPostRecordsToRecordsStorageWhenJobProfileSnapshotContainsUpdateMarcActionProfile(
+    TestContext testContext) {
     InitJobExecutionsRsDto response =
       constructAndPostInitJobExecutionRqDto(1);
     List<JobExecution> createdJobExecutions = response.getJobExecutions();
@@ -1978,7 +2002,7 @@ public class ChangeManagerAPITest extends AbstractRestTest {
       .spec(spec)
       .body(JsonObject.mapFrom(status).toString())
       .when()
-      .put(JOB_EXECUTION_PATH +jobExec.getId() + STATUS_PATH)
+      .put(JOB_EXECUTION_PATH + jobExec.getId() + STATUS_PATH)
       .then()
       .statusCode(HttpStatus.SC_OK);
 
@@ -2057,10 +2081,10 @@ public class ChangeManagerAPITest extends AbstractRestTest {
     JobExecution jobExec = createdJobExecutions.get(0);
 
     WireMock.stubFor(post(new UrlPathPattern(new RegexPattern(PROFILE_SNAPSHOT_URL + "/.*"), true))
-      .willReturn(WireMock.created().withBody(Json.encode(updateProfileSnapshotWrapperResponse))));
+      .willReturn(WireMock.created().withBody(Json.encode(matchProfileSnapshotWrapperResponse))));
 
     WireMock.stubFor(get(new UrlPathPattern(new RegexPattern(PROFILE_SNAPSHOT_URL + "/.*"), true))
-      .willReturn(WireMock.ok().withBody(Json.encode(updateProfileSnapshotWrapperResponse))));
+      .willReturn(WireMock.ok().withBody(Json.encode(matchProfileSnapshotWrapperResponse))));
 
     WireMock.stubFor(post(RECORDS_SERVICE_URL)
       .willReturn(created().withTransformers(RequestToResponseTransformer.NAME)));
@@ -2106,7 +2130,8 @@ public class ChangeManagerAPITest extends AbstractRestTest {
   }
 
   @Test
-  public void shouldHaveErrorRecordIf999ffsFieldExistsAndCreateInstanceActionProfile(TestContext testContext) throws InterruptedException {
+  public void shouldHaveErrorRecordIf999ffsFieldExistsAndCreateInstanceActionProfile(TestContext testContext)
+    throws InterruptedException {
     InitJobExecutionsRsDto response =
       constructAndPostInitJobExecutionRqDto(1);
     List<JobExecution> createdJobExecutions = response.getJobExecutions();
@@ -2150,20 +2175,23 @@ public class ChangeManagerAPITest extends AbstractRestTest {
       .decodeValue(obtainedEvent.getEventPayload(), RecordCollection.class);
     Assert.assertNull(recordCollection.getRecords().get(0).getMatchedId());
     Assert.assertNotNull(recordCollection.getRecords().get(0).getErrorRecord());
-    Assert.assertEquals("{\"error\":\"A new Instance was not created because the incoming record already contained a 999ff$s or 999ff$i field\"}",
+    Assert.assertEquals(
+      "{\"error\":\"A new Instance was not created because the incoming record already contained a 999ff$s or 999ff$i field\"}",
       recordCollection.getRecords().get(0).getErrorRecord().getDescription());
   }
 
   @Test
-  public void shouldHaveErrorRecordIsNullIf999ffsFieldExistsAndCreateInstanceActionProfileWithNonMatch(TestContext testContext) throws InterruptedException {
+  public void shouldHaveErrorRecordIsNullIf999ffsFieldExistsAndCreateInstanceActionProfileWithNonMatch(
+    TestContext testContext) throws InterruptedException {
     InitJobExecutionsRsDto response = constructAndPostInitJobExecutionRqDto(1);
     List<JobExecution> createdJobExecutions = response.getJobExecutions();
     assertThat(createdJobExecutions.size(), is(1));
     JobExecution jobExec = createdJobExecutions.get(0);
 
-    WireMock.stubFor(WireMock.get("/data-import-profiles/jobProfiles/" + DEFAULT_INSTANCE_JOB_PROFILE_ID + "?withRelations=false&")
-      .willReturn(WireMock.ok().withBody(Json.encode(new JobProfile().withId(DEFAULT_INSTANCE_JOB_PROFILE_ID)
-        .withName("Default - Create instance and SRS MARC Bib")))));
+    WireMock.stubFor(
+      WireMock.get("/data-import-profiles/jobProfiles/" + DEFAULT_INSTANCE_JOB_PROFILE_ID + "?withRelations=false&")
+        .willReturn(WireMock.ok().withBody(Json.encode(new JobProfile().withId(DEFAULT_INSTANCE_JOB_PROFILE_ID)
+          .withName("Default - Create instance and SRS MARC Bib")))));
 
     WireMock.stubFor(post(RECORDS_SERVICE_URL)
       .willReturn(created().withTransformers(RequestToResponseTransformer.NAME)));
@@ -2207,16 +2235,18 @@ public class ChangeManagerAPITest extends AbstractRestTest {
   }
 
   @Test
-  public void shouldHaveErrorRecordIf999ffsFieldExistsAndCreateMarcAuthorityActionProfile(TestContext testContext) throws InterruptedException {
+  public void shouldHaveErrorRecordIf999ffsFieldExistsAndCreateMarcAuthorityActionProfile(TestContext testContext)
+    throws InterruptedException {
     InitJobExecutionsRsDto response =
       constructAndPostInitJobExecutionRqDto(1);
     List<JobExecution> createdJobExecutions = response.getJobExecutions();
     assertThat(createdJobExecutions.size(), is(1));
     JobExecution jobExec = createdJobExecutions.get(0);
 
-
-    WireMock.stubFor(WireMock.get("/data-import-profiles/jobProfiles/"+ DEFAULT_MARC_AUTHORITY_JOB_PROFILE_ID +"?withRelations=false&")
-      .willReturn(WireMock.ok().withBody(Json.encode(new JobProfile().withId(DEFAULT_MARC_AUTHORITY_JOB_PROFILE_ID).withName("Default - Create SRS MARC Authority")))));
+    WireMock.stubFor(WireMock.get(
+        "/data-import-profiles/jobProfiles/" + DEFAULT_MARC_AUTHORITY_JOB_PROFILE_ID + "?withRelations=false&")
+      .willReturn(WireMock.ok().withBody(Json.encode(new JobProfile().withId(DEFAULT_MARC_AUTHORITY_JOB_PROFILE_ID)
+        .withName("Default - Create SRS MARC Authority")))));
 
     WireMock.stubFor(post(RECORDS_SERVICE_URL)
       .willReturn(created().withTransformers(RequestToResponseTransformer.NAME)));
@@ -2259,7 +2289,9 @@ public class ChangeManagerAPITest extends AbstractRestTest {
       .decodeValue(obtainedEvent.getEventPayload(), RecordCollection.class);
     Assert.assertNull(recordCollection.getRecords().get(0).getMatchedId());
     Assert.assertNotNull(recordCollection.getRecords().get(0).getErrorRecord());
-    Assert.assertEquals( "{\"error\":\"A new MARC-Authority was not created because the incoming record already contained a 999ff$s or 999ff$i field\"}", recordCollection.getRecords().get(0).getErrorRecord().getDescription());
+    Assert.assertEquals(
+      "{\"error\":\"A new MARC-Authority was not created because the incoming record already contained a 999ff$s or 999ff$i field\"}",
+      recordCollection.getRecords().get(0).getErrorRecord().getDescription());
   }
 
   @Test
@@ -2305,20 +2337,23 @@ public class ChangeManagerAPITest extends AbstractRestTest {
     assertEquals(DI_RAW_RECORDS_CHUNK_PARSED.value(), obtainedEvent.getEventType());
     RecordCollection recordCollection = Json.decodeValue(obtainedEvent.getEventPayload(), RecordCollection.class);
     assertEquals(1, recordCollection.getRecords().size());
-    MatcherAssert.assertThat(recordCollection.getRecords().get(0).getErrorRecord().getDescription(), containsString("Error during analyze leader line for determining record type"));
+    MatcherAssert.assertThat(recordCollection.getRecords().get(0).getErrorRecord().getDescription(),
+      containsString("Error during analyze leader line for determining record type"));
   }
 
   @Test
-  public void shouldHaveErrorRecordIf999ffsFieldExistsAndCreateMarcHoldingsActionProfile(TestContext testContext) throws InterruptedException {
+  public void shouldHaveErrorRecordIf999ffsFieldExistsAndCreateMarcHoldingsActionProfile(TestContext testContext)
+    throws InterruptedException {
     InitJobExecutionsRsDto response =
       constructAndPostInitJobExecutionRqDto(1);
     List<JobExecution> createdJobExecutions = response.getJobExecutions();
     assertThat(createdJobExecutions.size(), is(1));
     JobExecution jobExec = createdJobExecutions.get(0);
 
-
-    WireMock.stubFor(WireMock.get("/data-import-profiles/jobProfiles/"+ DEFAULT_MARC_HOLDINGS_JOB_PROFILE_ID +"?withRelations=false&")
-      .willReturn(WireMock.ok().withBody(Json.encode(new JobProfile().withId(DEFAULT_MARC_HOLDINGS_JOB_PROFILE_ID).withName("Default - Create Holdings and SRS MARC Holdings")))));
+    WireMock.stubFor(WireMock.get(
+        "/data-import-profiles/jobProfiles/" + DEFAULT_MARC_HOLDINGS_JOB_PROFILE_ID + "?withRelations=false&")
+      .willReturn(WireMock.ok().withBody(Json.encode(new JobProfile().withId(DEFAULT_MARC_HOLDINGS_JOB_PROFILE_ID)
+        .withName("Default - Create Holdings and SRS MARC Holdings")))));
 
     WireMock.stubFor(post(RECORDS_SERVICE_URL)
       .willReturn(created().withTransformers(RequestToResponseTransformer.NAME)));
@@ -2361,11 +2396,13 @@ public class ChangeManagerAPITest extends AbstractRestTest {
       .decodeValue(obtainedEvent.getEventPayload(), RecordCollection.class);
     Assert.assertNull(recordCollection.getRecords().get(0).getMatchedId());
     Assert.assertNotNull(recordCollection.getRecords().get(0).getErrorRecord());
-    Assert.assertEquals( "{\"error\":\"A new MARC-Holding was not created because the incoming record already contained a 999ff$s or 999ff$i field\"}", recordCollection.getRecords().get(0).getErrorRecord().getDescription());
+    Assert.assertEquals(
+      "{\"error\":\"A new MARC-Holding was not created because the incoming record already contained a 999ff$s or 999ff$i field\"}",
+      recordCollection.getRecords().get(0).getErrorRecord().getDescription());
   }
 
   @Test
-  public void testDeleteChangeManagerJobExecutionsSingleEntity(){
+  public void testDeleteChangeManagerJobExecutionsSingleEntity() {
     // given
     String jsonFiles;
     List<File> filesList;
@@ -2393,7 +2430,8 @@ public class ChangeManagerAPITest extends AbstractRestTest {
       .then().statusCode(HttpStatus.SC_CREATED)
       .extract().path("parentJobExecutionId");
 
-    DeleteJobExecutionsReq deleteJobExecutionsReq = new DeleteJobExecutionsReq().withIds(Arrays.asList(parentJobExecutionId));
+    DeleteJobExecutionsReq deleteJobExecutionsReq =
+      new DeleteJobExecutionsReq().withIds(Arrays.asList(parentJobExecutionId));
     RestAssured.given()
       .spec(spec)
       .body(deleteJobExecutionsReq)
@@ -2406,7 +2444,7 @@ public class ChangeManagerAPITest extends AbstractRestTest {
   }
 
   @Test
-  public void testDeleteChangeManagerJobExecutionsMultipleIds(){
+  public void testDeleteChangeManagerJobExecutionsMultipleIds() {
     // given
     String jsonFiles;
     List<File> filesList;
@@ -2442,7 +2480,8 @@ public class ChangeManagerAPITest extends AbstractRestTest {
       .then().statusCode(HttpStatus.SC_CREATED)
       .extract().path("parentJobExecutionId");
 
-    DeleteJobExecutionsReq deleteJobExecutionsReq = new DeleteJobExecutionsReq().withIds(Arrays.asList(parentJobExecutionId, parentJobExecutionId_2));
+    DeleteJobExecutionsReq deleteJobExecutionsReq =
+      new DeleteJobExecutionsReq().withIds(Arrays.asList(parentJobExecutionId, parentJobExecutionId_2));
     RestAssured.given()
       .spec(spec)
       .body(deleteJobExecutionsReq)
@@ -2457,7 +2496,7 @@ public class ChangeManagerAPITest extends AbstractRestTest {
   }
 
   @Test
-  public void testDeleteChangeManagerJobExecutionsFailure(){
+  public void testDeleteChangeManagerJobExecutionsFailure() {
     RestAssured.given()
       .spec(spec)
       .body("{\"ids\":null}")
@@ -2468,7 +2507,7 @@ public class ChangeManagerAPITest extends AbstractRestTest {
   }
 
   @Test
-  public void testDeleteChangeManagerJobExecutionsIncorrectBody(){
+  public void testDeleteChangeManagerJobExecutionsIncorrectBody() {
     RestAssured.given()
       .spec(spec)
       .body("{\"ids\":\"15065ccd-c305-4961-a411-8359e0b5a87b\"}")
@@ -2479,10 +2518,11 @@ public class ChangeManagerAPITest extends AbstractRestTest {
   }
 
   @Test
-  public void testDeleteChangeManagerJobExecutionsDeletedIds(){
+  public void testDeleteChangeManagerJobExecutionsDeletedIds() {
     String parentJobExecutionId = constructAndPostInitJobExecutionRqDto(1).getParentJobExecutionId();
     String parentJobExecutionId_2 = constructAndPostInitJobExecutionRqDto(1).getParentJobExecutionId();
-    DeleteJobExecutionsResp deleteJobExecutionsResp = returnDeletedJobExecutionResponse(new String[]{parentJobExecutionId});
+    DeleteJobExecutionsResp deleteJobExecutionsResp =
+      returnDeletedJobExecutionResponse(new String[] {parentJobExecutionId});
     assertThat(deleteJobExecutionsResp.getJobExecutionDetails().get(0).getJobExecutionId(), is(parentJobExecutionId));
     assertThat(deleteJobExecutionsResp.getJobExecutionDetails().get(0).getIsDeleted(), is(true));
 
@@ -2501,8 +2541,9 @@ public class ChangeManagerAPITest extends AbstractRestTest {
       .statusCode(HttpStatus.SC_OK);
   }
 
-  public static DeleteJobExecutionsResp returnDeletedJobExecutionResponse(String[] parentJobExecutionId){
-    DeleteJobExecutionsReq deleteJobExecutionsReq = new DeleteJobExecutionsReq().withIds(Arrays.asList(parentJobExecutionId));
+  public static DeleteJobExecutionsResp returnDeletedJobExecutionResponse(String[] parentJobExecutionId) {
+    DeleteJobExecutionsReq deleteJobExecutionsReq =
+      new DeleteJobExecutionsReq().withIds(Arrays.asList(parentJobExecutionId));
     return RestAssured.given()
       .spec(spec)
       .body(deleteJobExecutionsReq)
@@ -2520,12 +2561,13 @@ public class ChangeManagerAPITest extends AbstractRestTest {
     List<JobExecution> createdJobExecutions = response.getJobExecutions();
     assertThat(createdJobExecutions.size(), is(26));
     JobExecution multipleParent = createdJobExecutions.stream()
-      .filter(jobExec -> jobExec.getSubordinationType().equals(JobExecution.SubordinationType.PARENT_MULTIPLE)).findFirst().get();
+      .filter(jobExec -> jobExec.getSubordinationType().equals(JobExecution.SubordinationType.PARENT_MULTIPLE))
+      .findFirst().get();
 
-    DeleteJobExecutionsResp deleteJobExecutionsResp = returnDeletedJobExecutionResponse(new String[]{multipleParent.getId()});
+    DeleteJobExecutionsResp deleteJobExecutionsResp =
+      returnDeletedJobExecutionResponse(new String[] {multipleParent.getId()});
     assertThat(deleteJobExecutionsResp.getJobExecutionDetails().get(0).getJobExecutionId(), is(multipleParent.getId()));
     assertThat(deleteJobExecutionsResp.getJobExecutionDetails().get(0).getIsDeleted(), is(true));
-
 
     RestAssured.given()
       .spec(spec)
@@ -2544,7 +2586,7 @@ public class ChangeManagerAPITest extends AbstractRestTest {
     JobExecution child = createdJobExecutions.stream()
       .filter(jobExec -> jobExec.getSubordinationType().equals(JobExecution.SubordinationType.CHILD)).findFirst().get();
 
-    DeleteJobExecutionsResp deleteJobExecutionsResp = returnDeletedJobExecutionResponse(new String[]{child.getId()});
+    DeleteJobExecutionsResp deleteJobExecutionsResp = returnDeletedJobExecutionResponse(new String[] {child.getId()});
     assertThat(deleteJobExecutionsResp.getJobExecutionDetails().get(0).getJobExecutionId(), is(child.getId()));
     assertThat(deleteJobExecutionsResp.getJobExecutionDetails().get(0).getIsDeleted(), is(true));
 
@@ -2559,14 +2601,14 @@ public class ChangeManagerAPITest extends AbstractRestTest {
   }
 
   @Test
-  public void shouldNotUpdateJobProfileOfDeletedRecords(TestContext testContext){
+  public void shouldNotUpdateJobProfileOfDeletedRecords(TestContext testContext) {
     InitJobExecutionsRsDto response =
       constructAndPostInitJobExecutionRqDto(1);
     List<JobExecution> createdJobExecutions = response.getJobExecutions();
     assertThat(createdJobExecutions.size(), is(1));
     JobExecution jobExec = createdJobExecutions.get(0);
 
-    DeleteJobExecutionsResp deleteJobExecutionsResp = returnDeletedJobExecutionResponse(new String[]{jobExec.getId()});
+    DeleteJobExecutionsResp deleteJobExecutionsResp = returnDeletedJobExecutionResponse(new String[] {jobExec.getId()});
     assertThat(deleteJobExecutionsResp.getJobExecutionDetails().get(0).getJobExecutionId(), is(jobExec.getId()));
     assertThat(deleteJobExecutionsResp.getJobExecutionDetails().get(0).getIsDeleted(), is(true));
 
@@ -2585,14 +2627,14 @@ public class ChangeManagerAPITest extends AbstractRestTest {
   }
 
   @Test
-  public void shouldNotUpdateJobExecutionOfDeletedRecords(){
+  public void shouldNotUpdateJobExecutionOfDeletedRecords() {
     InitJobExecutionsRsDto response =
       constructAndPostInitJobExecutionRqDto(1);
     List<JobExecution> createdJobExecutions = response.getJobExecutions();
     assertThat(createdJobExecutions.size(), is(1));
     JobExecution jobExec = createdJobExecutions.get(0);
 
-    DeleteJobExecutionsResp deleteJobExecutionsResp = returnDeletedJobExecutionResponse(new String[]{jobExec.getId()});
+    DeleteJobExecutionsResp deleteJobExecutionsResp = returnDeletedJobExecutionResponse(new String[] {jobExec.getId()});
     assertThat(deleteJobExecutionsResp.getJobExecutionDetails().get(0).getJobExecutionId(), is(jobExec.getId()));
     assertThat(deleteJobExecutionsResp.getJobExecutionDetails().get(0).getIsDeleted(), is(true));
 

--- a/mod-source-record-manager-server/src/test/java/org/folio/services/ChangeEngineServiceImplTest.java
+++ b/mod-source-record-manager-server/src/test/java/org/folio/services/ChangeEngineServiceImplTest.java
@@ -404,7 +404,7 @@ public class ChangeEngineServiceImplTest {
       service.parseRawRecordsChunkForJobExecution(rawRecordsDto, jobExecution, "1", false, okapiConnectionParams).result();
     }
 
-    verifyNoInteractions(recordsPublishingService);
+    verify(recordsPublishingService).sendEventsWithRecords(any(), eq(jobExecution.getId()), any(), eq(DI_MARC_FOR_UPDATE_RECEIVED.value()));
   }
 
   @Test
@@ -427,7 +427,7 @@ public class ChangeEngineServiceImplTest {
       service.parseRawRecordsChunkForJobExecution(rawRecordsDto, jobExecution, "1", false, okapiConnectionParams).result();
     }
 
-    verifyNoInteractions(recordsPublishingService);
+    verify(recordsPublishingService).sendEventsWithRecords(any(), eq(jobExecution.getId()), any(), eq(DI_MARC_FOR_UPDATE_RECEIVED.value()));
   }
 
   @Test

--- a/mod-source-record-manager-server/src/test/java/org/folio/services/ChangeEngineServiceImplTest.java
+++ b/mod-source-record-manager-server/src/test/java/org/folio/services/ChangeEngineServiceImplTest.java
@@ -178,8 +178,6 @@ public class ChangeEngineServiceImplTest {
     when(jobExecutionSourceChunkDao.getById(any(), any()))
       .thenReturn(Future.succeededFuture(Optional.of(new JobExecutionSourceChunk())));
     when(jobExecutionSourceChunkDao.update(any(), any())).thenReturn(Future.succeededFuture(new JobExecutionSourceChunk()));
-    when(recordsPublishingService.sendEventsWithRecords(any(), any(), any(), any()))
-      .thenReturn(Future.succeededFuture(true));
 
     Future<List<Record>> serviceFuture = executeWithKafkaMock(rawRecordsDto, jobExecution, Future.succeededFuture(true));
 

--- a/mod-source-record-manager-server/src/test/java/org/folio/services/ChangeEngineServiceImplTest.java
+++ b/mod-source-record-manager-server/src/test/java/org/folio/services/ChangeEngineServiceImplTest.java
@@ -1,10 +1,41 @@
 package org.folio.services;
 
+import static org.folio.rest.jaxrs.model.ActionProfile.Action.CREATE;
+import static org.folio.rest.jaxrs.model.ActionProfile.FolioRecord.AUTHORITY;
+import static org.folio.rest.jaxrs.model.ActionProfile.FolioRecord.MARC_AUTHORITY;
+import static org.folio.rest.jaxrs.model.DataImportEventTypes.DI_MARC_FOR_UPDATE_RECEIVED;
+import static org.folio.rest.jaxrs.model.ProfileSnapshotWrapper.ContentType.ACTION_PROFILE;
+import static org.folio.rest.jaxrs.model.ProfileSnapshotWrapper.ContentType.JOB_PROFILE;
+import static org.folio.rest.jaxrs.model.ProfileSnapshotWrapper.ContentType.MAPPING_PROFILE;
+import static org.folio.rest.jaxrs.model.ProfileSnapshotWrapper.ContentType.MATCH_PROFILE;
+import static org.folio.rest.jaxrs.model.ProfileSnapshotWrapper.ReactTo.NON_MATCH;
+import static org.folio.services.ChangeEngineServiceImpl.RECORD_ID_HEADER;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.hasSize;
+import static org.hamcrest.Matchers.notNullValue;
+import static org.hamcrest.Matchers.nullValue;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
 import io.vertx.core.Future;
 import io.vertx.core.Vertx;
 import io.vertx.core.json.Json;
 import io.vertx.core.json.JsonObject;
 import io.vertx.kafka.client.producer.KafkaHeader;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
 import org.folio.MatchProfile;
 import org.folio.dao.JobExecutionSourceChunkDao;
 import org.folio.dataimport.util.OkapiConnectionParams;
@@ -37,34 +68,6 @@ import org.mockito.Mock;
 import org.mockito.Mockito;
 import org.mockito.junit.MockitoJUnitRunner;
 import org.springframework.test.util.ReflectionTestUtils;
-
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Optional;
-import java.util.UUID;
-
-import static org.folio.rest.jaxrs.model.DataImportEventTypes.DI_MARC_FOR_UPDATE_RECEIVED;
-import static org.folio.rest.jaxrs.model.ProfileSnapshotWrapper.ContentType.ACTION_PROFILE;
-import static org.folio.rest.jaxrs.model.ProfileSnapshotWrapper.ContentType.JOB_PROFILE;
-import static org.folio.rest.jaxrs.model.ProfileSnapshotWrapper.ContentType.MAPPING_PROFILE;
-import static org.folio.rest.jaxrs.model.ProfileSnapshotWrapper.ContentType.MATCH_PROFILE;
-import static org.folio.services.ChangeEngineServiceImpl.RECORD_ID_HEADER;
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.equalTo;
-import static org.hamcrest.Matchers.hasSize;
-import static org.hamcrest.Matchers.notNullValue;
-import static org.hamcrest.Matchers.nullValue;
-import static org.junit.Assert.assertTrue;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyList;
-import static org.mockito.ArgumentMatchers.anyString;
-import static org.mockito.ArgumentMatchers.eq;
-import static org.mockito.Mockito.doAnswer;
-import static org.mockito.Mockito.never;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.verifyNoInteractions;
-import static org.mockito.Mockito.when;
 
 @RunWith(MockitoJUnitRunner.class)
 public class ChangeEngineServiceImplTest {
@@ -195,7 +198,7 @@ public class ChangeEngineServiceImplTest {
         .withContentType(ACTION_PROFILE)
         .withContent(new JsonObject(Json.encode(new ActionProfile()
           .withAction(ActionProfile.Action.DELETE)
-          .withFolioRecord(ActionProfile.FolioRecord.MARC_AUTHORITY))).getMap())
+          .withFolioRecord(MARC_AUTHORITY))).getMap())
       ))
     );
 
@@ -212,6 +215,37 @@ public class ChangeEngineServiceImplTest {
     assertThat(actual, hasSize(1));
     assertThat(actual.get(0).getRecordType(), equalTo(Record.RecordType.MARC_AUTHORITY));
     assertThat(actual.get(0).getErrorRecord(), nullValue());
+  }
+
+  @Test
+  public void shouldReturnMarcAuthorityRecordWhenNotMatch() {
+    RawRecordsDto rawRecordsDto = getTestRawRecordsDto(MARC_AUTHORITY_REC_VALID);
+
+    JobExecution jobExecution = getTestJobExecution();
+    jobExecution.setJobProfileSnapshotWrapper(new ProfileSnapshotWrapper()
+      .withChildSnapshotWrappers(List.of(new ProfileSnapshotWrapper()
+          .withContentType(MATCH_PROFILE)
+          .withContent(new JsonObject(Json.encode(new MatchProfile()
+            .withExistingRecordType(EntityType.MARC_AUTHORITY)
+            .withIncomingRecordType(EntityType.MARC_AUTHORITY)))
+            .getMap())
+          .withChildSnapshotWrappers(List.of(new ProfileSnapshotWrapper()
+            .withContentType(ACTION_PROFILE)
+            .withReactTo(NON_MATCH)
+            .withContent(new JsonObject(Json.encode(new ActionProfile()
+              .withAction(CREATE)
+              .withFolioRecord(AUTHORITY)))
+              .getMap())))))
+    );
+    mockServicesForParseRawRecordsChunkForJobExecution();
+
+    try (var mockedStatic = Mockito.mockStatic(EventHandlingUtil.class)) {
+      mockedStatic.when(() -> EventHandlingUtil.sendEventToKafka(any(), any(), any(), kafkaHeadersCaptor.capture(), any(), any()))
+        .thenReturn(Future.succeededFuture(true));
+      service.parseRawRecordsChunkForJobExecution(rawRecordsDto, jobExecution, "1", false, okapiConnectionParams).result();
+    }
+
+    verify(recordsPublishingService).sendEventsWithRecords(any(), eq(jobExecution.getId()), any(), eq(DI_MARC_FOR_UPDATE_RECEIVED.value()));
   }
 
   @Test
@@ -372,7 +406,7 @@ public class ChangeEngineServiceImplTest {
       service.parseRawRecordsChunkForJobExecution(rawRecordsDto, jobExecution, "1", false, okapiConnectionParams).result();
     }
 
-    verify(recordsPublishingService).sendEventsWithRecords(any(), eq(jobExecution.getId()), any(), eq(DI_MARC_FOR_UPDATE_RECEIVED.value()));
+    verifyNoInteractions(recordsPublishingService);
   }
 
   @Test
@@ -395,7 +429,7 @@ public class ChangeEngineServiceImplTest {
       service.parseRawRecordsChunkForJobExecution(rawRecordsDto, jobExecution, "1", false, okapiConnectionParams).result();
     }
 
-    verify(recordsPublishingService).sendEventsWithRecords(any(), eq(jobExecution.getId()), any(), eq(DI_MARC_FOR_UPDATE_RECEIVED.value()));
+    verifyNoInteractions(recordsPublishingService);
   }
 
   @Test
@@ -484,7 +518,7 @@ public class ChangeEngineServiceImplTest {
           .withContentType(ACTION_PROFILE)
           .withContent(new JsonObject(Json.encode(new ActionProfile()
             .withAction(ActionProfile.Action.DELETE)
-            .withFolioRecord(ActionProfile.FolioRecord.MARC_AUTHORITY)
+            .withFolioRecord(MARC_AUTHORITY)
             .withRemove9Subfields(true))).getMap())
         ))
       ))
@@ -517,7 +551,7 @@ public class ChangeEngineServiceImplTest {
         .withContentType(ACTION_PROFILE)
         .withContent(new JsonObject(Json.encode(new ActionProfile()
           .withAction(ActionProfile.Action.DELETE)
-          .withFolioRecord(ActionProfile.FolioRecord.MARC_AUTHORITY)
+          .withFolioRecord(MARC_AUTHORITY)
           .withRemove9Subfields(false))).getMap())
       ))
     );
@@ -558,7 +592,7 @@ public class ChangeEngineServiceImplTest {
         .withContent(new JsonObject(Json.encode(new ActionProfile()
           .withId(UUID.randomUUID().toString())
           .withName("Create Instance")
-          .withAction(ActionProfile.Action.CREATE)
+          .withAction(CREATE)
           .withFolioRecord(ActionProfile.FolioRecord.INSTANCE))).getMap())
       ));
   };
@@ -574,7 +608,7 @@ public class ChangeEngineServiceImplTest {
           .withContent(new JsonObject(Json.encode(new ActionProfile()
             .withId(UUID.randomUUID().toString())
             .withName("Create Instance")
-            .withAction(ActionProfile.Action.CREATE)
+            .withAction(CREATE)
             .withFolioRecord(ActionProfile.FolioRecord.INSTANCE))).getMap())
         , new ProfileSnapshotWrapper()
           .withProfileId(UUID.randomUUID().toString())
@@ -582,7 +616,7 @@ public class ChangeEngineServiceImplTest {
           .withContent(new JsonObject(Json.encode(new ActionProfile()
             .withId(UUID.randomUUID().toString())
             .withName("Create MARC-Holdings ")
-            .withAction(ActionProfile.Action.CREATE)
+            .withAction(CREATE)
             .withFolioRecord(ActionProfile.FolioRecord.HOLDINGS))).getMap())
           .withChildSnapshotWrappers(Collections.singletonList(new ProfileSnapshotWrapper()
             .withProfileId(UUID.randomUUID().toString())
@@ -606,7 +640,7 @@ public class ChangeEngineServiceImplTest {
         .withContent(new JsonObject(Json.encode(new ActionProfile()
           .withId(UUID.randomUUID().toString())
           .withName("Create MARC-Holdings ")
-          .withAction(ActionProfile.Action.CREATE)
+          .withAction(CREATE)
           .withFolioRecord(ActionProfile.FolioRecord.HOLDINGS))).getMap())
         .withChildSnapshotWrappers(Collections.singletonList(new ProfileSnapshotWrapper()
           .withProfileId(UUID.randomUUID().toString())

--- a/mod-source-record-manager-server/src/test/java/org/folio/services/ChangeEngineServiceImplTest.java
+++ b/mod-source-record-manager-server/src/test/java/org/folio/services/ChangeEngineServiceImplTest.java
@@ -178,6 +178,8 @@ public class ChangeEngineServiceImplTest {
     when(jobExecutionSourceChunkDao.getById(any(), any()))
       .thenReturn(Future.succeededFuture(Optional.of(new JobExecutionSourceChunk())));
     when(jobExecutionSourceChunkDao.update(any(), any())).thenReturn(Future.succeededFuture(new JobExecutionSourceChunk()));
+    when(recordsPublishingService.sendEventsWithRecords(any(), any(), any(), any()))
+      .thenReturn(Future.succeededFuture(true));
 
     Future<List<Record>> serviceFuture = executeWithKafkaMock(rawRecordsDto, jobExecution, Future.succeededFuture(true));
 

--- a/mod-source-record-manager-server/src/test/java/org/folio/verticle/consumers/RawMarcChunkConsumersVerticleTest.java
+++ b/mod-source-record-manager-server/src/test/java/org/folio/verticle/consumers/RawMarcChunkConsumersVerticleTest.java
@@ -91,6 +91,20 @@ public class RawMarcChunkConsumersVerticleTest extends AbstractRestTest {
         .withContentType(ACTION_PROFILE)
         .withContent(updateInstanceActionProfile)));
 
+  private MatchProfile matchProfileMarcAuthorityToMarcAuthority =
+    new MatchProfile()
+      .withIncomingRecordType(EntityType.MARC_AUTHORITY)
+      .withExistingRecordType(EntityType.MARC_AUTHORITY);
+
+  private ProfileSnapshotWrapper matchAuthorityJobProfileSnapshot = new ProfileSnapshotWrapper()
+    .withId(UUID.randomUUID().toString())
+    .withContentType(JOB_PROFILE)
+    .withContent(jobProfile)
+    .withChildSnapshotWrappers(List.of(
+      new ProfileSnapshotWrapper()
+        .withContentType(MATCH_PROFILE)
+        .withContent(matchProfileMarcAuthorityToMarcAuthority)));
+
   private MatchProfile matchProfileMarcBibToInstance =
     new MatchProfile().withMatchDetails(List.of(new MatchDetail()
       .withIncomingRecordType(EntityType.MARC_BIBLIOGRAPHIC)
@@ -318,7 +332,7 @@ public class RawMarcChunkConsumersVerticleTest extends AbstractRestTest {
   public void shouldSendEventDiMarcForUpdateReceivedWhenProfileSnapshotContainsUpdateInstanceActionProfile() throws InterruptedException {
     // given
     WireMock.stubFor(post(new UrlPathPattern(new RegexPattern(PROFILE_SNAPSHOT_URL + "/.*"), true))
-      .willReturn(WireMock.created().withBody(Json.encode(updateInstanceJobProfileSnapshot))));
+      .willReturn(WireMock.created().withBody(Json.encode(matchAuthorityJobProfileSnapshot))));
 
     SendKeyValues<String, String> request = prepareWithSpecifiedRecord(JobProfileInfo.DataType.MARC,
       RecordsMetadata.ContentType.MARC_RAW, RAW_RECORD_WITH_999_ff_field);
@@ -364,7 +378,7 @@ public class RawMarcChunkConsumersVerticleTest extends AbstractRestTest {
   public void shouldSendEventDiErrorWhenParsingFailedForUpdateScenarios() throws InterruptedException {
     // given
     WireMock.stubFor(post(new UrlPathPattern(new RegexPattern(PROFILE_SNAPSHOT_URL + "/.*"), true))
-            .willReturn(WireMock.created().withBody(Json.encode(updateInstanceJobProfileSnapshot))));
+            .willReturn(WireMock.created().withBody(Json.encode(matchAuthorityJobProfileSnapshot))));
 
     SendKeyValues<String, String> request = prepareWithSpecifiedRecord(JobProfileInfo.DataType.MARC,
             RecordsMetadata.ContentType.MARC_RAW, INVALID_RECORD);

--- a/mod-source-record-manager-server/src/test/java/org/folio/verticle/consumers/RawMarcChunkConsumersVerticleTest.java
+++ b/mod-source-record-manager-server/src/test/java/org/folio/verticle/consumers/RawMarcChunkConsumersVerticleTest.java
@@ -91,20 +91,6 @@ public class RawMarcChunkConsumersVerticleTest extends AbstractRestTest {
         .withContentType(ACTION_PROFILE)
         .withContent(updateInstanceActionProfile)));
 
-  private MatchProfile matchProfileMarcAuthorityToMarcAuthority =
-    new MatchProfile()
-      .withIncomingRecordType(EntityType.MARC_AUTHORITY)
-      .withExistingRecordType(EntityType.MARC_AUTHORITY);
-
-  private ProfileSnapshotWrapper matchAuthorityJobProfileSnapshot = new ProfileSnapshotWrapper()
-    .withId(UUID.randomUUID().toString())
-    .withContentType(JOB_PROFILE)
-    .withContent(jobProfile)
-    .withChildSnapshotWrappers(List.of(
-      new ProfileSnapshotWrapper()
-        .withContentType(MATCH_PROFILE)
-        .withContent(matchProfileMarcAuthorityToMarcAuthority)));
-
   private MatchProfile matchProfileMarcBibToInstance =
     new MatchProfile().withMatchDetails(List.of(new MatchDetail()
       .withIncomingRecordType(EntityType.MARC_BIBLIOGRAPHIC)
@@ -332,7 +318,7 @@ public class RawMarcChunkConsumersVerticleTest extends AbstractRestTest {
   public void shouldSendEventDiMarcForUpdateReceivedWhenProfileSnapshotContainsUpdateInstanceActionProfile() throws InterruptedException {
     // given
     WireMock.stubFor(post(new UrlPathPattern(new RegexPattern(PROFILE_SNAPSHOT_URL + "/.*"), true))
-      .willReturn(WireMock.created().withBody(Json.encode(matchAuthorityJobProfileSnapshot))));
+      .willReturn(WireMock.created().withBody(Json.encode(updateInstanceJobProfileSnapshot))));
 
     SendKeyValues<String, String> request = prepareWithSpecifiedRecord(JobProfileInfo.DataType.MARC,
       RecordsMetadata.ContentType.MARC_RAW, RAW_RECORD_WITH_999_ff_field);
@@ -378,7 +364,7 @@ public class RawMarcChunkConsumersVerticleTest extends AbstractRestTest {
   public void shouldSendEventDiErrorWhenParsingFailedForUpdateScenarios() throws InterruptedException {
     // given
     WireMock.stubFor(post(new UrlPathPattern(new RegexPattern(PROFILE_SNAPSHOT_URL + "/.*"), true))
-            .willReturn(WireMock.created().withBody(Json.encode(matchAuthorityJobProfileSnapshot))));
+            .willReturn(WireMock.created().withBody(Json.encode(updateInstanceJobProfileSnapshot))));
 
     SendKeyValues<String, String> request = prepareWithSpecifiedRecord(JobProfileInfo.DataType.MARC,
             RecordsMetadata.ContentType.MARC_RAW, INVALID_RECORD);


### PR DESCRIPTION
## Purpose
MARC authority record is not created when use Job profile with match profile and action only on no-match branch. 
[MODSOURMAN-1108](https://issues.folio.org/browse/MODSOURMAN-1108)

## Approach
* replace condition for checking update action with match profile exist
* add test case
* fix tests

## Checklist
- [x] I have updated NEWS.md.
- [ ] I have added javadocs to new methods.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation e.g. README.md.
- [ ] I have ran karate tests against this feature.

