### PR TITLE
MODSOURMAN-1113 Reduce Memory Allocations Of Strings

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,4 +1,5 @@
 ## 2023-xx-xx v3.8.0-SNAPSHOT
+* [MODSOURMAN-1113](https://issues.folio.org/browse/MODSOURMAN-1113) Reduce Memory Allocations Of Strings
 * [MODSOURMAN-1085](https://issues.folio.org/browse/MODSOURMAN-1085) MARC record with a 100 tag without a $a is being discarded on import.
 * [MODSOURMAN-1030](https://issues.folio.org/browse/MODSOURMAN-1030) The number of updated records is not correct displayed in the 'SRS Marc' column in the 'Log summary' table
 * [MODSOURMAN-976](https://issues.folio.org/browse/MODSOURMAN-976) Incorrect error counts

--- a/mod-source-record-manager-server/src/main/java/org/folio/services/RecordProcessedEventHandlingServiceImpl.java
+++ b/mod-source-record-manager-server/src/main/java/org/folio/services/RecordProcessedEventHandlingServiceImpl.java
@@ -18,6 +18,7 @@ import org.folio.rest.jaxrs.model.Progress;
 import org.folio.rest.jaxrs.model.StatusDto;
 import org.folio.rest.jaxrs.model.JobExecution.SubordinationType;
 import org.folio.services.progress.JobExecutionProgressService;
+import org.folio.util.DataImportEventPayloadWithoutCurrentNode;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
@@ -50,7 +51,7 @@ public class RecordProcessedEventHandlingServiceImpl implements EventHandlingSer
     Promise<Boolean> promise = Promise.promise();
     DataImportEventPayload dataImportEventPayload;
     try {
-      dataImportEventPayload = Json.decodeValue(eventContent, DataImportEventPayload.class);
+      dataImportEventPayload = Json.decodeValue(eventContent, DataImportEventPayloadWithoutCurrentNode.class);
     } catch (DecodeException e) {
       LOGGER.warn("handle:: Failed to read eventContent {}", eventContent, e);
       promise.fail(e);

--- a/mod-source-record-manager-server/src/main/java/org/folio/services/RecordsPublishingServiceImpl.java
+++ b/mod-source-record-manager-server/src/main/java/org/folio/services/RecordsPublishingServiceImpl.java
@@ -1,9 +1,9 @@
 package org.folio.services;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
 import io.vertx.core.Future;
 import io.vertx.core.Promise;
 import io.vertx.core.json.Json;
+import io.vertx.core.json.jackson.DatabindCodec;
 import org.apache.commons.collections4.CollectionUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -77,7 +77,7 @@ import static org.folio.services.util.EventHandlingUtil.sendEventToKafka;
     Promise<Boolean> promise = Promise.promise();
     List<Future<Boolean>> futures = new ArrayList<>();
     List<Record> failedRecords = new ArrayList<>();
-    ProfileSnapshotWrapper profileSnapshotWrapper = new ObjectMapper().convertValue(jobExecution.getJobProfileSnapshotWrapper(), ProfileSnapshotWrapper.class);
+    ProfileSnapshotWrapper profileSnapshotWrapper = DatabindCodec.mapper().convertValue(jobExecution.getJobProfileSnapshotWrapper(), ProfileSnapshotWrapper.class);
 
     for (Record record : createdRecords) {
       String key = String.valueOf(indexer.incrementAndGet() % maxDistributionNum);

--- a/mod-source-record-manager-server/src/main/java/org/folio/services/afterprocessing/AdditionalFieldsUtil.java
+++ b/mod-source-record-manager-server/src/main/java/org/folio/services/afterprocessing/AdditionalFieldsUtil.java
@@ -7,12 +7,13 @@ import com.github.benmanes.caffeine.cache.stats.CacheStats;
 import io.vertx.core.Context;
 import io.vertx.core.Vertx;
 import io.vertx.core.json.JsonObject;
-import java.util.function.Consumer;
 import org.apache.commons.collections4.CollectionUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import org.folio.okapi.common.MetricsUtil;
 import org.folio.rest.jaxrs.model.Record;
+import org.folio.services.util.CaffeineStatsCounter;
 import org.marc4j.MarcJsonReader;
 import org.marc4j.MarcJsonWriter;
 import org.marc4j.MarcStreamWriter;
@@ -26,9 +27,12 @@ import org.marc4j.marc.VariableField;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.nio.charset.StandardCharsets;
+import java.time.Duration;
+import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
 import java.util.concurrent.ForkJoinPool;
+import java.util.function.Consumer;
 
 import static org.apache.commons.lang3.StringUtils.isNotEmpty;
 
@@ -52,40 +56,44 @@ public final class AdditionalFieldsUtil {
     // In this case, this is a MARC4J Record
     parsedRecordContentCacheLoader =
       parsedRecordContent -> {
-        MarcJsonReader marcJsonReader =
-          new MarcJsonReader(
-            new ByteArrayInputStream(
-              parsedRecordContent.toString().getBytes(StandardCharsets.UTF_8)));
-        if (marcJsonReader.hasNext()) {
-          return marcJsonReader.next();
+        try {
+          MarcJsonReader marcJsonReader =
+            new MarcJsonReader(
+              new ByteArrayInputStream(
+                parsedRecordContent.toString().getBytes(StandardCharsets.UTF_8)));
+          if (marcJsonReader.hasNext()) {
+            return marcJsonReader.next();
+          }
+          return null;
+        } catch (Exception e) {
+          LOGGER.error("something happened while loading a cache value for parsedRecordContentCache", e);
+          return null;
         }
-        return null;
       };
 
-    parsedRecordContentCache =
-        Caffeine.newBuilder()
-            .maximumSize(2000)
-            // weak keys allows parsed content strings that are used as keys to be garbage
-            // collected, even it is still
-            // referenced by the cache.
-            .weakKeys()
-            .recordStats()
-            .executor(
-                serviceExecutor -> {
-                  // Due to the static nature and the API of this AdditionalFieldsUtil class, it is difficult to
-                  // pass a vertx instance or assume whether a call to any of its static methods here is by a Vertx
-                  // thread or a regular thread. The logic before is able to discern the type of thread and execute
-                  // cache operations using the appropriate threading model.
-                  Context context = Vertx.currentContext();
-                  if (context != null) {
-                    context.runOnContext(ar -> serviceExecutor.run());
-                  }
-                  else {
-                    // The common pool below is used because it is the  default executor for caffeine
-                    ForkJoinPool.commonPool().execute(serviceExecutor);
-                  }
-                })
-          .build(parsedRecordContentCacheLoader);
+    Caffeine<Object, Object> cacheBuilder = Caffeine.newBuilder()
+      .maximumSize(2000)
+      .expireAfterWrite(Duration.ofMinutes(5))
+      .executor(
+        serviceExecutor -> {
+          // Due to the static nature and the API of this AdditionalFieldsUtil class, it is difficult to
+          // pass a vertx instance or assume whether a call to any of its static methods here is by a Vertx
+          // thread or a regular thread. The logic before is able to discern the type of thread and execute
+          // cache operations using the appropriate threading model.
+          Context context = Vertx.currentContext();
+          if (context != null) {
+            context.runOnContext(ar -> serviceExecutor.run());
+          } else {
+            // The common pool below is used because it is the  default executor for caffeine
+            ForkJoinPool.commonPool().execute(serviceExecutor);
+          }
+        });
+    if (MetricsUtil.isEnabled()) {
+      cacheBuilder
+        .recordStats(() -> new CaffeineStatsCounter("parsedRecordContentCache", Collections.emptyList()));
+    }
+
+    parsedRecordContentCache = cacheBuilder.build(parsedRecordContentCacheLoader);
   }
 
   private AdditionalFieldsUtil() {

--- a/mod-source-record-manager-server/src/main/java/org/folio/services/journal/InvoiceUtil.java
+++ b/mod-source-record-manager-server/src/main/java/org/folio/services/journal/InvoiceUtil.java
@@ -2,8 +2,9 @@ package org.folio.services.journal;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.core.type.TypeReference;
-import com.fasterxml.jackson.databind.ObjectMapper;
+import io.vertx.core.json.Json;
 import io.vertx.core.json.JsonObject;
+import io.vertx.core.json.jackson.DatabindCodec;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -89,7 +90,7 @@ public class InvoiceUtil {
   private static Map<String, Object> buildInvoiceRecord(DataImportEventPayload eventPayload) throws JournalRecordMapperException {
     try {
       String edifactRecordAsString = eventPayload.getContext().get(EDIFACT_INVOICE.value());
-      Record edifactRecord = new ObjectMapper().readValue(edifactRecordAsString, Record.class);
+      Record edifactRecord = Json.decodeValue(edifactRecordAsString, Record.class);
 
       String recordAsString = eventPayload.getContext().get(INVOICE.value());
       JsonObject invoiceJson = new JsonObject(recordAsString);
@@ -166,7 +167,7 @@ public class InvoiceUtil {
   private static List<JournalRecord> buildErrorJournalRecord(DataImportEventPayload eventPayload) throws JournalRecordMapperException {
     try {
       String edifactRecordAsString = eventPayload.getContext().get(EDIFACT_INVOICE.value());
-      Record edifactRecord = new ObjectMapper().readValue(edifactRecordAsString, Record.class);
+      Record edifactRecord = Json.decodeValue(edifactRecordAsString, Record.class);
 
       Integer invoiceOrder = edifactRecord.getOrder() != null ? edifactRecord.getOrder() : 0;
 
@@ -211,7 +212,7 @@ public class InvoiceUtil {
 
     String errorInvoiceLines = eventPayload.getContext().get(INVOICE_LINES_ERRORS_KEY);
     if (isNotEmpty(errorInvoiceLines)) {
-      return new ObjectMapper().readValue(errorInvoiceLines, new TypeReference<>() {
+      return DatabindCodec.mapper().readValue(errorInvoiceLines, new TypeReference<>() {
       });
     }
     return new HashMap<>();

--- a/mod-source-record-manager-server/src/main/java/org/folio/services/journal/JournalUtil.java
+++ b/mod-source-record-manager-server/src/main/java/org/folio/services/journal/JournalUtil.java
@@ -1,7 +1,7 @@
 package org.folio.services.journal;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.collect.Lists;
+import io.vertx.core.json.Json;
 import io.vertx.core.json.JsonArray;
 import io.vertx.core.json.JsonObject;
 import org.apache.commons.lang3.StringUtils;
@@ -78,7 +78,7 @@ public class JournalUtil {
           .withSnapshotId(eventPayload.getJobExecutionId())
           .withOrder(0);
       } else {
-        record = new ObjectMapper().readValue(recordAsString, Record.class);
+        record = Json.decodeValue(recordAsString, Record.class);
       }
 
       String entityAsString = eventPayloadContext.get(entityType.value());

--- a/mod-source-record-manager-server/src/main/java/org/folio/services/mappers/processor/MappingParametersProvider.java
+++ b/mod-source-record-manager-server/src/main/java/org/folio/services/mappers/processor/MappingParametersProvider.java
@@ -2,7 +2,6 @@ package org.folio.services.mappers.processor;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.core.type.TypeReference;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import com.github.benmanes.caffeine.cache.AsyncLoadingCache;
 import com.github.benmanes.caffeine.cache.Caffeine;
 import com.google.common.base.Objects;
@@ -21,6 +20,7 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Function;
 
+import io.vertx.core.json.jackson.DatabindCodec;
 import org.apache.commons.lang.StringUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -489,7 +489,7 @@ public class MappingParametersProvider {
         if (StringUtils.isNotBlank(response)) {
           List<LinkingRuleDto> linkingRules = new LinkedList<>();
           try {
-            linkingRules = new ObjectMapper().readValue(response, new TypeReference<>(){});
+            linkingRules = DatabindCodec.mapper().readValue(response, new TypeReference<>(){});
           } catch (JsonProcessingException e) {
             LOGGER.warn("Unable to parse linking rules response: {}", e.getMessage());
             promise.complete(Collections.emptyList());

--- a/mod-source-record-manager-server/src/main/java/org/folio/services/util/CaffeineStatsCounter.java
+++ b/mod-source-record-manager-server/src/main/java/org/folio/services/util/CaffeineStatsCounter.java
@@ -1,0 +1,103 @@
+package org.folio.services.util;
+
+import com.github.benmanes.caffeine.cache.RemovalCause;
+import com.github.benmanes.caffeine.cache.stats.CacheStats;
+import com.github.benmanes.caffeine.cache.stats.StatsCounter;
+import io.micrometer.core.instrument.Counter;
+import io.micrometer.core.instrument.Tag;
+import org.folio.okapi.common.MetricsUtil;
+
+import static java.util.Objects.requireNonNull;
+
+/**
+ * StatsCounter that is a bridge to RMB's metrics collection system
+ */
+public class CaffeineStatsCounter implements StatsCounter {
+  private final Counter hitCount;
+  private final Counter missCount;
+  private final Counter loadSuccessCount;
+  private final Counter loadFailureCount;
+  private final Counter totalLoadTime;
+  private final Counter evictionCount;
+  private final Counter evictionWeight;
+
+  public CaffeineStatsCounter(String cacheName, Iterable<Tag> tags) {
+    if (!MetricsUtil.isEnabled()) {
+      throw new RuntimeException("Metrics is not enabled for RMB");
+    }
+    hitCount = MetricsUtil.recordCounter(cacheName+".hitCount", tags);
+    missCount = MetricsUtil.recordCounter(cacheName+".missCount", tags);
+    loadSuccessCount = MetricsUtil.recordCounter(cacheName+".loadSuccessCount", tags);
+    loadFailureCount = MetricsUtil.recordCounter(cacheName+".loadFailureCount", tags);
+    totalLoadTime = MetricsUtil.recordCounter(cacheName+".totalLoadTime", tags);
+    evictionCount = MetricsUtil.recordCounter(cacheName+".evictionCount", tags);
+    evictionWeight = MetricsUtil.recordCounter(cacheName+".evictionWeight", tags);
+  }
+
+  @Override
+  public void recordHits(int count) {
+    hitCount.increment(count);
+  }
+
+  @Override
+  public void recordMisses(int count) {
+    missCount.increment(count);
+  }
+
+  @Override
+  public void recordLoadSuccess(long loadTime) {
+    loadSuccessCount.increment();
+    totalLoadTime.increment(loadTime);
+  }
+
+  @Override
+  public void recordLoadFailure(long loadTime) {
+    loadFailureCount.increment();
+    totalLoadTime.increment(loadTime);
+  }
+
+  @Override
+  public void recordEviction(int weight, RemovalCause cause) {
+    requireNonNull(cause);
+    evictionCount.increment();
+    evictionWeight.increment(weight);
+  }
+
+  @Override
+  public CacheStats snapshot() {
+    return CacheStats.of(
+      negativeToMaxValue((long) hitCount.count()),
+      negativeToMaxValue((long) missCount.count()),
+      negativeToMaxValue((long) loadSuccessCount.count()),
+      negativeToMaxValue((long) loadFailureCount.count()),
+      negativeToMaxValue((long) totalLoadTime.count()),
+      negativeToMaxValue((long) evictionCount.count()),
+      negativeToMaxValue((long) evictionWeight.count()));
+  }
+
+  /** Returns {@code value}, if non-negative. Otherwise, returns {@link Long#MAX_VALUE}. */
+  private static long negativeToMaxValue(long value) {
+    return (value >= 0) ? value : Long.MAX_VALUE;
+  }
+
+  /**
+   * Increments all counters by the values in {@code other}.
+   *
+   * @param other the counter to increment from
+   */
+  public void incrementBy(StatsCounter other) {
+    CacheStats otherStats = other.snapshot();
+    hitCount.increment(otherStats.hitCount());
+    missCount.increment(otherStats.missCount());
+    loadSuccessCount.increment(otherStats.loadSuccessCount());
+    loadFailureCount.increment(otherStats.loadFailureCount());
+    totalLoadTime.increment(otherStats.totalLoadTime());
+    evictionCount.increment(otherStats.evictionCount());
+    evictionWeight.increment(otherStats.evictionWeight());
+  }
+
+  @Override
+  public String toString() {
+    return snapshot().toString();
+  }
+}

--- a/mod-source-record-manager-server/src/main/java/org/folio/util/DataImportEventPayloadWithoutCurrentNode.java
+++ b/mod-source-record-manager-server/src/main/java/org/folio/util/DataImportEventPayloadWithoutCurrentNode.java
@@ -1,0 +1,14 @@
+package org.folio.util;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import org.folio.DataImportEventPayload;
+
+/**
+ * Another version of DataImportEventPayload that will not deserialize currentNode and currentNodePath.
+ * currentNode is expensive in CPU and memory. If business logic does not require the use of currentNode,
+ * this class can be used for deserialization instead.
+ */
+@JsonIgnoreProperties({"currentNode", "currentNodePath"})
+public class DataImportEventPayloadWithoutCurrentNode extends DataImportEventPayload {
+
+}

--- a/mod-source-record-manager-server/src/main/java/org/folio/util/JournalEvent.java
+++ b/mod-source-record-manager-server/src/main/java/org/folio/util/JournalEvent.java
@@ -1,0 +1,47 @@
+package org.folio.util;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+
+/**
+ * Another representation of {@link org.folio.rest.jaxrs.model.Event} that uses the less
+ * expensive DataImportPayload type. This is currently scoped for journal events.
+ */
+@JsonDeserialize(using = JournalEventDeserializer.class)
+public class JournalEvent {
+  @JsonProperty("id")
+  private String id;
+
+  @JsonProperty("eventType")
+  private String eventType;
+
+  @JsonProperty("eventPayload")
+  private DataImportEventPayloadWithoutCurrentNode eventPayload;
+
+  public String getId() {
+    return id;
+  }
+
+  public JournalEvent setId(String id) {
+    this.id = id;
+    return this;
+  }
+
+  public String getEventType() {
+    return eventType;
+  }
+
+  public JournalEvent setEventType(String eventType) {
+    this.eventType = eventType;
+    return this;
+  }
+
+  public DataImportEventPayloadWithoutCurrentNode getEventPayload() {
+    return eventPayload;
+  }
+
+  public JournalEvent setEventPayload(DataImportEventPayloadWithoutCurrentNode eventPayload) {
+    this.eventPayload = eventPayload;
+    return this;
+  }
+}

--- a/mod-source-record-manager-server/src/main/java/org/folio/util/JournalEventDeserializer.java
+++ b/mod-source-record-manager-server/src/main/java/org/folio/util/JournalEventDeserializer.java
@@ -1,0 +1,56 @@
+package org.folio.util;
+
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.core.JsonToken;
+import com.fasterxml.jackson.databind.DeserializationContext;
+import com.fasterxml.jackson.databind.JsonDeserializer;
+import io.vertx.core.json.jackson.DatabindCodec;
+
+import java.io.CharArrayReader;
+import java.io.IOException;
+
+/**
+ * Custom deserializer for {@link JournalEvent}. This deserializer understands that the
+ * {@link JournalEvent#eventPayload} is a string that has a JSON object embedded within.
+ * {@link JournalEvent#eventPayload} is deserialized without creating some intermediate String
+ * objects if this custom deserializer was not used.
+ * <p>
+ *   This was needed because the event payload is very large, containing "current node" information.
+ *   Multiple string representations of the event payload costed more memory than needed.
+ * </p>
+ */
+public class JournalEventDeserializer extends JsonDeserializer<JournalEvent> {
+
+  @Override
+  public JournalEvent deserialize(JsonParser jsonParser, DeserializationContext deserializationContext)
+    throws IOException {
+    JournalEvent journalEvent = new JournalEvent();
+
+    while (!jsonParser.isClosed()) {
+      JsonToken jsonToken = jsonParser.nextToken();
+
+      if (JsonToken.FIELD_NAME.equals(jsonToken)) {
+        String fieldName = jsonParser.getCurrentName();
+        jsonParser.nextToken(); // move to the value of the field
+        switch (fieldName) {
+          case "id":
+            journalEvent.setId(jsonParser.getValueAsString());
+            break;
+          case "eventType":
+            journalEvent.setEventType(jsonParser.getValueAsString());
+            break;
+          case "eventPayload":
+            // get a char array which is already created within the JsonParser for the purpose of decoding to text
+            // and not creating a string representation
+            try (CharArrayReader charArrayReader = new CharArrayReader(jsonParser.getTextCharacters())) {
+              DataImportEventPayloadWithoutCurrentNode payload = DatabindCodec.mapper().readValue(charArrayReader, DataImportEventPayloadWithoutCurrentNode.class);
+              journalEvent.setEventPayload(payload);
+            }
+            break;
+        }
+      }
+    }
+
+    return journalEvent;
+  }
+}

--- a/mod-source-record-manager-server/src/main/java/org/folio/verticle/DataImportConsumersVerticle.java
+++ b/mod-source-record-manager-server/src/main/java/org/folio/verticle/DataImportConsumersVerticle.java
@@ -21,11 +21,11 @@ import static org.springframework.beans.factory.config.BeanDefinition.SCOPE_PROT
  */
 @Component
 @Scope(SCOPE_PROTOTYPE)
-public class DataImportConsumersVerticle extends AbstractConsumersVerticle {
+public class DataImportConsumersVerticle extends AbstractConsumersVerticle<String, byte[]> {
 
   @Autowired
   @Qualifier("DataImportKafkaHandler")
-  private AsyncRecordHandler<String, String> dataImportKafkaHandler;
+  private AsyncRecordHandler<String, byte[]> dataImportKafkaHandler;
 
   @Override
   public List<String> getEvents() {
@@ -33,8 +33,13 @@ public class DataImportConsumersVerticle extends AbstractConsumersVerticle {
   }
 
   @Override
-  public AsyncRecordHandler<String, String> getHandler() {
+  public AsyncRecordHandler<String, byte[]> getHandler() {
     return this.dataImportKafkaHandler;
+  }
+
+  @Override
+  public String getDeserializerClass() {
+    return "org.apache.kafka.common.serialization.ByteArrayDeserializer";
   }
 
 }

--- a/mod-source-record-manager-server/src/main/java/org/folio/verticle/DataImportInitConsumersVerticle.java
+++ b/mod-source-record-manager-server/src/main/java/org/folio/verticle/DataImportInitConsumersVerticle.java
@@ -18,7 +18,7 @@ import static org.folio.rest.jaxrs.model.DataImportEventTypes.DI_INITIALIZATION_
  */
 @Component
 @Scope(SCOPE_PROTOTYPE)
-public class DataImportInitConsumersVerticle extends AbstractConsumersVerticle {
+public class DataImportInitConsumersVerticle extends AbstractConsumersVerticle<String, String> {
 
   @Autowired
   private DataImportInitKafkaHandler initializationHandler;

--- a/mod-source-record-manager-server/src/main/java/org/folio/verticle/DataImportJournalConsumersVerticle.java
+++ b/mod-source-record-manager-server/src/main/java/org/folio/verticle/DataImportJournalConsumersVerticle.java
@@ -48,11 +48,11 @@ import org.springframework.stereotype.Component;
  */
 @Component
 @Scope(SCOPE_PROTOTYPE)
-public class DataImportJournalConsumersVerticle extends AbstractConsumersVerticle {
+public class DataImportJournalConsumersVerticle extends AbstractConsumersVerticle<String, byte[]> {
 
   @Autowired
   @Qualifier("DataImportJournalKafkaHandler")
-  private AsyncRecordHandler<String, String> dataImportJournalKafkaHandler;
+  private AsyncRecordHandler<String, byte[]> dataImportJournalKafkaHandler;
 
   @Override
   public List<String> getEvents() {
@@ -91,7 +91,12 @@ public class DataImportJournalConsumersVerticle extends AbstractConsumersVerticl
   }
 
   @Override
-  public AsyncRecordHandler<String, String> getHandler() {
+  public AsyncRecordHandler<String, byte[]> getHandler() {
     return this.dataImportJournalKafkaHandler;
+  }
+
+  @Override
+  public String getDeserializerClass() {
+    return "org.apache.kafka.common.serialization.ByteArrayDeserializer";
   }
 }

--- a/mod-source-record-manager-server/src/main/java/org/folio/verticle/QuickMarcUpdateConsumersVerticle.java
+++ b/mod-source-record-manager-server/src/main/java/org/folio/verticle/QuickMarcUpdateConsumersVerticle.java
@@ -19,7 +19,7 @@ import static org.springframework.beans.factory.config.BeanDefinition.SCOPE_PROT
  */
 @Component
 @Scope(SCOPE_PROTOTYPE)
-public class QuickMarcUpdateConsumersVerticle extends AbstractConsumersVerticle {
+public class QuickMarcUpdateConsumersVerticle extends AbstractConsumersVerticle<String, String> {
 
   @Autowired
   private QuickMarcUpdateKafkaHandler quickMarcUpdateKafkaHandler;

--- a/mod-source-record-manager-server/src/main/java/org/folio/verticle/RawMarcChunkConsumersVerticle.java
+++ b/mod-source-record-manager-server/src/main/java/org/folio/verticle/RawMarcChunkConsumersVerticle.java
@@ -23,18 +23,18 @@ import static org.folio.rest.jaxrs.model.DataImportEventTypes.DI_RAW_RECORDS_CHU
  */
 @Component
 @Scope(SCOPE_PROTOTYPE)
-public class RawMarcChunkConsumersVerticle extends AbstractConsumersVerticle {
+public class RawMarcChunkConsumersVerticle extends AbstractConsumersVerticle<String, byte[]> {
 
   @Value("${di.flow.control.enable:true}")
   private boolean enableFlowControl;
 
   @Autowired
   @Qualifier("RawMarcChunksKafkaHandler")
-  private AsyncRecordHandler<String, String> rawMarcChunksKafkaHandler;
+  private AsyncRecordHandler<String, byte[]> rawMarcChunksKafkaHandler;
 
   @Autowired
   @Qualifier("RawMarcChunksErrorHandler")
-  private ProcessRecordErrorHandler<String, String> errorHandler;
+  private ProcessRecordErrorHandler<String, byte[]> errorHandler;
 
   @Override
   public List<String> getEvents() {
@@ -42,12 +42,12 @@ public class RawMarcChunkConsumersVerticle extends AbstractConsumersVerticle {
   }
 
   @Override
-  public AsyncRecordHandler<String, String> getHandler() {
+  public AsyncRecordHandler<String, byte[]> getHandler() {
     return this.rawMarcChunksKafkaHandler;
   }
 
   @Override
-  public ProcessRecordErrorHandler<String, String> getErrorHandler() {
+  public ProcessRecordErrorHandler<String, byte[]> getErrorHandler() {
     return this.errorHandler;
   }
 
@@ -74,6 +74,11 @@ public class RawMarcChunkConsumersVerticle extends AbstractConsumersVerticle {
     counts.
      */
     return false;
+  }
+
+  @Override
+  public String getDeserializerClass() {
+    return "org.apache.kafka.common.serialization.ByteArrayDeserializer";
   }
 
 }

--- a/mod-source-record-manager-server/src/main/java/org/folio/verticle/StoredRecordChunkConsumersVerticle.java
+++ b/mod-source-record-manager-server/src/main/java/org/folio/verticle/StoredRecordChunkConsumersVerticle.java
@@ -21,15 +21,15 @@ import static org.springframework.beans.factory.config.BeanDefinition.SCOPE_PROT
  */
 @Component
 @Scope(SCOPE_PROTOTYPE)
-public class StoredRecordChunkConsumersVerticle extends AbstractConsumersVerticle {
+public class StoredRecordChunkConsumersVerticle extends AbstractConsumersVerticle<String, byte[]> {
 
   @Autowired
   @Qualifier("StoredRecordChunksKafkaHandler")
-  private AsyncRecordHandler<String, String> storedRecordChunksKafkaHandler;
+  private AsyncRecordHandler<String, byte[]> storedRecordChunksKafkaHandler;
 
   @Autowired
   @Qualifier("StoredRecordChunksErrorHandler")
-  private ProcessRecordErrorHandler<String, String> errorHandler;
+  private ProcessRecordErrorHandler<String, byte[]> errorHandler;
 
   @Override
   public List<String> getEvents() {
@@ -37,12 +37,17 @@ public class StoredRecordChunkConsumersVerticle extends AbstractConsumersVerticl
   }
 
   @Override
-  public AsyncRecordHandler<String, String> getHandler() {
+  public AsyncRecordHandler<String, byte[]> getHandler() {
     return this.storedRecordChunksKafkaHandler;
   }
 
   @Override
-  public ProcessRecordErrorHandler<String, String> getErrorHandler() {
+  public ProcessRecordErrorHandler<String, byte[]> getErrorHandler() {
     return this.errorHandler;
+  }
+
+  @Override
+  public String getDeserializerClass() {
+    return "org.apache.kafka.common.serialization.ByteArrayDeserializer";
   }
 }

--- a/mod-source-record-manager-server/src/main/java/org/folio/verticle/consumers/consumerstorage/KafkaConsumersStorage.java
+++ b/mod-source-record-manager-server/src/main/java/org/folio/verticle/consumers/consumerstorage/KafkaConsumersStorage.java
@@ -14,7 +14,7 @@ public interface KafkaConsumersStorage {
    * @param eventName the event name that is the key of consumer
    * @param consumer  consumer wrapper to add
    */
-  void addConsumer(String eventName, KafkaConsumerWrapper<String, String> consumer);
+  void addConsumer(String eventName, KafkaConsumerWrapper<?,?> consumer);
 
   /**
    * Gets consumer by event name.
@@ -22,12 +22,12 @@ public interface KafkaConsumersStorage {
    * @param eventName the event name
    * @return consumer wrappers by event name
    */
-  Collection<KafkaConsumerWrapper<String, String>> getConsumersByEvent(String eventName);
+  Collection<KafkaConsumerWrapper<?,?>> getConsumersByEvent(String eventName);
 
   /**
    * Gets all registered consumers.
    *
    * @return collection of all registered consumer wrappers
    */
-  Collection<KafkaConsumerWrapper<String, String>> getConsumersList();
+  Collection<KafkaConsumerWrapper<?,?>> getConsumersList();
 }

--- a/mod-source-record-manager-server/src/main/java/org/folio/verticle/consumers/consumerstorage/KafkaConsumersStorageImpl.java
+++ b/mod-source-record-manager-server/src/main/java/org/folio/verticle/consumers/consumerstorage/KafkaConsumersStorageImpl.java
@@ -16,20 +16,20 @@ import java.util.stream.Collectors;
 public class KafkaConsumersStorageImpl implements KafkaConsumersStorage {
   private static final Logger LOGGER = LogManager.getLogger();
 
-  private final Map<String, List<KafkaConsumerWrapper<String, String>>> consumerWrappersMap = new ConcurrentHashMap<>();
+  private final Map<String, List<KafkaConsumerWrapper<?,?>>> consumerWrappersMap = new ConcurrentHashMap<>();
 
   @Override
-  public void addConsumer(String eventName, KafkaConsumerWrapper<String, String> consumer) {
+  public void addConsumer(String eventName, KafkaConsumerWrapper<?,?> consumer) {
     consumerWrappersMap.computeIfAbsent(eventName, k -> new ArrayList<>()).add(consumer);
   }
 
   @Override
-  public Collection<KafkaConsumerWrapper<String, String>> getConsumersByEvent(String eventName) {
+  public Collection<KafkaConsumerWrapper<?,?>> getConsumersByEvent(String eventName) {
     return consumerWrappersMap.get(eventName);
   }
 
   @Override
-  public Collection<KafkaConsumerWrapper<String, String>> getConsumersList() {
+  public Collection<KafkaConsumerWrapper<?,?>> getConsumersList() {
     return consumerWrappersMap.values()
       .stream()
       .flatMap(Collection::stream)

--- a/mod-source-record-manager-server/src/main/java/org/folio/verticle/consumers/errorhandlers/payloadbuilders/EdifactDiErrorPayloadBuilder.java
+++ b/mod-source-record-manager-server/src/main/java/org/folio/verticle/consumers/errorhandlers/payloadbuilders/EdifactDiErrorPayloadBuilder.java
@@ -1,6 +1,5 @@
 package org.folio.verticle.consumers.errorhandlers.payloadbuilders;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.collect.Lists;
 import io.vertx.core.Future;
 import io.vertx.core.json.Json;
@@ -133,7 +132,7 @@ public class EdifactDiErrorPayloadBuilder implements DiErrorPayloadBuilder {
   @SneakyThrows
   public DataImportEventPayload mapPayloadWithPopulatingInvoiceDetails(DataImportEventPayload dataImportEventPayload) {
     String edifactRecordAsString = dataImportEventPayload.getContext().get(EDIFACT_INVOICE.value());
-    Record edifactRecord = new ObjectMapper().readValue(edifactRecordAsString, Record.class);
+    Record edifactRecord = Json.decodeValue(edifactRecordAsString, Record.class);
     if(Objects.nonNull(edifactRecord.getParsedRecord())) {
       DataImportEventPayload mappedPayload = MappingManager.map(dataImportEventPayload, new MappingContext());
       mappedPayload.setEventType(DI_ERROR.value());

--- a/mod-source-record-manager-server/src/main/resources/vertx-default-jul-logging.properties
+++ b/mod-source-record-manager-server/src/main/resources/vertx-default-jul-logging.properties
@@ -1,5 +1,0 @@
-handlers = java.util.logging.ConsoleHandler
-.level = ALL
-
-logger.cql2pgjson.level = ERROR
-logger.cql2pgjson.name = org.folio.cql2pgjson.CQL2PgJSON

--- a/mod-source-record-manager-server/src/test/java/org/folio/rest/impl/AbstractRestTest.java
+++ b/mod-source-record-manager-server/src/test/java/org/folio/rest/impl/AbstractRestTest.java
@@ -637,8 +637,8 @@ public abstract class AbstractRestTest {
     throw new NotFoundException(String.format("Couldn't find bean %s", clazz.getName()));
   }
 
-  protected ConsumerRecord<String, String> buildConsumerRecord(String topic, Event event) {
-    ConsumerRecord<java.lang.String, java.lang.String> consumerRecord = new ConsumerRecord("folio", 0, 0, topic, Json.encode(event));
+  protected <V> ConsumerRecord<String, V> buildConsumerRecord(String topic, Event event) {
+    ConsumerRecord<java.lang.String, V> consumerRecord = new ConsumerRecord("folio", 0, 0, topic, Json.encode(event));
     consumerRecord.headers().add(new RecordHeader(OkapiConnectionParams.OKAPI_TENANT_HEADER, TENANT_ID.getBytes(StandardCharsets.UTF_8)));
     consumerRecord.headers().add(new RecordHeader(OKAPI_URL_HEADER, ("http://localhost:" + snapshotMockServer.port()).getBytes(StandardCharsets.UTF_8)));
     consumerRecord.headers().add(new RecordHeader(OKAPI_TOKEN_HEADER, (TOKEN).getBytes(StandardCharsets.UTF_8)));

--- a/mod-source-record-manager-server/src/test/java/org/folio/verticle/consumers/DataImportJournalConsumerVerticleMockTest.java
+++ b/mod-source-record-manager-server/src/test/java/org/folio/verticle/consumers/DataImportJournalConsumerVerticleMockTest.java
@@ -162,7 +162,7 @@ public class DataImportJournalConsumerVerticleMockTest extends AbstractRestTest 
 
     Mockito.doNothing().when(journalService).saveBatch(ArgumentMatchers.any(JsonArray.class), ArgumentMatchers.any(String.class));
 
-    KafkaConsumerRecord<String, String> kafkaConsumerRecord = buildKafkaConsumerRecord(dataImportEventPayload);
+    KafkaConsumerRecord<String, byte[]> kafkaConsumerRecord = buildKafkaConsumerRecord(dataImportEventPayload);
     dataImportJournalKafkaHandler.handle(kafkaConsumerRecord);
 
     Mockito.verify(journalService).saveBatch(journalRecordCaptor.capture(), Mockito.anyString());
@@ -205,7 +205,7 @@ public class DataImportJournalConsumerVerticleMockTest extends AbstractRestTest 
 
     Mockito.doNothing().when(journalService).saveBatch(ArgumentMatchers.any(JsonArray.class), ArgumentMatchers.any(String.class));
 
-    KafkaConsumerRecord<String, String> kafkaConsumerRecord = buildKafkaConsumerRecord(dataImportEventPayload);
+    KafkaConsumerRecord<String, byte[]> kafkaConsumerRecord = buildKafkaConsumerRecord(dataImportEventPayload);
     dataImportJournalKafkaHandler.handle(kafkaConsumerRecord);
 
     Mockito.verify(journalService).saveBatch(journalRecordCaptor.capture(), Mockito.anyString());
@@ -242,7 +242,7 @@ public class DataImportJournalConsumerVerticleMockTest extends AbstractRestTest 
 
     Mockito.doNothing().when(journalService).saveBatch(ArgumentMatchers.any(JsonArray.class), ArgumentMatchers.any(String.class));
 
-    KafkaConsumerRecord<String, String> kafkaConsumerRecord = buildKafkaConsumerRecord(dataImportEventPayload);
+    KafkaConsumerRecord<String, byte[]> kafkaConsumerRecord = buildKafkaConsumerRecord(dataImportEventPayload);
     dataImportJournalKafkaHandler.handle(kafkaConsumerRecord);
 
     Mockito.verify(journalService).saveBatch(journalRecordCaptor.capture(), Mockito.anyString());
@@ -274,7 +274,7 @@ public class DataImportJournalConsumerVerticleMockTest extends AbstractRestTest 
     Mockito.doNothing().when(journalService).saveBatch(ArgumentMatchers.any(JsonArray.class), ArgumentMatchers.any(String.class));
 
     // when
-    KafkaConsumerRecord<String, String> kafkaConsumerRecord = buildKafkaConsumerRecord(dataImportEventPayload);
+    KafkaConsumerRecord<String, byte[]> kafkaConsumerRecord = buildKafkaConsumerRecord(dataImportEventPayload);
     dataImportJournalKafkaHandler.handle(kafkaConsumerRecord);
 
     // then
@@ -303,7 +303,7 @@ public class DataImportJournalConsumerVerticleMockTest extends AbstractRestTest 
     Mockito.doNothing().when(journalService).saveBatch(ArgumentMatchers.any(JsonArray.class), ArgumentMatchers.any(String.class));
 
     // when
-    KafkaConsumerRecord<String, String> kafkaConsumerRecord = buildKafkaConsumerRecord(dataImportEventPayload);
+    KafkaConsumerRecord<String, byte[]> kafkaConsumerRecord = buildKafkaConsumerRecord(dataImportEventPayload);
     dataImportJournalKafkaHandler.handle(kafkaConsumerRecord);
 
     // then
@@ -331,7 +331,7 @@ public class DataImportJournalConsumerVerticleMockTest extends AbstractRestTest 
       .withTenant(TENANT_ID);
 
     // when
-    KafkaConsumerRecord<String, String> kafkaConsumerRecord = buildKafkaConsumerRecord(dataImportEventPayload);
+    KafkaConsumerRecord<String, byte[]> kafkaConsumerRecord = buildKafkaConsumerRecord(dataImportEventPayload);
     Future<String> future = dataImportJournalKafkaHandler.handle(kafkaConsumerRecord);
 
     // then
@@ -353,7 +353,7 @@ public class DataImportJournalConsumerVerticleMockTest extends AbstractRestTest 
       .withTenant(TENANT_ID);
 
     // when
-    KafkaConsumerRecord<String, String> kafkaConsumerRecord = buildKafkaConsumerRecord(dataImportEventPayload);
+    KafkaConsumerRecord<String, byte[]> kafkaConsumerRecord = buildKafkaConsumerRecord(dataImportEventPayload);
     Future<String> future = dataImportJournalKafkaHandler.handle(kafkaConsumerRecord);
 
     // then
@@ -362,10 +362,10 @@ public class DataImportJournalConsumerVerticleMockTest extends AbstractRestTest 
     assertTrue(future.cause() instanceof PgException);
   }
 
-  private KafkaConsumerRecord<String, String> buildKafkaConsumerRecord(DataImportEventPayload record) {
+  private KafkaConsumerRecord<String, byte[]> buildKafkaConsumerRecord(DataImportEventPayload record) {
     String topic = KafkaTopicNameHelper.formatTopicName(ENV_KEY, getDefaultNameSpace(), TENANT_ID, record.getEventType());
     Event event = new Event().withId(UUID.randomUUID().toString()).withEventPayload(Json.encode(record));
-    ConsumerRecord<String, String> consumerRecord = buildConsumerRecord(topic, event);
+    ConsumerRecord<String, byte[]> consumerRecord = buildConsumerRecord(topic, event);
     return new KafkaConsumerRecordImpl<>(consumerRecord);
   }
 }

--- a/mod-source-record-manager-server/src/test/java/org/folio/verticle/consumers/DataImportJournalConsumerVerticleTest.java
+++ b/mod-source-record-manager-server/src/test/java/org/folio/verticle/consumers/DataImportJournalConsumerVerticleTest.java
@@ -9,7 +9,6 @@ import io.vertx.ext.unit.junit.VertxUnitRunner;
 import io.vertx.kafka.client.consumer.KafkaConsumerRecord;
 import io.vertx.kafka.client.consumer.impl.KafkaConsumerRecordImpl;
 import org.apache.kafka.clients.consumer.ConsumerRecord;
-import org.apache.kafka.common.header.internals.RecordHeader;
 import org.folio.ActionProfile;
 import org.folio.DataImportEventPayload;
 import org.folio.dao.JobExecutionDaoImpl;
@@ -114,7 +113,7 @@ public class DataImportJournalConsumerVerticleTest extends AbstractRestTest {
       .withToken("token");
 
     // when
-    KafkaConsumerRecord<String, String> kafkaConsumerRecord = buildKafkaConsumerRecord(dataImportEventPayload);
+    KafkaConsumerRecord<String, byte[]> kafkaConsumerRecord = buildKafkaConsumerRecord(dataImportEventPayload);
     dataImportJournalKafkaHandler.handle(kafkaConsumerRecord);
 
     // then
@@ -142,7 +141,7 @@ public class DataImportJournalConsumerVerticleTest extends AbstractRestTest {
       .withToken(TOKEN);
 
     // when
-    KafkaConsumerRecord<String, String> kafkaConsumerRecord = buildKafkaConsumerRecord(dataImportEventPayload);
+    KafkaConsumerRecord<String, byte[]> kafkaConsumerRecord = buildKafkaConsumerRecord(dataImportEventPayload);
     dataImportJournalKafkaHandler.handle(kafkaConsumerRecord);
 
     // then
@@ -170,7 +169,7 @@ public class DataImportJournalConsumerVerticleTest extends AbstractRestTest {
       .withToken(TOKEN);
 
     // when
-    KafkaConsumerRecord<String, String> kafkaConsumerRecord = buildKafkaConsumerRecord(dataImportEventPayload);
+    KafkaConsumerRecord<String, byte[]> kafkaConsumerRecord = buildKafkaConsumerRecord(dataImportEventPayload);
     dataImportJournalKafkaHandler.handle(kafkaConsumerRecord);
 
     // then
@@ -207,7 +206,7 @@ public class DataImportJournalConsumerVerticleTest extends AbstractRestTest {
       .withEventsChain(List.of(DI_INVENTORY_HOLDING_CREATED.value(), DI_INVENTORY_ITEM_CREATED.value()));
 
     // when
-    KafkaConsumerRecord<String, String> kafkaConsumerRecord = buildKafkaConsumerRecord(completedEventPayload);
+    KafkaConsumerRecord<String, byte[]> kafkaConsumerRecord = buildKafkaConsumerRecord(completedEventPayload);
     dataImportJournalKafkaHandler.handle(kafkaConsumerRecord);
 
     // then
@@ -247,7 +246,7 @@ public class DataImportJournalConsumerVerticleTest extends AbstractRestTest {
       .withEventsChain(List.of(DI_SRS_MARC_BIB_RECORD_CREATED.value(), DI_INVENTORY_HOLDING_CREATED.value()));
 
     // when
-    KafkaConsumerRecord<String, String> kafkaConsumerRecord = buildKafkaConsumerRecord(eventPayload);
+    KafkaConsumerRecord<String, byte[]> kafkaConsumerRecord = buildKafkaConsumerRecord(eventPayload);
     dataImportJournalKafkaHandler.handle(kafkaConsumerRecord);
 
     // then
@@ -266,7 +265,7 @@ public class DataImportJournalConsumerVerticleTest extends AbstractRestTest {
     // given
     String topic = KafkaTopicNameHelper.formatTopicName("folio", getDefaultNameSpace(), TENANT_ID, DI_SRS_MARC_HOLDING_RECORD_CREATED.value());
     Event event = new Event().withEventPayload(null).withEventType(DI_LOG_SRS_MARC_BIB_RECORD_CREATED.value()).withId(UUID.randomUUID().toString());
-    ConsumerRecord<String, String> consumerRecord = buildConsumerRecord(topic, event);
+    ConsumerRecord<String, byte[]> consumerRecord = buildConsumerRecord(topic, event);
 
     // when
     Future<String> future = dataImportJournalKafkaHandler.handle(new KafkaConsumerRecordImpl<>(consumerRecord));
@@ -278,10 +277,10 @@ public class DataImportJournalConsumerVerticleTest extends AbstractRestTest {
       });
   }
 
-  private KafkaConsumerRecord<String, String> buildKafkaConsumerRecord(DataImportEventPayload record) {
+  private KafkaConsumerRecord<String, byte[]> buildKafkaConsumerRecord(DataImportEventPayload record) {
     String topic = KafkaTopicNameHelper.formatTopicName("folio", getDefaultNameSpace(), TENANT_ID, record.getEventType());
     Event event = new Event().withEventPayload(Json.encode(record));
-    ConsumerRecord<String, String> consumerRecord = buildConsumerRecord(topic, event);
+    ConsumerRecord<String, byte[]> consumerRecord = buildConsumerRecord(topic, event);
     return new KafkaConsumerRecordImpl<>(consumerRecord);
   }
 }

--- a/mod-source-record-manager-server/src/test/java/org/folio/verticle/consumers/ImportInvoiceJournalConsumerVerticleMockTest.java
+++ b/mod-source-record-manager-server/src/test/java/org/folio/verticle/consumers/ImportInvoiceJournalConsumerVerticleMockTest.java
@@ -161,7 +161,7 @@ public class ImportInvoiceJournalConsumerVerticleMockTest extends AbstractRestTe
 
     Mockito.doNothing().when(journalService).saveBatch(ArgumentMatchers.any(JsonArray.class), ArgumentMatchers.any(String.class));
 
-    KafkaConsumerRecord<String, String> kafkaConsumerRecord = buildKafkaConsumerRecord(dataImportEventPayload);
+    KafkaConsumerRecord<String, byte[]> kafkaConsumerRecord = buildKafkaConsumerRecord(dataImportEventPayload);
     dataImportJournalKafkaHandler.handle(kafkaConsumerRecord);
 
     Mockito.verify(journalService).saveBatch(invoiceRecordCaptor.capture(), Mockito.anyString());
@@ -217,7 +217,7 @@ public class ImportInvoiceJournalConsumerVerticleMockTest extends AbstractRestTe
 
     Mockito.doNothing().when(journalService).saveBatch(ArgumentMatchers.any(JsonArray.class), ArgumentMatchers.any(String.class));
 
-    KafkaConsumerRecord<String, String> kafkaConsumerRecord = buildKafkaConsumerRecord(dataImportEventPayload);
+    KafkaConsumerRecord<String, byte[]> kafkaConsumerRecord = buildKafkaConsumerRecord(dataImportEventPayload);
     dataImportJournalKafkaHandler.handle(kafkaConsumerRecord);
 
     Mockito.verify(journalService).saveBatch(invoiceRecordCaptor.capture(), Mockito.anyString());
@@ -261,7 +261,7 @@ public class ImportInvoiceJournalConsumerVerticleMockTest extends AbstractRestTe
 
     Mockito.doNothing().when(journalService).saveBatch(ArgumentMatchers.any(JsonArray.class), ArgumentMatchers.any(String.class));
 
-    KafkaConsumerRecord<String, String> kafkaConsumerRecord = buildKafkaConsumerRecord(dataImportEventPayload);
+    KafkaConsumerRecord<String, byte[]> kafkaConsumerRecord = buildKafkaConsumerRecord(dataImportEventPayload);
     dataImportJournalKafkaHandler.handle(kafkaConsumerRecord);
 
     Mockito.verify(journalService).saveBatch(invoiceRecordCaptor.capture(), Mockito.anyString());
@@ -301,7 +301,7 @@ public class ImportInvoiceJournalConsumerVerticleMockTest extends AbstractRestTe
 
     Mockito.doNothing().when(journalService).saveBatch(ArgumentMatchers.any(JsonArray.class), ArgumentMatchers.any(String.class));
 
-    KafkaConsumerRecord<String, String> kafkaConsumerRecord = buildKafkaConsumerRecord(dataImportEventPayload);
+    KafkaConsumerRecord<String, byte[]> kafkaConsumerRecord = buildKafkaConsumerRecord(dataImportEventPayload);
     dataImportJournalKafkaHandler.handle(kafkaConsumerRecord);
 
     Mockito.verify(journalService).saveBatch(invoiceRecordCaptor.capture(), Mockito.anyString());
@@ -337,7 +337,7 @@ public class ImportInvoiceJournalConsumerVerticleMockTest extends AbstractRestTe
 
     Mockito.doNothing().when(journalService).saveBatch(ArgumentMatchers.any(JsonArray.class), ArgumentMatchers.any(String.class));
 
-    KafkaConsumerRecord<String, String> kafkaConsumerRecord = buildKafkaConsumerRecord(dataImportEventPayload);
+    KafkaConsumerRecord<String, byte[]> kafkaConsumerRecord = buildKafkaConsumerRecord(dataImportEventPayload);
     dataImportJournalKafkaHandler.handle(kafkaConsumerRecord);
 
     Mockito.verify(journalService).saveBatch(invoiceRecordCaptor.capture(), Mockito.anyString());
@@ -348,10 +348,10 @@ public class ImportInvoiceJournalConsumerVerticleMockTest extends AbstractRestTe
     async.complete();
   }
 
-  private KafkaConsumerRecord<String, String> buildKafkaConsumerRecord(DataImportEventPayload record) throws IOException {
+  private KafkaConsumerRecord<String, byte[]> buildKafkaConsumerRecord(DataImportEventPayload record) throws IOException {
     String topic = KafkaTopicNameHelper.formatTopicName(ENV_KEY, getDefaultNameSpace(), TENANT_ID, record.getEventType());
     Event event = new Event().withId(EVENT_ID).withEventPayload(Json.encode(record));
-    ConsumerRecord<String, String> consumerRecord = buildConsumerRecord(topic, event);
+    ConsumerRecord<String, byte[]> consumerRecord = buildConsumerRecord(topic, event);
     return new KafkaConsumerRecordImpl<>(consumerRecord);
   }
 }

--- a/mod-source-record-manager-server/src/test/java/org/folio/verticle/consumers/ImportInvoiceJournalConsumerVerticleTest.java
+++ b/mod-source-record-manager-server/src/test/java/org/folio/verticle/consumers/ImportInvoiceJournalConsumerVerticleTest.java
@@ -157,7 +157,7 @@ public class ImportInvoiceJournalConsumerVerticleTest extends AbstractRestTest {
       .withEventsChain(List.of(DI_INVOICE_CREATED.value()));
 
     // when
-    KafkaConsumerRecord<String, String> kafkaConsumerRecord = buildKafkaConsumerRecord(dataImportEventPayload);
+    KafkaConsumerRecord<String, byte[]> kafkaConsumerRecord = buildKafkaConsumerRecord(dataImportEventPayload);
     dataImportJournalKafkaHandler.handle(kafkaConsumerRecord);
 
     // then
@@ -171,10 +171,10 @@ public class ImportInvoiceJournalConsumerVerticleTest extends AbstractRestTest {
     async.complete();
   }
 
-  private KafkaConsumerRecord<String, String> buildKafkaConsumerRecord(DataImportEventPayload record) throws IOException {
+  private KafkaConsumerRecord<String, byte[]> buildKafkaConsumerRecord(DataImportEventPayload record) throws IOException {
     String topic = KafkaTopicNameHelper.formatTopicName("folio", getDefaultNameSpace(), TENANT_ID, record.getEventType());
     Event event = new Event().withEventPayload(Json.encode(record));
-    ConsumerRecord<String, String> consumerRecord = buildConsumerRecord(topic, event);
+    ConsumerRecord<String, byte[]> consumerRecord = buildConsumerRecord(topic, event);
     return new KafkaConsumerRecordImpl<>(consumerRecord);
   }
 }

--- a/mod-source-record-manager-server/src/test/java/org/folio/verticle/consumers/StoredRecordChunksKafkaHandlerTest.java
+++ b/mod-source-record-manager-server/src/test/java/org/folio/verticle/consumers/StoredRecordChunksKafkaHandlerTest.java
@@ -32,6 +32,7 @@ import org.mockito.Captor;
 import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
@@ -64,7 +65,7 @@ public class StoredRecordChunksKafkaHandlerTest {
   @Mock
   private RecordsPublishingService recordsPublishingService;
   @Mock
-  private KafkaConsumerRecord<String, String> kafkaRecord;
+  private KafkaConsumerRecord<String, byte[]> kafkaRecord;
   @Mock
   private JournalService journalService;
   @Mock
@@ -77,7 +78,7 @@ public class StoredRecordChunksKafkaHandlerTest {
   private ArgumentCaptor<JsonArray> journalRecordsCaptor;
 
   private Vertx vertx = Vertx.vertx();
-  private AsyncRecordHandler<String, String> storedRecordChunksKafkaHandler;
+  private AsyncRecordHandler<String, byte[]> storedRecordChunksKafkaHandler;
 
   @BeforeClass
   public static void setUpClass() throws IOException {
@@ -102,7 +103,7 @@ public class StoredRecordChunksKafkaHandlerTest {
       .withId(UUID.randomUUID().toString())
       .withEventPayload(Json.encode(recordsBatch));
 
-    when(kafkaRecord.value()).thenReturn(Json.encode(event));
+    when(kafkaRecord.value()).thenReturn(Json.encode(event).getBytes(StandardCharsets.UTF_8));
     when(kafkaRecord.headers()).thenReturn(List.of(KafkaHeader.header(OKAPI_HEADER_TENANT.toLowerCase(), TENANT_ID)));
     when(eventProcessedService.collectData(STORED_RECORD_CHUNKS_KAFKA_HANDLER_UUID, event.getId(), TENANT_ID))
       .thenReturn(Future.failedFuture(new DuplicateEventException("Constraint Violation Occurs")));
@@ -147,7 +148,7 @@ public class StoredRecordChunksKafkaHandlerTest {
       .withId(UUID.randomUUID().toString())
       .withEventPayload(Json.encode(savedRecordsBatch));
 
-    when(kafkaRecord.value()).thenReturn(Json.encode(event));
+    when(kafkaRecord.value()).thenReturn(Json.encode(event).getBytes(StandardCharsets.UTF_8));
     when(kafkaRecord.headers()).thenReturn(List.of(KafkaHeader.header(OKAPI_HEADER_TENANT.toLowerCase(), TENANT_ID), KafkaHeader.header("jobExecutionId", UUID.randomUUID().toString())));
     when(eventProcessedService.collectData(STORED_RECORD_CHUNKS_KAFKA_HANDLER_UUID, event.getId(), TENANT_ID)).thenReturn(Future.succeededFuture());
 
@@ -170,7 +171,7 @@ public class StoredRecordChunksKafkaHandlerTest {
       .withId(UUID.randomUUID().toString())
       .withEventPayload(Json.encode(savedRecordsBatch));
 
-    when(kafkaRecord.value()).thenReturn(Json.encode(event));
+    when(kafkaRecord.value()).thenReturn(Json.encode(event).getBytes(StandardCharsets.UTF_8));
     when(kafkaRecord.headers()).thenReturn(List.of(KafkaHeader.header(OKAPI_HEADER_TENANT.toLowerCase(), TENANT_ID), KafkaHeader.header("jobExecutionId", UUID.randomUUID().toString())));
     when(eventProcessedService.collectData(STORED_RECORD_CHUNKS_KAFKA_HANDLER_UUID, event.getId(), TENANT_ID)).thenReturn(Future.succeededFuture());
     when(mappingRuleCache.get(new MappingRuleCacheKey(TENANT_ID, EntityType.EDIFACT))).thenReturn(Future.failedFuture(new Exception()));
@@ -217,7 +218,7 @@ public class StoredRecordChunksKafkaHandlerTest {
       .withId(UUID.randomUUID().toString())
       .withEventPayload(Json.encode(savedRecordsBatch));
 
-    when(kafkaRecord.value()).thenReturn(Json.encode(event));
+    when(kafkaRecord.value()).thenReturn(Json.encode(event).getBytes(StandardCharsets.UTF_8));
     when(kafkaRecord.headers()).thenReturn(List.of(KafkaHeader.header(OKAPI_HEADER_TENANT.toLowerCase(), TENANT_ID), KafkaHeader.header("jobExecutionId", UUID.randomUUID().toString())));
     when(eventProcessedService.collectData(STORED_RECORD_CHUNKS_KAFKA_HANDLER_UUID, event.getId(), TENANT_ID)).thenReturn(Future.succeededFuture());
     when(mappingRuleCache.get(new MappingRuleCacheKey(TENANT_ID, entityType))).thenReturn(Future.succeededFuture(Optional.of(mappingRules)));


### PR DESCRIPTION
## Purpose
Reduce memory allocations of strings to reduce memory requirements of SRS and improve performance & reliability at the limit

## Approach
Here are the several approaches involved:
- Changed the the cache in AdditionalFieldsUtil to enable stats only when metrics is enabled
- Utilized existing ObjectMappers instead of creating new ObjectMapper for each new JSON operation.
- In MappingMetadataService, instead of caching POJOs and then serializing them upon every HTTP request to get mapping metadata, the serialized POJO (as a string) is cached instead. This saves creating new String representations with each HTTP request, the strings can be large.
- In some handlers like one for journals, `currentNode` in `DataImportEventPayload` is ignored since it is not used and is expensive to create.
- Kafka consumers convert from byte[] to POJO. This included allowing KafkaConsumerWrappers to be able to configure value deserializer class.
- During journal processing, `DataImportEventPayload` is serialized into a String in a `Event` object. When `Event` is deserialized, it creates a large string for `DataImportEventPayload`. This large string is then deserialized into a `DataImportEventPayload` object. For example, if the paylaod was 1MB, the following object will be around 1MB
  - The byte array from Kafka consumer record
  - The `Event` POJO containing the payload string
  - The `DataImportEventPayload` POJO


  Deserialization has been changed such that intermediate String in the `Event` POJO is not created. This can be quite large.

