### PR TITLE
MODSOURMAN-1115 Accomodate for authority-source-files api changes

### DIFF
--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -637,7 +637,7 @@
     },
     {
       "id": "authority-source-files",
-      "version": "2.0"
+      "version": "2.1"
     }
   ],
   "permissionSets": [


### PR DESCRIPTION
## Purpose
Accomodate for authority-source-files api changes

## Approach
Update authority-source-files interface version, use updated dto from data-import-processing core

## Is this change testable? If not - why?


## Checklist
- [ ] I have updated NEWS.md.
- [ ] I have added javadocs to new methods.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation e.g. README.md.
- [ ] I have ran karate tests against this feature.

