### PR TITLE
MODSOURMAN-1063: remove entity type set for journal records 

### DIFF
--- a/mod-source-record-manager-server/src/main/java/org/folio/services/journal/JournalUtil.java
+++ b/mod-source-record-manager-server/src/main/java/org/folio/services/journal/JournalUtil.java
@@ -13,7 +13,6 @@ import org.folio.rest.jaxrs.model.IncomingRecord;
 import org.folio.rest.jaxrs.model.JournalRecord;
 import org.folio.rest.jaxrs.model.Record;
 
-import java.util.Arrays;
 import java.util.ArrayList;
 import java.util.Date;
 import java.util.HashMap;
@@ -78,11 +77,6 @@ public class JournalUtil {
         .withActionType(JournalRecord.ActionType.PARSE)
         .withActionDate(new Date())
         .withActionStatus(record.getErrorRecord() == null ? JournalRecord.ActionStatus.COMPLETED : JournalRecord.ActionStatus.ERROR);
-      if (record.getRecordType() != null) {
-        Arrays.stream(JournalRecord.EntityType.values())
-          .filter(v -> v.value().startsWith(record.getRecordType().value()))
-          .findFirst().ifPresent(journalRecord::setEntityType);
-      }
       if (record.getErrorRecord() != null) {
         journalRecord.setError(record.getErrorRecord().getDescription());
       }

--- a/mod-source-record-manager-server/src/test/java/org/folio/services/JournalUtilTest.java
+++ b/mod-source-record-manager-server/src/test/java/org/folio/services/JournalUtilTest.java
@@ -66,7 +66,7 @@ public class JournalUtilTest {
     assertThat(journalRecords.get(0).getActionType()).isEqualTo(JournalRecord.ActionType.PARSE);
     assertThat(journalRecords.get(0).getActionDate()).isNotNull();
     assertThat(journalRecords.get(0).getActionStatus()).isEqualTo(JournalRecord.ActionStatus.COMPLETED);
-    assertThat(journalRecords.get(0).getEntityType()).isEqualTo(MARC_BIBLIOGRAPHIC);
+    assertThat(journalRecords.get(0).getEntityType()).isNull();
     assertThat(journalRecords.get(0).getError()).isNull();
   }
 
@@ -93,7 +93,7 @@ public class JournalUtilTest {
     assertThat(journalRecords.get(0).getActionType()).isEqualTo(JournalRecord.ActionType.PARSE);
     assertThat(journalRecords.get(0).getActionDate()).isNotNull();
     assertThat(journalRecords.get(0).getActionStatus()).isEqualTo(ERROR);
-    assertThat(journalRecords.get(0).getEntityType()).isEqualTo(MARC_BIBLIOGRAPHIC);
+    assertThat(journalRecords.get(0).getEntityType()).isNull();
     assertThat(journalRecords.get(0).getError()).isEqualTo(errorRecord.getDescription());
   }
 


### PR DESCRIPTION
## Purpose
Remove entity type set for journal records to not fetch them with `get_job_log_entries`

