### PR TITLE
MODSOURMAN-1123 Create Kafka topics instead of relying on auto create in mod-srm

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,4 +1,5 @@
 ## 2023-xx-xx v3.8.0-SNAPSHOT
+* [MODSOURMAN-1123](https://issues.folio.org/browse/MODSOURMAN-1123) Create Kafka topics instead of relying on auto create in mod-srm
 * [MODSOURMAN-1113](https://issues.folio.org/browse/MODSOURMAN-1113) Reduce Memory Allocations Of Strings
 * [MODSOURMAN-1085](https://issues.folio.org/browse/MODSOURMAN-1085) MARC record with a 100 tag without a $a is being discarded on import.
 * [MODSOURMAN-1020](https://issues.folio.org/browse/MODSOURMAN-1020) Add table to save incoming records for DI logs

--- a/README.md
+++ b/README.md
@@ -116,12 +116,12 @@ After setup, it is good to check logs in all related modules for errors. Data im
   * "_srm.kafkacache.cleanup.interval.ms_": 3600000
   * "_srm.kafkacache.expiration.time.hours_": 3
 
-There are another important properties - `number of partitions` for topics `DI_COMPLETE`, `DI_ERROR`, `DI_MARC_BIB_FOR_ORDER_CREATED`, 
+There are another important properties - `number of partitions` for topics `DI_COMPLETE`, `DI_ERROR`, `DI_INCOMING_MARC_BIB_FOR_ORDER_PARSED`, 
 `DI_SRS_MARC_AUTHORITY_RECORD_CREATED`, `DI_SRS_MARC_HOLDINGS_RECORD_CREATED`, `DI_MARC_FOR_UPDATE_RECEIVED`, 
 `DI_MARC_FOR_DELETE_RECEIVED`
 and `DI_RAW_RECORDS_CHUNK_PARSED`
 which are created during tenant initialization, the values of which can be customized with
-`DI_COMPLETE_PARTITIONS`, `DI_ERROR_PARTITIONS`, `DI_MARC_BIB_FOR_ORDER_CREATED_PARTITIONS`, 
+`DI_COMPLETE_PARTITIONS`, `DI_ERROR_PARTITIONS`, `DI_INCOMING_MARC_BIB_FOR_ORDER_PARSED_PARTITIONS`, 
 `DI_SRS_MARC_AUTHORITY_RECORD_CREATED_PARTITIONS`, `DI_SRS_MARC_HOLDINGS_RECORD_CREATED_PARTITIONS`,
 `DI_MARC_FOR_UPDATE_RECEIVED_PARTITIONS`, `DI_MARC_FOR_DELETE_RECEIVED_PARTITIONS`
 and `DI_RAW_RECORDS_CHUNK_PARSED_PARTITIONS` env variables respectively.

--- a/README.md
+++ b/README.md
@@ -116,10 +116,14 @@ After setup, it is good to check logs in all related modules for errors. Data im
   * "_srm.kafkacache.cleanup.interval.ms_": 3600000
   * "_srm.kafkacache.expiration.time.hours_": 3
 
-There are another important properties - `number of partitions` for topics `DI_COMPLETE`, `DI_ERROR`, `DI_PARSED_RECORDS_CHUNK_SAVED`
+There are another important properties - `number of partitions` for topics `DI_COMPLETE`, `DI_ERROR`, `DI_SRS_MARC_BIB_RECORD_CREATED`, 
+`DI_SRS_MARC_AUTHORITY_RECORD_CREATED`, `DI_SRS_MARC_HOLDINGS_RECORD_CREATED`, `DI_MARC_FOR_UPDATE_RECEIVED`, 
+`DI_MARC_FOR_DELETE_RECEIVED`, `DI_EDIFACT_RECORD_CREATED`
 and `DI_RAW_RECORDS_CHUNK_PARSED`
 which are created during tenant initialization, the values of which can be customized with
-`DI_COMPLETE_PARTITIONS`, `DI_ERROR_PARTITIONS`, `DI_PARSED_RECORDS_CHUNK_SAVED_PARTITIONS`
+`DI_COMPLETE_PARTITIONS`, `DI_ERROR_PARTITIONS`, `DI_SRS_MARC_BIB_RECORD_CREATED_PARTITIONS`, 
+`DI_SRS_MARC_AUTHORITY_RECORD_CREATED_PARTITIONS`, `DI_SRS_MARC_HOLDINGS_RECORD_CREATED_PARTITIONS`,
+`DI_MARC_FOR_UPDATE_RECEIVED_PARTITIONS`, `DI_MARC_FOR_DELETE_RECEIVED_PARTITIONS`, `DI_EDIFACT_RECORD_CREATED_PARTITIONS`
 and `DI_RAW_RECORDS_CHUNK_PARSED_PARTITIONS` env variables respectively.
 Default value - `1`.
 

--- a/README.md
+++ b/README.md
@@ -116,6 +116,13 @@ After setup, it is good to check logs in all related modules for errors. Data im
   * "_srm.kafkacache.cleanup.interval.ms_": 3600000
   * "_srm.kafkacache.expiration.time.hours_": 3
 
+There are another important properties - `number of partitions` for topics `DI_COMPLETE`, `DI_ERROR`, `DI_PARSED_RECORDS_CHUNK_SAVED`
+and `DI_RAW_RECORDS_CHUNK_PARSED`
+which are created during tenant initialization, the values of which can be customized with
+`DI_COMPLETE_PARTITIONS`, `DI_ERROR_PARTITIONS`, `DI_PARSED_RECORDS_CHUNK_SAVED_PARTITIONS`
+and `DI_RAW_RECORDS_CHUNK_PARSED_PARTITIONS` env variables respectively.
+Default value - `1`.
+
 #### Note:
 From v 3.1.3 there is a new property which defines limit for retrieving data to fill mapping parameters for the data-import mechanism: **"srm.mapping.parameters.settings.limit:1000"**
 

--- a/README.md
+++ b/README.md
@@ -116,14 +116,14 @@ After setup, it is good to check logs in all related modules for errors. Data im
   * "_srm.kafkacache.cleanup.interval.ms_": 3600000
   * "_srm.kafkacache.expiration.time.hours_": 3
 
-There are another important properties - `number of partitions` for topics `DI_COMPLETE`, `DI_ERROR`, `DI_SRS_MARC_BIB_RECORD_CREATED`, 
+There are another important properties - `number of partitions` for topics `DI_COMPLETE`, `DI_ERROR`, `DI_MARC_BIB_FOR_ORDER_CREATED`, 
 `DI_SRS_MARC_AUTHORITY_RECORD_CREATED`, `DI_SRS_MARC_HOLDINGS_RECORD_CREATED`, `DI_MARC_FOR_UPDATE_RECEIVED`, 
-`DI_MARC_FOR_DELETE_RECEIVED`, `DI_EDIFACT_RECORD_CREATED`
+`DI_MARC_FOR_DELETE_RECEIVED`
 and `DI_RAW_RECORDS_CHUNK_PARSED`
 which are created during tenant initialization, the values of which can be customized with
-`DI_COMPLETE_PARTITIONS`, `DI_ERROR_PARTITIONS`, `DI_SRS_MARC_BIB_RECORD_CREATED_PARTITIONS`, 
+`DI_COMPLETE_PARTITIONS`, `DI_ERROR_PARTITIONS`, `DI_MARC_BIB_FOR_ORDER_CREATED_PARTITIONS`, 
 `DI_SRS_MARC_AUTHORITY_RECORD_CREATED_PARTITIONS`, `DI_SRS_MARC_HOLDINGS_RECORD_CREATED_PARTITIONS`,
-`DI_MARC_FOR_UPDATE_RECEIVED_PARTITIONS`, `DI_MARC_FOR_DELETE_RECEIVED_PARTITIONS`, `DI_EDIFACT_RECORD_CREATED_PARTITIONS`
+`DI_MARC_FOR_UPDATE_RECEIVED_PARTITIONS`, `DI_MARC_FOR_DELETE_RECEIVED_PARTITIONS`
 and `DI_RAW_RECORDS_CHUNK_PARSED_PARTITIONS` env variables respectively.
 Default value - `1`.
 

--- a/mod-source-record-manager-server/pom.xml
+++ b/mod-source-record-manager-server/pom.xml
@@ -19,6 +19,7 @@
     <testcontainers.version>1.16.0</testcontainers.version>
     <kafkaclients.version>3.6.0</kafkaclients.version>
     <kafkajunit.version>3.5.1</kafkajunit.version>
+    <commons-lang3.version>3.12.0</commons-lang3.version>
   </properties>
 
   <dependencies>
@@ -249,6 +250,11 @@
       <groupId>commons-lang</groupId>
       <artifactId>commons-lang</artifactId>
       <version>2.6</version>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.commons</groupId>
+      <artifactId>commons-lang3</artifactId>
+      <version>${commons-lang3.version}</version>
     </dependency>
   </dependencies>
   <build>

--- a/mod-source-record-manager-server/src/main/java/org/folio/services/kafka/SRMKafkaTopicService.java
+++ b/mod-source-record-manager-server/src/main/java/org/folio/services/kafka/SRMKafkaTopicService.java
@@ -35,22 +35,18 @@ public class SRMKafkaTopicService {
   private Integer diMarcOrderParsedNumPartitions;
 
   public KafkaTopic[] createTopicObjects() {
-    var diCompleteTopic = new SRMKafkaTopic("DI_COMPLETE", diCompleteNumPartitions);
-    var diError = new SRMKafkaTopic("DI_ERROR", diErrorNumPartitions);
-    var diSrsMarcAuthorityCreated = new SRMKafkaTopic("DI_SRS_MARC_AUTHORITY_RECORD_CREATED", diSrsMarcAuthorityRecordCreatedNumPartitions);
-    var diSrsMarcHoldingsCreated = new SRMKafkaTopic("DI_SRS_MARC_HOLDINGS_RECORD_CREATED",
-      diSrsMarcHoldingsRecordCreatedNumPartitions);
-    var diRawRecordsChunkParsed = new SRMKafkaTopic("DI_RAW_RECORDS_CHUNK_PARSED", diRawRecordsChunkParsedNumPartitions);
-    var diMarcForUpdateReceived = new SRMKafkaTopic("DI_MARC_FOR_UPDATE_RECEIVED",
-      diMarcForUpdateReceivedNumPartitions);
-    var diMarcForDeleteReceived = new SRMKafkaTopic("DI_MARC_FOR_DELETE_RECEIVED",
-      diMarcForDeleteReceivedNumPartitions);
-
-    var diIncomingMarcBibForOrderParsed = new SRMKafkaTopic("DI_INCOMING_MARC_BIB_FOR_ORDER_PARSED",
-      diMarcOrderParsedNumPartitions);
-
-    return new SRMKafkaTopic[] {diCompleteTopic, diError, diSrsMarcAuthorityCreated,
-                                diSrsMarcHoldingsCreated, diRawRecordsChunkParsed,
-                                diMarcForUpdateReceived, diMarcForDeleteReceived, diIncomingMarcBibForOrderParsed};
+    return new SRMKafkaTopic[] {
+      new SRMKafkaTopic("DI_COMPLETE", diCompleteNumPartitions),
+      new SRMKafkaTopic("DI_ERROR", diErrorNumPartitions),
+      new SRMKafkaTopic("DI_SRS_MARC_AUTHORITY_RECORD_CREATED", diSrsMarcAuthorityRecordCreatedNumPartitions),
+      new SRMKafkaTopic("DI_SRS_MARC_HOLDINGS_RECORD_CREATED",
+        diSrsMarcHoldingsRecordCreatedNumPartitions),
+      new SRMKafkaTopic("DI_RAW_RECORDS_CHUNK_PARSED", diRawRecordsChunkParsedNumPartitions),
+      new SRMKafkaTopic("DI_MARC_FOR_UPDATE_RECEIVED",
+        diMarcForUpdateReceivedNumPartitions),
+      new SRMKafkaTopic("DI_MARC_FOR_DELETE_RECEIVED",
+      diMarcForDeleteReceivedNumPartitions),
+      new SRMKafkaTopic("DI_INCOMING_MARC_BIB_FOR_ORDER_PARSED",
+      diMarcOrderParsedNumPartitions)};
   }
 }

--- a/mod-source-record-manager-server/src/main/java/org/folio/services/kafka/SRMKafkaTopicService.java
+++ b/mod-source-record-manager-server/src/main/java/org/folio/services/kafka/SRMKafkaTopicService.java
@@ -31,8 +31,8 @@ public class SRMKafkaTopicService {
   @Value("${di_marc_for_delete_received.partitions}")
   private Integer diMarcForDeleteReceivedNumPartitions;
 
-  @Value("${di_marc_for_order_created.partitions}")
-  private Integer diMarcOrderCreatedNumPartitions;
+  @Value("${di_marc_for_order_parsed.partitions}")
+  private Integer diMarcOrderParsedNumPartitions;
 
   public KafkaTopic[] createTopicObjects() {
     var diCompleteTopic = new SRMKafkaTopic("DI_COMPLETE", diCompleteNumPartitions);
@@ -46,10 +46,11 @@ public class SRMKafkaTopicService {
     var diMarcForDeleteReceived = new SRMKafkaTopic("DI_MARC_FOR_DELETE_RECEIVED",
       diMarcForDeleteReceivedNumPartitions);
 
-    var diMarcBibOrderCreated = new SRMKafkaTopic("DI_MARC_BIB_FOR_ORDER_CREATED", diMarcOrderCreatedNumPartitions);
+    var diIncomingMarcBibForOrderParsed = new SRMKafkaTopic("DI_INCOMING_MARC_BIB_FOR_ORDER_PARSED",
+      diMarcOrderParsedNumPartitions);
 
     return new SRMKafkaTopic[] {diCompleteTopic, diError, diSrsMarcAuthorityCreated,
                                 diSrsMarcHoldingsCreated, diRawRecordsChunkParsed,
-                                diMarcForUpdateReceived, diMarcForDeleteReceived, diMarcBibOrderCreated};
+                                diMarcForUpdateReceived, diMarcForDeleteReceived, diIncomingMarcBibForOrderParsed};
   }
 }

--- a/mod-source-record-manager-server/src/main/java/org/folio/services/kafka/SRMKafkaTopicService.java
+++ b/mod-source-record-manager-server/src/main/java/org/folio/services/kafka/SRMKafkaTopicService.java
@@ -16,9 +16,6 @@ public class SRMKafkaTopicService {
   @Value("${di_error.partitions}")
   private Integer diErrorNumPartitions;
 
-  @Value("${di_srs_marc_bib_record_created.partitions}")
-  private Integer diSrsMarcBibRecordCreatedNumPartitions;
-
   @Value("${di_srs_marc_authority_record_created.partitions}")
   private Integer diSrsMarcAuthorityRecordCreatedNumPartitions;
 
@@ -28,30 +25,31 @@ public class SRMKafkaTopicService {
   @Value("${di_raw_records_chunk_parsed.partitions}")
   private Integer diRawRecordsChunkParsedNumPartitions;
 
-  @Value("${di_edifact_record_created.partitions}")
-  private Integer diEdifactRecordCreatedNumPartitions;
-
   @Value("${di_marc_for_update_received.partitions}")
   private Integer diMarcForUpdateReceivedNumPartitions;
 
   @Value("${di_marc_for_delete_received.partitions}")
   private Integer diMarcForDeleteReceivedNumPartitions;
 
+  @Value("${di_marc_for_order_created.partitions}")
+  private Integer diMarcOrderCreatedNumPartitions;
+
   public KafkaTopic[] createTopicObjects() {
     var diCompleteTopic = new SRMKafkaTopic("DI_COMPLETE", diCompleteNumPartitions);
     var diError = new SRMKafkaTopic("DI_ERROR", diErrorNumPartitions);
-    var diSrsMarcBibRecordCreated = new SRMKafkaTopic("DI_SRS_MARC_BIB_RECORD_CREATED", diSrsMarcBibRecordCreatedNumPartitions);
     var diSrsMarcAuthorityCreated = new SRMKafkaTopic("DI_SRS_MARC_AUTHORITY_RECORD_CREATED", diSrsMarcAuthorityRecordCreatedNumPartitions);
     var diSrsMarcHoldingsCreated = new SRMKafkaTopic("DI_SRS_MARC_HOLDINGS_RECORD_CREATED",
       diSrsMarcHoldingsRecordCreatedNumPartitions);
     var diRawRecordsChunkParsed = new SRMKafkaTopic("DI_RAW_RECORDS_CHUNK_PARSED", diRawRecordsChunkParsedNumPartitions);
-    var diEdifactRecordCreated = new SRMKafkaTopic("DI_EDIFACT_RECORD_CREATED", diEdifactRecordCreatedNumPartitions);
     var diMarcForUpdateReceived = new SRMKafkaTopic("DI_MARC_FOR_UPDATE_RECEIVED",
       diMarcForUpdateReceivedNumPartitions);
     var diMarcForDeleteReceived = new SRMKafkaTopic("DI_MARC_FOR_DELETE_RECEIVED",
       diMarcForDeleteReceivedNumPartitions);
-    return new SRMKafkaTopic[] {diCompleteTopic, diError, diSrsMarcBibRecordCreated, diSrsMarcAuthorityCreated,
-                                diSrsMarcHoldingsCreated, diRawRecordsChunkParsed, diEdifactRecordCreated,
-                                diMarcForUpdateReceived, diMarcForDeleteReceived};
+
+    var diMarcBibOrderCreated = new SRMKafkaTopic("DI_MARC_BIB_FOR_ORDER_CREATED", diMarcOrderCreatedNumPartitions);
+
+    return new SRMKafkaTopic[] {diCompleteTopic, diError, diSrsMarcAuthorityCreated,
+                                diSrsMarcHoldingsCreated, diRawRecordsChunkParsed,
+                                diMarcForUpdateReceived, diMarcForDeleteReceived, diMarcBibOrderCreated};
   }
 }

--- a/mod-source-record-manager-server/src/main/java/org/folio/services/kafka/SRMKafkaTopicService.java
+++ b/mod-source-record-manager-server/src/main/java/org/folio/services/kafka/SRMKafkaTopicService.java
@@ -1,0 +1,33 @@
+package org.folio.services.kafka;
+
+import org.folio.kafka.services.KafkaTopic;
+import org.folio.services.kafka.support.SRMKafkaTopic;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.PropertySource;
+import org.springframework.stereotype.Service;
+
+@Service
+@PropertySource(value = "kafka.properties")
+public class SRMKafkaTopicService {
+
+  @Value("${di_complete.partitions}")
+  private Integer diCompleteNumPartitions;
+
+  @Value("${di_error.partitions}")
+  private Integer diErrorNumPartitions;
+
+  @Value("${di_parsed_records_chunk_saved.partitions}")
+  private Integer diParsedRecordsChunkSavedNumPartitions;
+
+  @Value("${di_raw_records_chunk_parsed.partitions}")
+  private Integer diRawRecordsChunkParsedNumPartitions;
+
+  public KafkaTopic[] createTopicObjects() {
+    var diCompleteTopic = new SRMKafkaTopic("DI_COMPLETE", diCompleteNumPartitions);
+    var diError = new SRMKafkaTopic("DI_ERROR", diErrorNumPartitions);
+    var diParsedRecordsChunkSaved = new SRMKafkaTopic("DI_PARSED_RECORDS_CHUNK_SAVED", diParsedRecordsChunkSavedNumPartitions);
+    var diRawRecordsChunkParsed = new SRMKafkaTopic("DI_RAW_RECORDS_CHUNK_PARSED", diRawRecordsChunkParsedNumPartitions);
+
+    return new SRMKafkaTopic[] {diCompleteTopic, diError, diParsedRecordsChunkSaved, diRawRecordsChunkParsed};
+  }
+}

--- a/mod-source-record-manager-server/src/main/java/org/folio/services/kafka/SRMKafkaTopicService.java
+++ b/mod-source-record-manager-server/src/main/java/org/folio/services/kafka/SRMKafkaTopicService.java
@@ -16,18 +16,42 @@ public class SRMKafkaTopicService {
   @Value("${di_error.partitions}")
   private Integer diErrorNumPartitions;
 
-  @Value("${di_parsed_records_chunk_saved.partitions}")
-  private Integer diParsedRecordsChunkSavedNumPartitions;
+  @Value("${di_srs_marc_bib_record_created.partitions}")
+  private Integer diSrsMarcBibRecordCreatedNumPartitions;
+
+  @Value("${di_srs_marc_authority_record_created.partitions}")
+  private Integer diSrsMarcAuthorityRecordCreatedNumPartitions;
+
+  @Value("${di_srs_marc_holdings_record_created.partitions}")
+  private Integer diSrsMarcHoldingsRecordCreatedNumPartitions;
 
   @Value("${di_raw_records_chunk_parsed.partitions}")
   private Integer diRawRecordsChunkParsedNumPartitions;
 
+  @Value("${di_edifact_record_created.partitions}")
+  private Integer diEdifactRecordCreatedNumPartitions;
+
+  @Value("${di_marc_for_update_received.partitions}")
+  private Integer diMarcForUpdateReceivedNumPartitions;
+
+  @Value("${di_marc_for_delete_received.partitions}")
+  private Integer diMarcForDeleteReceivedNumPartitions;
+
   public KafkaTopic[] createTopicObjects() {
     var diCompleteTopic = new SRMKafkaTopic("DI_COMPLETE", diCompleteNumPartitions);
     var diError = new SRMKafkaTopic("DI_ERROR", diErrorNumPartitions);
-    var diParsedRecordsChunkSaved = new SRMKafkaTopic("DI_PARSED_RECORDS_CHUNK_SAVED", diParsedRecordsChunkSavedNumPartitions);
+    var diSrsMarcBibRecordCreated = new SRMKafkaTopic("DI_SRS_MARC_BIB_RECORD_CREATED", diSrsMarcBibRecordCreatedNumPartitions);
+    var diSrsMarcAuthorityCreated = new SRMKafkaTopic("DI_SRS_MARC_AUTHORITY_RECORD_CREATED", diSrsMarcAuthorityRecordCreatedNumPartitions);
+    var diSrsMarcHoldingsCreated = new SRMKafkaTopic("DI_SRS_MARC_HOLDINGS_RECORD_CREATED",
+      diSrsMarcHoldingsRecordCreatedNumPartitions);
     var diRawRecordsChunkParsed = new SRMKafkaTopic("DI_RAW_RECORDS_CHUNK_PARSED", diRawRecordsChunkParsedNumPartitions);
-
-    return new SRMKafkaTopic[] {diCompleteTopic, diError, diParsedRecordsChunkSaved, diRawRecordsChunkParsed};
+    var diEdifactRecordCreated = new SRMKafkaTopic("DI_EDIFACT_RECORD_CREATED", diEdifactRecordCreatedNumPartitions);
+    var diMarcForUpdateReceived = new SRMKafkaTopic("DI_MARC_FOR_UPDATE_RECEIVED",
+      diMarcForUpdateReceivedNumPartitions);
+    var diMarcForDeleteReceived = new SRMKafkaTopic("DI_MARC_FOR_DELETE_RECEIVED",
+      diMarcForDeleteReceivedNumPartitions);
+    return new SRMKafkaTopic[] {diCompleteTopic, diError, diSrsMarcBibRecordCreated, diSrsMarcAuthorityCreated,
+                                diSrsMarcHoldingsCreated, diRawRecordsChunkParsed, diEdifactRecordCreated,
+                                diMarcForUpdateReceived, diMarcForDeleteReceived};
   }
 }

--- a/mod-source-record-manager-server/src/main/java/org/folio/services/kafka/support/SRMKafkaTopic.java
+++ b/mod-source-record-manager-server/src/main/java/org/folio/services/kafka/support/SRMKafkaTopic.java
@@ -1,5 +1,9 @@
 package org.folio.services.kafka.support;
 
+import static org.folio.kafka.KafkaTopicNameHelper.formatTopicName;
+import static org.folio.kafka.services.KafkaEnvironmentProperties.environment;
+
+import org.folio.kafka.KafkaConfig;
 import org.folio.kafka.services.KafkaTopic;
 
 public class SRMKafkaTopic implements KafkaTopic {
@@ -25,5 +29,10 @@ public class SRMKafkaTopic implements KafkaTopic {
   @Override
   public int numPartitions() {
     return numPartitions;
+  }
+
+  @Override
+  public String fullTopicName(String tenant) {
+    return formatTopicName(environment(), tenant, topicName());
   }
 }

--- a/mod-source-record-manager-server/src/main/java/org/folio/services/kafka/support/SRMKafkaTopic.java
+++ b/mod-source-record-manager-server/src/main/java/org/folio/services/kafka/support/SRMKafkaTopic.java
@@ -1,0 +1,29 @@
+package org.folio.services.kafka.support;
+
+import org.folio.kafka.services.KafkaTopic;
+
+public class SRMKafkaTopic implements KafkaTopic {
+
+  private final String topic;
+  private final int numPartitions;
+
+  public SRMKafkaTopic(String topic, int numPartitions) {
+    this.topic = topic;
+    this.numPartitions = numPartitions;
+  }
+
+  @Override
+  public String moduleName() {
+    return "srm";
+  }
+
+  @Override
+  public String topicName() {
+    return topic;
+  }
+
+  @Override
+  public int numPartitions() {
+    return numPartitions;
+  }
+}

--- a/mod-source-record-manager-server/src/main/java/org/folio/services/kafka/support/SRMKafkaTopic.java
+++ b/mod-source-record-manager-server/src/main/java/org/folio/services/kafka/support/SRMKafkaTopic.java
@@ -3,7 +3,6 @@ package org.folio.services.kafka.support;
 import static org.folio.kafka.KafkaTopicNameHelper.formatTopicName;
 import static org.folio.kafka.services.KafkaEnvironmentProperties.environment;
 
-import org.folio.kafka.KafkaConfig;
 import org.folio.kafka.services.KafkaTopic;
 
 public class SRMKafkaTopic implements KafkaTopic {

--- a/mod-source-record-manager-server/src/main/resources/kafka.properties
+++ b/mod-source-record-manager-server/src/main/resources/kafka.properties
@@ -1,10 +1,9 @@
 
 di_complete.partitions = ${DI_COMPLETE_PARTITIONS:1}
 di_error.partitions = ${DI_ERROR_PARTITIONS:1}
-di_srs_marc_bib_record_created.partitions = ${DI_SRS_MARC_BIB_RECORD_CREATED_PARTITIONS:1}
 di_srs_marc_authority_record_created.partitions = ${DI_SRS_MARC_AUTHORITY_RECORD_CREATED_PARTITIONS:1}
 di_srs_marc_holdings_record_created.partitions = ${DI_SRS_MARC_HOLDINGS_RECORD_CREATED_PARTITIONS:1}
 di_raw_records_chunk_parsed.partitions = ${DI_RAW_RECORDS_CHUNK_PARSED_PARTITIONS:1}
-di_edifact_record_created.partitions = ${DI_EDIFACT_RECORD_CREATED_PARTITIONS:1}
 di_marc_for_update_received.partitions = ${DI_MARC_FOR_UPDATE_RECEIVED_PARTITIONS:1}
 di_marc_for_delete_received.partitions = ${DI_MARC_FOR_DELETE_RECEIVED_PARTITIONS:1}
+di_marc_for_order_created.partitions = ${DI_MARC_BIB_FOR_ORDER_CREATED_PARTITIONS:1}

--- a/mod-source-record-manager-server/src/main/resources/kafka.properties
+++ b/mod-source-record-manager-server/src/main/resources/kafka.properties
@@ -1,0 +1,5 @@
+
+di_complete.partitions = ${DI_COMPLETE_PARTITIONS:1}
+di_error.partitions = ${DI_ERROR_PARTITIONS:1}
+di_parsed_records_chunk_saved.partitions = ${DI_PARSED_RECORDS_CHUNK_SAVED_PARTITIONS:1}
+di_raw_records_chunk_parsed.partitions = ${DI_RAW_RECORDS_CHUNK_PARSED_PARTITIONS:1}

--- a/mod-source-record-manager-server/src/main/resources/kafka.properties
+++ b/mod-source-record-manager-server/src/main/resources/kafka.properties
@@ -1,5 +1,10 @@
 
 di_complete.partitions = ${DI_COMPLETE_PARTITIONS:1}
 di_error.partitions = ${DI_ERROR_PARTITIONS:1}
-di_parsed_records_chunk_saved.partitions = ${DI_PARSED_RECORDS_CHUNK_SAVED_PARTITIONS:1}
+di_srs_marc_bib_record_created.partitions = ${DI_SRS_MARC_BIB_RECORD_CREATED_PARTITIONS:1}
+di_srs_marc_authority_record_created.partitions = ${DI_SRS_MARC_AUTHORITY_RECORD_CREATED_PARTITIONS:1}
+di_srs_marc_holdings_record_created.partitions = ${DI_SRS_MARC_HOLDINGS_RECORD_CREATED_PARTITIONS:1}
 di_raw_records_chunk_parsed.partitions = ${DI_RAW_RECORDS_CHUNK_PARSED_PARTITIONS:1}
+di_edifact_record_created.partitions = ${DI_EDIFACT_RECORD_CREATED_PARTITIONS:1}
+di_marc_for_update_received.partitions = ${DI_MARC_FOR_UPDATE_RECEIVED_PARTITIONS:1}
+di_marc_for_delete_received.partitions = ${DI_MARC_FOR_DELETE_RECEIVED_PARTITIONS:1}

--- a/mod-source-record-manager-server/src/main/resources/kafka.properties
+++ b/mod-source-record-manager-server/src/main/resources/kafka.properties
@@ -6,4 +6,4 @@ di_srs_marc_holdings_record_created.partitions = ${DI_SRS_MARC_HOLDINGS_RECORD_C
 di_raw_records_chunk_parsed.partitions = ${DI_RAW_RECORDS_CHUNK_PARSED_PARTITIONS:1}
 di_marc_for_update_received.partitions = ${DI_MARC_FOR_UPDATE_RECEIVED_PARTITIONS:1}
 di_marc_for_delete_received.partitions = ${DI_MARC_FOR_DELETE_RECEIVED_PARTITIONS:1}
-di_marc_for_order_created.partitions = ${DI_MARC_BIB_FOR_ORDER_CREATED_PARTITIONS:1}
+di_marc_for_order_parsed.partitions = ${DI_INCOMING_MARC_BIB_FOR_ORDER_PARSED_PARTITIONS:1}

--- a/mod-source-record-manager-server/src/test/java/org/folio/services/KafkaAdminClientServiceTest.java
+++ b/mod-source-record-manager-server/src/test/java/org/folio/services/KafkaAdminClientServiceTest.java
@@ -60,7 +60,6 @@ public class KafkaAdminClientServiceTest {
       new SRMKafkaTopic("DI_INCOMING_MARC_BIB_FOR_ORDER_PARSED", 10)
     };
 
-
     when(srmKafkaTopicService.createTopicObjects()).thenReturn(topicObjects);
   }
 
@@ -145,13 +144,13 @@ public class KafkaAdminClientServiceTest {
   }
 
   private final Set<String> allExpectedTopics = Set.of(
-    "test-env.foo-tenant.srm.DI_COMPLETE",
-    "test-env.foo-tenant.srm.DI_ERROR",
-    "test-env.foo-tenant.srm.DI_SRS_MARC_AUTHORITY_RECORD_CREATED",
-    "test-env.foo-tenant.srm.DI_SRS_MARC_HOLDINGS_RECORD_CREATED",
-    "test-env.foo-tenant.srm.DI_RAW_RECORDS_CHUNK_PARSED",
-    "test-env.foo-tenant.srm.DI_MARC_FOR_UPDATE_RECEIVED",
-    "test-env.foo-tenant.srm.DI_MARC_FOR_DELETE_RECEIVED",
-    "test-env.foo-tenant.srm.DI_INCOMING_MARC_BIB_FOR_ORDER_PARSED"
+    "folio.foo-tenant.DI_COMPLETE",
+    "folio.foo-tenant.DI_ERROR",
+    "folio.foo-tenant.DI_SRS_MARC_AUTHORITY_RECORD_CREATED",
+    "folio.foo-tenant.DI_SRS_MARC_HOLDINGS_RECORD_CREATED",
+    "folio.foo-tenant.DI_RAW_RECORDS_CHUNK_PARSED",
+    "folio.foo-tenant.DI_MARC_FOR_UPDATE_RECEIVED",
+    "folio.foo-tenant.DI_MARC_FOR_DELETE_RECEIVED",
+    "folio.foo-tenant.DI_INCOMING_MARC_BIB_FOR_ORDER_PARSED"
   );
 }

--- a/mod-source-record-manager-server/src/test/java/org/folio/services/KafkaAdminClientServiceTest.java
+++ b/mod-source-record-manager-server/src/test/java/org/folio/services/KafkaAdminClientServiceTest.java
@@ -57,7 +57,7 @@ public class KafkaAdminClientServiceTest {
       new SRMKafkaTopic("DI_RAW_RECORDS_CHUNK_PARSED", 10),
       new SRMKafkaTopic("DI_MARC_FOR_UPDATE_RECEIVED", 10),
       new SRMKafkaTopic("DI_MARC_FOR_DELETE_RECEIVED", 10),
-      new SRMKafkaTopic("DI_MARC_BIB_FOR_ORDER_CREATED", 10)
+      new SRMKafkaTopic("DI_INCOMING_MARC_BIB_FOR_ORDER_PARSED", 10)
     };
 
 
@@ -152,6 +152,6 @@ public class KafkaAdminClientServiceTest {
     "test-env.foo-tenant.srm.DI_RAW_RECORDS_CHUNK_PARSED",
     "test-env.foo-tenant.srm.DI_MARC_FOR_UPDATE_RECEIVED",
     "test-env.foo-tenant.srm.DI_MARC_FOR_DELETE_RECEIVED",
-    "test-env.foo-tenant.srm.DI_MARC_BIB_FOR_ORDER_CREATED"
+    "test-env.foo-tenant.srm.DI_INCOMING_MARC_BIB_FOR_ORDER_PARSED"
   );
 }

--- a/mod-source-record-manager-server/src/test/java/org/folio/services/KafkaAdminClientServiceTest.java
+++ b/mod-source-record-manager-server/src/test/java/org/folio/services/KafkaAdminClientServiceTest.java
@@ -144,13 +144,13 @@ public class KafkaAdminClientServiceTest {
   }
 
   private final Set<String> allExpectedTopics = Set.of(
-    "folio.foo-tenant.DI_COMPLETE",
-    "folio.foo-tenant.DI_ERROR",
-    "folio.foo-tenant.DI_SRS_MARC_AUTHORITY_RECORD_CREATED",
-    "folio.foo-tenant.DI_SRS_MARC_HOLDINGS_RECORD_CREATED",
-    "folio.foo-tenant.DI_RAW_RECORDS_CHUNK_PARSED",
-    "folio.foo-tenant.DI_MARC_FOR_UPDATE_RECEIVED",
-    "folio.foo-tenant.DI_MARC_FOR_DELETE_RECEIVED",
-    "folio.foo-tenant.DI_INCOMING_MARC_BIB_FOR_ORDER_PARSED"
+    "test-env.foo-tenant.DI_COMPLETE",
+    "test-env.foo-tenant.DI_ERROR",
+    "test-env.foo-tenant.DI_SRS_MARC_AUTHORITY_RECORD_CREATED",
+    "test-env.foo-tenant.DI_SRS_MARC_HOLDINGS_RECORD_CREATED",
+    "test-env.foo-tenant.DI_RAW_RECORDS_CHUNK_PARSED",
+    "test-env.foo-tenant.DI_MARC_FOR_UPDATE_RECEIVED",
+    "test-env.foo-tenant.DI_MARC_FOR_DELETE_RECEIVED",
+    "test-env.foo-tenant.DI_INCOMING_MARC_BIB_FOR_ORDER_PARSED"
   );
 }

--- a/mod-source-record-manager-server/src/test/java/org/folio/services/KafkaAdminClientServiceTest.java
+++ b/mod-source-record-manager-server/src/test/java/org/folio/services/KafkaAdminClientServiceTest.java
@@ -52,13 +52,12 @@ public class KafkaAdminClientServiceTest {
     KafkaTopic[] topicObjects = {
       new SRMKafkaTopic("DI_COMPLETE", 10),
       new SRMKafkaTopic("DI_ERROR", 10),
-      new SRMKafkaTopic("DI_SRS_MARC_BIB_RECORD_CREATED", 10),
       new SRMKafkaTopic("DI_SRS_MARC_AUTHORITY_RECORD_CREATED", 10),
       new SRMKafkaTopic("DI_SRS_MARC_HOLDINGS_RECORD_CREATED", 10),
       new SRMKafkaTopic("DI_RAW_RECORDS_CHUNK_PARSED", 10),
-      new SRMKafkaTopic("DI_EDIFACT_RECORD_CREATED", 10),
       new SRMKafkaTopic("DI_MARC_FOR_UPDATE_RECEIVED", 10),
-      new SRMKafkaTopic("DI_MARC_FOR_DELETE_RECEIVED", 10)
+      new SRMKafkaTopic("DI_MARC_FOR_DELETE_RECEIVED", 10),
+      new SRMKafkaTopic("DI_MARC_BIB_FOR_ORDER_CREATED", 10)
     };
 
 
@@ -148,12 +147,11 @@ public class KafkaAdminClientServiceTest {
   private final Set<String> allExpectedTopics = Set.of(
     "test-env.foo-tenant.srm.DI_COMPLETE",
     "test-env.foo-tenant.srm.DI_ERROR",
-    "test-env.foo-tenant.srm.DI_SRS_MARC_BIB_RECORD_CREATED",
     "test-env.foo-tenant.srm.DI_SRS_MARC_AUTHORITY_RECORD_CREATED",
     "test-env.foo-tenant.srm.DI_SRS_MARC_HOLDINGS_RECORD_CREATED",
     "test-env.foo-tenant.srm.DI_RAW_RECORDS_CHUNK_PARSED",
-    "test-env.foo-tenant.srm.DI_EDIFACT_RECORD_CREATED",
     "test-env.foo-tenant.srm.DI_MARC_FOR_UPDATE_RECEIVED",
-    "test-env.foo-tenant.srm.DI_MARC_FOR_DELETE_RECEIVED"
+    "test-env.foo-tenant.srm.DI_MARC_FOR_DELETE_RECEIVED",
+    "test-env.foo-tenant.srm.DI_MARC_BIB_FOR_ORDER_CREATED"
   );
 }

--- a/mod-source-record-manager-server/src/test/java/org/folio/services/KafkaAdminClientServiceTest.java
+++ b/mod-source-record-manager-server/src/test/java/org/folio/services/KafkaAdminClientServiceTest.java
@@ -141,9 +141,9 @@ public class KafkaAdminClientServiceTest {
   }
 
   private final Set<String> allExpectedTopics = Set.of(
-    "folio.foo-tenant.srm.DI_COMPLETE",
-    "folio.foo-tenant.srm.DI_ERROR",
-    "folio.foo-tenant.srm.DI_PARSED_RECORDS_CHUNK_SAVED",
-    "folio.foo-tenant.srm.DI_RAW_RECORDS_CHUNK_PARSED"
+    "test-env.foo-tenant.srm.DI_COMPLETE",
+    "test-env.foo-tenant.srm.DI_ERROR",
+    "test-env.foo-tenant.srm.DI_PARSED_RECORDS_CHUNK_SAVED",
+    "test-env.foo-tenant.srm.DI_RAW_RECORDS_CHUNK_PARSED"
   );
 }

--- a/mod-source-record-manager-server/src/test/java/org/folio/services/KafkaAdminClientServiceTest.java
+++ b/mod-source-record-manager-server/src/test/java/org/folio/services/KafkaAdminClientServiceTest.java
@@ -1,0 +1,149 @@
+package org.folio.services;
+
+import static io.vertx.core.Future.failedFuture;
+import static io.vertx.core.Future.succeededFuture;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsInAnyOrder;
+import static org.hamcrest.Matchers.instanceOf;
+import static org.mockito.ArgumentCaptor.forClass;
+import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.ArgumentMatchers.anyMap;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import io.vertx.core.Future;
+import io.vertx.core.Vertx;
+import io.vertx.ext.unit.TestContext;
+import io.vertx.ext.unit.junit.VertxUnitRunner;
+import io.vertx.kafka.admin.KafkaAdminClient;
+import io.vertx.kafka.admin.NewTopic;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+import org.apache.kafka.common.errors.TopicExistsException;
+import org.folio.kafka.services.KafkaAdminClientService;
+import org.folio.kafka.services.KafkaTopic;
+import org.folio.services.kafka.SRMKafkaTopicService;
+import org.folio.services.kafka.support.SRMKafkaTopic;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+
+@RunWith(VertxUnitRunner.class)
+public class KafkaAdminClientServiceTest {
+
+  private final String STUB_TENANT = "foo-tenant";
+  private KafkaAdminClient mockClient;
+  private Vertx vertx;
+  @Mock
+  private SRMKafkaTopicService srmKafkaTopicService;
+
+  @Before
+  public void setUp() {
+    vertx = mock(Vertx.class);
+    mockClient = mock(KafkaAdminClient.class);
+    srmKafkaTopicService = mock(SRMKafkaTopicService.class);
+    KafkaTopic[] topicObjects = {
+      new SRMKafkaTopic("DI_COMPLETE", 10),
+      new SRMKafkaTopic("DI_ERROR", 10),
+      new SRMKafkaTopic("DI_PARSED_RECORDS_CHUNK_SAVED", 10),
+      new SRMKafkaTopic("DI_RAW_RECORDS_CHUNK_PARSED", 10)
+    };
+
+
+    when(srmKafkaTopicService.createTopicObjects()).thenReturn(topicObjects);
+  }
+
+  @Test
+  public void shouldCreateTopicIfAlreadyExist(TestContext testContext) {
+    when(mockClient.createTopics(anyList()))
+      .thenReturn(failedFuture(new TopicExistsException("x")))
+      .thenReturn(failedFuture(new TopicExistsException("y")))
+      .thenReturn(failedFuture(new TopicExistsException("z")))
+      .thenReturn(succeededFuture());
+    when(mockClient.listTopics()).thenReturn(succeededFuture(Set.of("old")));
+    when(mockClient.close()).thenReturn(succeededFuture());
+
+    createKafkaTopicsAsync(mockClient)
+      .onComplete(testContext.asyncAssertSuccess(notUsed -> {
+        verify(mockClient, times(4)).listTopics();
+        verify(mockClient, times(4)).createTopics(anyList());
+        verify(mockClient, times(1)).close();
+      }));
+  }
+
+  @Test
+  public void shouldFailIfExistExceptionIsPermanent(TestContext testContext) {
+    when(mockClient.createTopics(anyList())).thenReturn(failedFuture(new TopicExistsException("x")));
+    when(mockClient.listTopics()).thenReturn(succeededFuture(Set.of("old")));
+    when(mockClient.close()).thenReturn(succeededFuture());
+
+    createKafkaTopicsAsync(mockClient)
+      .onComplete(testContext.asyncAssertFailure(e -> {
+        assertThat(e, instanceOf(TopicExistsException.class));
+        verify(mockClient, times(1)).close();
+      }));
+  }
+
+  @Test
+  public void shouldNotCreateTopicOnOther(TestContext testContext) {
+    when(mockClient.createTopics(anyList())).thenReturn(failedFuture(new RuntimeException("err msg")));
+    when(mockClient.listTopics()).thenReturn(succeededFuture(Set.of("old")));
+    when(mockClient.close()).thenReturn(succeededFuture());
+
+    createKafkaTopicsAsync(mockClient)
+      .onComplete(testContext.asyncAssertFailure(cause -> {
+          testContext.assertEquals("err msg", cause.getMessage());
+          verify(mockClient, times(1)).close();
+        }
+      ));
+  }
+
+  @Test
+  public void shouldCreateTopicIfNotExist(TestContext testContext) {
+    when(mockClient.createTopics(anyList())).thenReturn(succeededFuture());
+    when(mockClient.listTopics()).thenReturn(succeededFuture(Set.of("old")));
+    when(mockClient.close()).thenReturn(succeededFuture());
+
+    createKafkaTopicsAsync(mockClient)
+      .onComplete(testContext.asyncAssertSuccess(notUsed -> {
+
+        @SuppressWarnings("unchecked")
+        final ArgumentCaptor<List<NewTopic>> createTopicsCaptor = forClass(List.class);
+
+        verify(mockClient, times(1)).createTopics(createTopicsCaptor.capture());
+        verify(mockClient, times(1)).close();
+
+        // Only these items are expected, so implicitly checks size of list
+        assertThat(getTopicNames(createTopicsCaptor), containsInAnyOrder(allExpectedTopics.toArray()));
+      }));
+  }
+
+  private List<String> getTopicNames(ArgumentCaptor<List<NewTopic>> createTopicsCaptor) {
+    return createTopicsCaptor.getAllValues().get(0).stream()
+      .map(NewTopic::getName)
+      .collect(Collectors.toList());
+  }
+
+  private Future<Void> createKafkaTopicsAsync(KafkaAdminClient client) {
+    try (var mocked = mockStatic(KafkaAdminClient.class)) {
+      mocked.when(() -> KafkaAdminClient.create(eq(vertx), anyMap())).thenReturn(client);
+
+      return new KafkaAdminClientService(vertx)
+        .createKafkaTopics(srmKafkaTopicService.createTopicObjects(), STUB_TENANT);
+    }
+  }
+
+  private final Set<String> allExpectedTopics = Set.of(
+    "folio.foo-tenant.srm.DI_COMPLETE",
+    "folio.foo-tenant.srm.DI_ERROR",
+    "folio.foo-tenant.srm.DI_PARSED_RECORDS_CHUNK_SAVED",
+    "folio.foo-tenant.srm.DI_RAW_RECORDS_CHUNK_PARSED"
+  );
+}

--- a/mod-source-record-manager-server/src/test/java/org/folio/services/KafkaAdminClientServiceTest.java
+++ b/mod-source-record-manager-server/src/test/java/org/folio/services/KafkaAdminClientServiceTest.java
@@ -52,8 +52,13 @@ public class KafkaAdminClientServiceTest {
     KafkaTopic[] topicObjects = {
       new SRMKafkaTopic("DI_COMPLETE", 10),
       new SRMKafkaTopic("DI_ERROR", 10),
-      new SRMKafkaTopic("DI_PARSED_RECORDS_CHUNK_SAVED", 10),
-      new SRMKafkaTopic("DI_RAW_RECORDS_CHUNK_PARSED", 10)
+      new SRMKafkaTopic("DI_SRS_MARC_BIB_RECORD_CREATED", 10),
+      new SRMKafkaTopic("DI_SRS_MARC_AUTHORITY_RECORD_CREATED", 10),
+      new SRMKafkaTopic("DI_SRS_MARC_HOLDINGS_RECORD_CREATED", 10),
+      new SRMKafkaTopic("DI_RAW_RECORDS_CHUNK_PARSED", 10),
+      new SRMKafkaTopic("DI_EDIFACT_RECORD_CREATED", 10),
+      new SRMKafkaTopic("DI_MARC_FOR_UPDATE_RECEIVED", 10),
+      new SRMKafkaTopic("DI_MARC_FOR_DELETE_RECEIVED", 10)
     };
 
 
@@ -143,7 +148,12 @@ public class KafkaAdminClientServiceTest {
   private final Set<String> allExpectedTopics = Set.of(
     "test-env.foo-tenant.srm.DI_COMPLETE",
     "test-env.foo-tenant.srm.DI_ERROR",
-    "test-env.foo-tenant.srm.DI_PARSED_RECORDS_CHUNK_SAVED",
-    "test-env.foo-tenant.srm.DI_RAW_RECORDS_CHUNK_PARSED"
+    "test-env.foo-tenant.srm.DI_SRS_MARC_BIB_RECORD_CREATED",
+    "test-env.foo-tenant.srm.DI_SRS_MARC_AUTHORITY_RECORD_CREATED",
+    "test-env.foo-tenant.srm.DI_SRS_MARC_HOLDINGS_RECORD_CREATED",
+    "test-env.foo-tenant.srm.DI_RAW_RECORDS_CHUNK_PARSED",
+    "test-env.foo-tenant.srm.DI_EDIFACT_RECORD_CREATED",
+    "test-env.foo-tenant.srm.DI_MARC_FOR_UPDATE_RECEIVED",
+    "test-env.foo-tenant.srm.DI_MARC_FOR_DELETE_RECEIVED"
   );
 }


### PR DESCRIPTION
## Purpose
Create Kafka topics instead of relying on auto create in mod-srm [MODSOURMAN-1123](https://issues.folio.org/browse/MODSOURMAN-1123)

## Approach
* create kafka topics when tenant init
* add test

## Is this change testable? If not - why?

## Checklist
- [x] I have updated NEWS.md.
- [ ] I have added javadocs to new methods.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation e.g. README.md.
- [ ] I have ran karate tests against this feature.

