### PR TITLE
MODSOURMAN-1139 Fix Kafka test failures in ChangeManagerAPITest

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,6 @@
 ## 2023-xx-xx v3.8.0-SNAPSHOT
-* [MODDATAIMP-1003](https://folio-org.atlassian.net/browse/MODDATAIMP-1003)
+* [MODSOURMAN-1139](https://folio-org.atlassian.net/browse/MODSOURMAN-1139) Fix Kafka test failures in ChangeManagerAPITest
+* [MODDATAIMP-1003](https://folio-org.atlassian.net/browse/MODDATAIMP-1003) Provide "orders-storage.titles.item.get" module permission
 * [MODSOURMAN-1123](https://issues.folio.org/browse/MODSOURMAN-1123) Create Kafka topics instead of relying on auto create in mod-srm
 * [MODSOURMAN-1113](https://issues.folio.org/browse/MODSOURMAN-1113) Reduce Memory Allocations Of Strings
 * [MODSOURMAN-1085](https://issues.folio.org/browse/MODSOURMAN-1085) MARC record with a 100 tag without a $a is being discarded on import.


### PR DESCRIPTION
## Purpose
Fix Kafka test failures in ChangeManagerAPITest [MODSOURMAN-1139](https://folio-org.atlassian.net/browse/MODSOURMAN-1139)

## Approach
add awaitility to wait for event to be received

## Checklist
- [x] I have updated NEWS.md.
- [ ] I have added javadocs to new methods.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation e.g. README.md.
- [ ] I have ran karate tests against this feature.

