### PR TITLE
[MODSOURMAN-1141] Change get_job_log_entries sql function to retrieve sourceRecordId from existing bib

### DIFF
--- a/mod-source-record-manager-server/src/main/java/org/folio/services/journal/JournalUtil.java
+++ b/mod-source-record-manager-server/src/main/java/org/folio/services/journal/JournalUtil.java
@@ -27,6 +27,7 @@ import static org.apache.commons.lang3.StringUtils.isEmpty;
 import static org.folio.rest.jaxrs.model.DataImportEventTypes.DI_ERROR;
 import static org.folio.rest.jaxrs.model.DataImportEventTypes.DI_INVENTORY_INSTANCE_CREATED;
 import static org.folio.rest.jaxrs.model.DataImportEventTypes.DI_INVENTORY_INSTANCE_UPDATED;
+import static org.folio.rest.jaxrs.model.JournalRecord.ActionType.UPDATE;
 import static org.folio.rest.jaxrs.model.JournalRecord.EntityType.AUTHORITY;
 import static org.folio.rest.jaxrs.model.JournalRecord.EntityType.HOLDINGS;
 import static org.folio.rest.jaxrs.model.JournalRecord.EntityType.INSTANCE;
@@ -142,7 +143,8 @@ public class JournalUtil {
       }
 
       if (!isEmpty(entityAsString)) {
-        if (entityType == INSTANCE || entityType == PO_LINE || entityType == AUTHORITY) {
+        if (entityType == INSTANCE || entityType == PO_LINE || entityType == AUTHORITY ||
+          (entityType == MARC_BIBLIOGRAPHIC && actionType == UPDATE)) {
           JsonObject entityJson = new JsonObject(entityAsString);
           journalRecord.setEntityId(entityJson.getString(ID_KEY));
           if (entityType == INSTANCE || entityType == PO_LINE) {
@@ -200,7 +202,7 @@ public class JournalUtil {
       String actionTypeFromContext = eventPayloadContext.get(MARC_BIB_RECORD_CREATED);
 
       if (actionTypeFromContext.equals(Boolean.TRUE.toString())) actionTypeForMarcBib = JournalRecord.ActionType.CREATE;
-      else actionTypeForMarcBib = JournalRecord.ActionType.UPDATE;
+      else actionTypeForMarcBib = UPDATE;
     }
 
     return buildCommonJournalRecord(actionStatus, actionTypeForMarcBib, currentRecord, eventPayload, eventPayloadContext, incomingRecordId)

--- a/mod-source-record-manager-server/src/main/resources/templates/db_scripts/create_get_job_log_entries_function.sql
+++ b/mod-source-record-manager-server/src/main/resources/templates/db_scripts/create_get_job_log_entries_function.sql
@@ -145,11 +145,15 @@ WHERE tmp.entity_type = ''ITEM''
   marc_holdings AS (
     SELECT temp_result.job_execution_id, entity_id, title, source_record_order, action_type, error, source_id, tenant_id
     FROM temp_result WHERE entity_type = ''MARC_HOLDINGS''
+  ),
+  marc_bibliographic AS (
+    SELECT temp_result.job_execution_id, entity_id, title, source_record_order, action_type, error, source_id, tenant_id
+    FROM temp_result WHERE entity_type = ''MARC_BIBLIOGRAPHIC''
   )
 
 SELECT records_actions.job_execution_id AS job_execution_id,
-       records_actions.source_id AS source_id,
        records_actions.source_id AS incoming_record_id,
+       coalesce(marc_bibliographic_entity_id::uuid, marc_authority_entity_id::uuid, marc_holdings_entity_id::uuid) AS source_id,
        records_actions.source_record_order AS source_record_order,
        '''' as invoiceline_number,
        coalesce(rec_titles.title, marc_holdings_info.title) AS title,
@@ -293,11 +297,20 @@ FROM (
 ) AS marc_authority_info ON marc_authority_info.source_id = records_actions.source_id
 
        LEFT JOIN (
+  SELECT marc_bibliographic.action_type AS action_type,
+         marc_bibliographic.source_id AS source_id,
+         marc_bibliographic.title AS title,
+         marc_bibliographic.entity_id AS marc_bibliographic_entity_id,
+         marc_bibliographic.error AS marc_bibliographic_entity_error
+  FROM  marc_bibliographic WHERE entity_id IS NOT NULL
+) AS marc_bibliographic_info ON marc_bibliographic_info.source_id = records_actions.source_id
+
+       LEFT JOIN (
   SELECT marc_holdings.action_type AS action_type,
          marc_holdings.source_id AS source_id,
          marc_holdings.title AS title,
-         marc_holdings.entity_id AS marc_authority_entity_id,
-         marc_holdings.error AS marc_authority_entity_error
+         marc_holdings.entity_id AS marc_holdings_entity_id,
+         marc_holdings.error AS marc_holdings_entity_error
   FROM  marc_holdings
 ) AS marc_holdings_info ON marc_holdings_info.source_id = records_actions.source_id
 
@@ -315,8 +328,8 @@ FROM (
 UNION
 
 SELECT records_actions.job_execution_id AS job_execution_id,
-       records_actions.source_id AS source_id,
        records_actions.source_id AS incoming_record_id,
+       records_actions.source_id AS source_id,
        source_record_order AS source_record_order,
        entity_hrid as invoiceline_number,
        invoice_line_info.title AS title,

--- a/mod-source-record-manager-server/src/test/java/org/folio/rest/impl/metadataProvider/MetaDataProviderRecordProcessingLogCollectionAPITest.java
+++ b/mod-source-record-manager-server/src/test/java/org/folio/rest/impl/metadataProvider/MetaDataProviderRecordProcessingLogCollectionAPITest.java
@@ -1,6 +1,7 @@
 package org.folio.rest.impl.metadataProvider;
 
 import io.restassured.RestAssured;
+import io.restassured.response.ValidatableResponse;
 import io.vertx.core.CompositeFuture;
 import io.vertx.core.Future;
 import io.vertx.core.Vertx;
@@ -94,9 +95,10 @@ public class MetaDataProviderRecordProcessingLogCollectionAPITest extends Abstra
     JobExecution createdJobExecution = constructAndPostInitJobExecutionRqDto(1).getJobExecutions().get(0);
     String sourceRecordId = UUID.randomUUID().toString();
     String recordTitle = "test title";
+    String marcBibEntityId = UUID.randomUUID().toString();
 
     Future<JournalRecord> future = Future.succeededFuture()
-      .compose(v -> createJournalRecord(createdJobExecution.getId(), sourceRecordId, null, null, recordTitle, 0, CREATE, MARC_BIBLIOGRAPHIC, COMPLETED, null, null))
+      .compose(v -> createJournalRecord(createdJobExecution.getId(), sourceRecordId, marcBibEntityId, null, recordTitle, 0, CREATE, MARC_BIBLIOGRAPHIC, COMPLETED, null, null))
       .compose(v -> createJournalRecord(createdJobExecution.getId(), sourceRecordId, null, "in00000000001", null, 0, UPDATE, MARC_BIBLIOGRAPHIC, COMPLETED, null, null))
       .onFailure(context::fail);
 
@@ -110,7 +112,8 @@ public class MetaDataProviderRecordProcessingLogCollectionAPITest extends Abstra
         .body("entries", hasSize(1))
         .body("totalRecords", is(1))
         .body("entries[0].jobExecutionId", is(createdJobExecution.getId()))
-        .body("entries[0].sourceRecordId", is(sourceRecordId))
+        .body("entries[0].sourceRecordId", is(marcBibEntityId))
+        .body("entries[0].incomingRecordId", is(sourceRecordId))
         .body("entries[0].sourceRecordTitle", is(recordTitle))
         .body("entries[0].sourceRecordActionStatus", is(ActionStatus.CREATED.value()));
 
@@ -155,7 +158,7 @@ public class MetaDataProviderRecordProcessingLogCollectionAPITest extends Abstra
         .body("entries", hasSize(1))
         .body("totalRecords", is(1))
         .body("entries[0].jobExecutionId", is(createdJobExecution.getId()))
-        .body("entries[0].sourceRecordId", is(sourceRecordId))
+        .body("entries[0].incomingRecordId", is(sourceRecordId))
         .body("entries[0].sourceRecordTitle", is(recordTitle))
         .body("entries[0].sourceRecordActionStatus", is(ActionStatus.CREATED.value()))
         .body("entries[0].relatedHoldingsInfo[0].actionStatus", is(ActionStatus.CREATED.value()))
@@ -174,9 +177,10 @@ public class MetaDataProviderRecordProcessingLogCollectionAPITest extends Abstra
     JobExecution createdJobExecution = constructAndPostInitJobExecutionRqDto(1).getJobExecutions().get(0);
     String sourceRecordId = UUID.randomUUID().toString();
     String recordTitle = "test title";
+    String marcBibEntityId = UUID.randomUUID().toString();
 
     Future<JournalRecord> future = Future.succeededFuture()
-      .compose(v -> createJournalRecord(createdJobExecution.getId(), sourceRecordId, null, null, recordTitle, 0, CREATE, MARC_BIBLIOGRAPHIC, COMPLETED, null, null))
+      .compose(v -> createJournalRecord(createdJobExecution.getId(), sourceRecordId, marcBibEntityId, null, recordTitle, 0, CREATE, MARC_BIBLIOGRAPHIC, COMPLETED, null, null))
       .compose(v -> createJournalRecord(createdJobExecution.getId(), sourceRecordId, null, null, null, 0, MODIFY, MARC_BIBLIOGRAPHIC, COMPLETED, null, null))
       .onFailure(context::fail);
 
@@ -190,7 +194,8 @@ public class MetaDataProviderRecordProcessingLogCollectionAPITest extends Abstra
         .body("entries", hasSize(1))
         .body("totalRecords", is(1))
         .body("entries[0].jobExecutionId", is(createdJobExecution.getId()))
-        .body("entries[0].sourceRecordId", is(sourceRecordId))
+        .body("entries[0].sourceRecordId", is(marcBibEntityId))
+        .body("entries[0].incomingRecordId", is(sourceRecordId))
         .body("entries[0].sourceRecordTitle", is(recordTitle))
         .body("entries[0].sourceRecordActionStatus", is(ActionStatus.CREATED.value()));
 
@@ -204,10 +209,11 @@ public class MetaDataProviderRecordProcessingLogCollectionAPITest extends Abstra
     JobExecution createdJobExecution = constructAndPostInitJobExecutionRqDto(1).getJobExecutions().get(0);
     String sourceRecordId = UUID.randomUUID().toString();
     String recordTitle = "test title";
+    String marcBibEntityId = UUID.randomUUID().toString();
 
     Future<JournalRecord> future = Future.succeededFuture()
       .compose(v -> createJournalRecord(createdJobExecution.getId(), sourceRecordId, null, null, recordTitle, 0, NON_MATCH, MARC_BIBLIOGRAPHIC, COMPLETED, null, null))
-      .compose(v -> createJournalRecord(createdJobExecution.getId(), sourceRecordId, null, null, recordTitle, 0, CREATE, MARC_BIBLIOGRAPHIC, COMPLETED, null, null))
+      .compose(v -> createJournalRecord(createdJobExecution.getId(), sourceRecordId, marcBibEntityId, null, recordTitle, 0, CREATE, MARC_BIBLIOGRAPHIC, COMPLETED, null, null))
       .onFailure(context::fail);
 
     future.onComplete(ar -> context.verify(v -> {
@@ -220,7 +226,8 @@ public class MetaDataProviderRecordProcessingLogCollectionAPITest extends Abstra
         .body("entries", hasSize(1))
         .body("totalRecords", is(1))
         .body("entries[0].jobExecutionId", is(createdJobExecution.getId()))
-        .body("entries[0].sourceRecordId", is(sourceRecordId))
+        .body("entries[0].sourceRecordId", is(marcBibEntityId))
+        .body("entries[0].incomingRecordId", is(sourceRecordId))
         .body("entries[0].sourceRecordTitle", is(recordTitle))
         .body("entries[0].sourceRecordActionStatus", is(ActionStatus.CREATED.value()));
 
@@ -269,9 +276,10 @@ public class MetaDataProviderRecordProcessingLogCollectionAPITest extends Abstra
     JobExecution createdJobExecution = constructAndPostInitJobExecutionRqDto(1).getJobExecutions().get(0);
     String sourceRecordId = UUID.randomUUID().toString();
     String recordTitle = "test title";
+    String marcBibEntityId = UUID.randomUUID().toString();
 
     Future<JournalRecord> future = Future.succeededFuture()
-      .compose(v -> createJournalRecord(createdJobExecution.getId(), sourceRecordId, null, null, recordTitle, 0, CREATE, MARC_BIBLIOGRAPHIC, COMPLETED, null, null))
+      .compose(v -> createJournalRecord(createdJobExecution.getId(), sourceRecordId, marcBibEntityId, null, recordTitle, 0, CREATE, MARC_BIBLIOGRAPHIC, COMPLETED, null, null))
       .compose(v -> createJournalRecord(createdJobExecution.getId(), sourceRecordId, null, null, null, 0, CREATE, INSTANCE, ERROR, "error msg", null))
       .onFailure(context::fail);
 
@@ -285,7 +293,8 @@ public class MetaDataProviderRecordProcessingLogCollectionAPITest extends Abstra
         .body("entries.size()", is(1))
         .body("totalRecords", is(1))
         .body("entries[0].jobExecutionId", is(createdJobExecution.getId()))
-        .body("entries[0].sourceRecordId", is(sourceRecordId))
+        .body("entries[0].sourceRecordId", is(marcBibEntityId))
+        .body("entries[0].incomingRecordId", is(sourceRecordId))
         .body("entries[0].sourceRecordTitle", is(recordTitle))
         .body("entries[0].relatedInstanceInfo.actionStatus", is(ActionStatus.DISCARDED.value()))
         .body("entries[0].relatedInstanceInfo.error", not(emptyOrNullString()));
@@ -300,10 +309,11 @@ public class MetaDataProviderRecordProcessingLogCollectionAPITest extends Abstra
     JobExecution createdJobExecution = constructAndPostInitJobExecutionRqDto(1).getJobExecutions().get(0);
     String sourceRecordId = UUID.randomUUID().toString();
     String recordTitle = "test title";
+    String marcBibEntityId = UUID.randomUUID().toString();
 
     Future<JournalRecord> future = Future.succeededFuture()
-      .compose(v -> createJournalRecord(createdJobExecution.getId(), sourceRecordId, "marcEntityID", null, recordTitle, 0, CREATE, MARC_BIBLIOGRAPHIC, COMPLETED, null, null))
-      .compose(v -> createJournalRecord(createdJobExecution.getId(), sourceRecordId, "marcEntityID", null, recordTitle, 0, MODIFY, MARC_BIBLIOGRAPHIC, COMPLETED, null, null))
+      .compose(v -> createJournalRecord(createdJobExecution.getId(), sourceRecordId, marcBibEntityId, null, recordTitle, 0, CREATE, MARC_BIBLIOGRAPHIC, COMPLETED, null, null))
+      .compose(v -> createJournalRecord(createdJobExecution.getId(), sourceRecordId, null, null, recordTitle, 0, MODIFY, MARC_BIBLIOGRAPHIC, COMPLETED, null, null))
       .compose(v -> createJournalRecord(createdJobExecution.getId(), sourceRecordId, null, null, null, 0, UPDATE, INSTANCE, COMPLETED, null, null))
       .compose(v -> createJournalRecord(createdJobExecution.getId(), sourceRecordId, "instanceEntityID", "in00000000001", null, 0, CREATE, INSTANCE, COMPLETED, null, null))
       .onFailure(context::fail);
@@ -318,7 +328,8 @@ public class MetaDataProviderRecordProcessingLogCollectionAPITest extends Abstra
         .body("entries.size()", is(2))
         .body("totalRecords", is(1))
         .body("entries[0].jobExecutionId", is(createdJobExecution.getId()))
-        .body("entries[0].sourceRecordId", is(sourceRecordId))
+        .body("entries[0].sourceRecordId", is(marcBibEntityId))
+        .body("entries[0].incomingRecordId", is(sourceRecordId))
         .body("entries[0].sourceRecordTitle", is(recordTitle))
         .body("entries[0].relatedInstanceInfo.actionStatus", is(ActionStatus.CREATED.value()));
 
@@ -332,9 +343,10 @@ public class MetaDataProviderRecordProcessingLogCollectionAPITest extends Abstra
     JobExecution createdJobExecution = constructAndPostInitJobExecutionRqDto(1).getJobExecutions().get(0);
     String sourceRecordId = UUID.randomUUID().toString();
     String recordTitle = "test title";
+    String marcBibEntityId = UUID.randomUUID().toString();
 
     Future<JournalRecord> future = Future.succeededFuture()
-      .compose(v -> createJournalRecord(createdJobExecution.getId(), sourceRecordId, "marcEntityID", null, recordTitle, 0, CREATE, MARC_BIBLIOGRAPHIC, COMPLETED, null, null))
+      .compose(v -> createJournalRecord(createdJobExecution.getId(), sourceRecordId, marcBibEntityId, null, recordTitle, 0, CREATE, MARC_BIBLIOGRAPHIC, COMPLETED, null, null))
       .compose(v -> createJournalRecord(createdJobExecution.getId(), sourceRecordId, "poLineEntityID", null, null, 0, CREATE, PO_LINE, COMPLETED, null, null))
       .onFailure(context::fail);
 
@@ -348,7 +360,8 @@ public class MetaDataProviderRecordProcessingLogCollectionAPITest extends Abstra
         .body("entries.size()", is(1))
         .body("totalRecords", is(1))
         .body("entries[0].jobExecutionId", is(createdJobExecution.getId()))
-        .body("entries[0].sourceRecordId", is(sourceRecordId))
+        .body("entries[0].sourceRecordId", is(marcBibEntityId))
+        .body("entries[0].incomingRecordId", is(sourceRecordId))
         .body("entries[0].sourceRecordTitle", is(recordTitle))
         .body("entries[0].relatedPoLineInfo.actionStatus", is(ActionStatus.CREATED.value()));
 
@@ -362,9 +375,10 @@ public class MetaDataProviderRecordProcessingLogCollectionAPITest extends Abstra
     JobExecution createdJobExecution = constructAndPostInitJobExecutionRqDto(1).getJobExecutions().get(0);
     String sourceRecordId = UUID.randomUUID().toString();
     String recordTitle = "test title";
+    String authorityEntityId = UUID.randomUUID().toString();
 
     Future<JournalRecord> future = Future.succeededFuture()
-      .compose(v -> createJournalRecord(createdJobExecution.getId(), sourceRecordId, "authorityEntityID", null, recordTitle, 0, MATCH, MARC_AUTHORITY, ERROR, "errorMsg", null))
+      .compose(v -> createJournalRecord(createdJobExecution.getId(), sourceRecordId, authorityEntityId, null, recordTitle, 0, MATCH, MARC_AUTHORITY, ERROR, "errorMsg", null))
       .onFailure(context::fail);
 
     future.onComplete(ar -> context.verify(v -> {
@@ -377,7 +391,8 @@ public class MetaDataProviderRecordProcessingLogCollectionAPITest extends Abstra
         .body("entries.size()", is(1))
         .body("totalRecords", is(1))
         .body("entries[0].jobExecutionId", is(createdJobExecution.getId()))
-        .body("entries[0].sourceRecordId", is(sourceRecordId))
+        .body("entries[0].sourceRecordId", is(authorityEntityId))
+        .body("entries[0].incomingRecordId", is(sourceRecordId))
         .body("entries[0].sourceRecordType", is(MARC_AUTHORITY.value()))
         .body("entries[0].sourceRecordTitle", is(recordTitle))
         .body("entries[0].relatedAuthorityInfo.error", is(notNullValue()))
@@ -425,11 +440,10 @@ public class MetaDataProviderRecordProcessingLogCollectionAPITest extends Abstra
         .get(GET_JOB_EXECUTION_JOURNAL_RECORDS_PATH + "/" + holdingsCreationJobExecution.getId())
         .then()
         .statusCode(HttpStatus.SC_OK)
-
         .body("entries.size()", is(1))
         .body("totalRecords", is(1))
         .body("entries[0].jobExecutionId", is(holdingsCreationJobExecution.getId()))
-        .body("entries[0].sourceRecordId", is(holdingsCreationSourceRecordId))
+        .body("entries[0].incomingRecordId", is(holdingsCreationSourceRecordId))
         .body("entries[0].sourceRecordOrder", is("0"))
         .body("entries[0].error", emptyOrNullString())
         .body("entries[0].relatedInstanceInfo.idList[0]", is("instanceEntityID"))
@@ -448,9 +462,10 @@ public class MetaDataProviderRecordProcessingLogCollectionAPITest extends Abstra
     String sourceRecordId = UUID.randomUUID().toString();
     String recordTitle = "test title";
     String orderId = UUID.randomUUID().toString();
+    String marcBibEntityId = UUID.randomUUID().toString();
 
     Future<JournalRecord> future = Future.succeededFuture()
-      .compose(v -> createJournalRecord(createdJobExecution.getId(), sourceRecordId, "marcEntityID", null, recordTitle, 0, CREATE, MARC_BIBLIOGRAPHIC, COMPLETED, null, null))
+      .compose(v -> createJournalRecord(createdJobExecution.getId(), sourceRecordId, marcBibEntityId, null, recordTitle, 0, CREATE, MARC_BIBLIOGRAPHIC, COMPLETED, null, null))
       .compose(v -> createJournalRecord(createdJobExecution.getId(), sourceRecordId, "poLineEntityID", null, null, 0, CREATE, PO_LINE, COMPLETED, "Test error", orderId))
       .onFailure(context::fail);
 
@@ -464,7 +479,8 @@ public class MetaDataProviderRecordProcessingLogCollectionAPITest extends Abstra
         .body("entries.size()", is(1))
         .body("totalRecords", is(1))
         .body("entries[0].jobExecutionId", is(createdJobExecution.getId()))
-        .body("entries[0].sourceRecordId", is(sourceRecordId))
+        .body("entries[0].sourceRecordId", is(marcBibEntityId))
+        .body("entries[0].incomingRecordId", is(sourceRecordId))
         .body("entries[0].sourceRecordTitle", is(recordTitle))
         .body("entries[0].sourceRecordActionStatus", is(ActionStatus.CREATED.value()))
         .body("entries[0].relatedPoLineInfo", notNullValue())
@@ -483,11 +499,12 @@ public class MetaDataProviderRecordProcessingLogCollectionAPITest extends Abstra
     String marcBibAndInstanceUpdateSourceRecordId = UUID.randomUUID().toString();
 
     String recordTitle = "test title";
+    String marcBibEntityId = UUID.randomUUID().toString();
 
     Future<JournalRecord> future = Future.succeededFuture()
       .compose(v -> createJournalRecord(marcBibAndInstanceUpdateJobExecution.getId(), marcBibAndInstanceUpdateSourceRecordId, "instanceEntityID", "in00000000001", null, 0, UPDATE, INSTANCE, COMPLETED, null, null))
       .compose(v -> createJournalRecord(marcBibAndInstanceUpdateJobExecution.getId(), marcBibAndInstanceUpdateSourceRecordId, "instanceEntityID", "in00000000001", null, 0, UPDATE, INSTANCE, COMPLETED, null, null))
-      .compose(v -> createJournalRecord(marcBibAndInstanceUpdateJobExecution.getId(), marcBibAndInstanceUpdateSourceRecordId, "marcBibEntityID", null, recordTitle, 0, MODIFY, MARC_BIBLIOGRAPHIC, COMPLETED, null, null))
+      .compose(v -> createJournalRecord(marcBibAndInstanceUpdateJobExecution.getId(), marcBibAndInstanceUpdateSourceRecordId, marcBibEntityId, null, recordTitle, 0, MODIFY, MARC_BIBLIOGRAPHIC, COMPLETED, null, null))
       .onFailure(context::fail);
 
     future.onComplete(ar -> context.verify(v -> {
@@ -500,7 +517,8 @@ public class MetaDataProviderRecordProcessingLogCollectionAPITest extends Abstra
         .body("entries.size()", is(1))
         .body("totalRecords", is(1))
         .body("entries[0].jobExecutionId", is(marcBibAndInstanceUpdateJobExecution.getId()))
-        .body("entries[0].sourceRecordId", is(marcBibAndInstanceUpdateSourceRecordId))
+        .body("entries[0].sourceRecordId", is(marcBibEntityId))
+        .body("entries[0].incomingRecordId", is(marcBibAndInstanceUpdateSourceRecordId))
         .body("entries[0].error", emptyOrNullString())
         .body("entries[0].relatedInstanceInfo.idList.size()", is(1))
         .body("entries[0].relatedInstanceInfo.hridList.size()", is(1))
@@ -532,7 +550,7 @@ public class MetaDataProviderRecordProcessingLogCollectionAPITest extends Abstra
         .statusCode(HttpStatus.SC_OK)
         .body("entries.size()", is(1))
         .body("totalRecords", is(1))
-        .body("entries[0].sourceRecordId", is(sourceRecordId))
+        .body("entries[0].incomingRecordId", is(sourceRecordId))
         .body("entries[0].sourceRecordTitle", is(recordTitle))
         .body("entries[0].relatedHoldingsInfo[0].actionStatus", is(ActionStatus.CREATED.value()));
       async.complete();
@@ -559,7 +577,7 @@ public class MetaDataProviderRecordProcessingLogCollectionAPITest extends Abstra
         .statusCode(HttpStatus.SC_OK)
         .body("entries.size()", is(1))
         .body("totalRecords", is(1))
-        .body("entries[0].sourceRecordId", is(sourceRecordId))
+        .body("entries[0].incomingRecordId", is(sourceRecordId))
         .body("entries[0].sourceRecordTitle", is("Holdings ho00000000001"))
         .body("entries[0].relatedHoldingsInfo[0].hrid", is("ho00000000001"))
         .body("entries[0].sourceRecordType", is(MARC_HOLDINGS.value()));
@@ -624,13 +642,16 @@ public class MetaDataProviderRecordProcessingLogCollectionAPITest extends Abstra
     String sourceRecordId2 = UUID.randomUUID().toString();
     String sourceRecordId3 = UUID.randomUUID().toString();
     String recordTitle1 = "title1";
+    String marcBibEntityId1 = UUID.randomUUID().toString();
+    String marcBibEntityId2 = UUID.randomUUID().toString();
+    String marcBibEntityId3 = UUID.randomUUID().toString();
 
     Future<JournalRecord> future = Future.succeededFuture()
-      .compose(v -> createJournalRecord(createdJobExecution.getId(), sourceRecordId1, null, null, recordTitle1, 1, CREATE, MARC_BIBLIOGRAPHIC, COMPLETED, null, null))
+      .compose(v -> createJournalRecord(createdJobExecution.getId(), sourceRecordId1, marcBibEntityId1, null, recordTitle1, 1, CREATE, MARC_BIBLIOGRAPHIC, COMPLETED, null, null))
       .compose(v -> createJournalRecord(createdJobExecution.getId(), sourceRecordId1, null, "in00000000001", null, 1, CREATE, INSTANCE, COMPLETED, null, null))
-      .compose(v -> createJournalRecord(createdJobExecution.getId(), sourceRecordId2, null, null, "title0", 0, CREATE, MARC_BIBLIOGRAPHIC, COMPLETED, null, null))
+      .compose(v -> createJournalRecord(createdJobExecution.getId(), sourceRecordId2, marcBibEntityId2, null, "title0", 0, CREATE, MARC_BIBLIOGRAPHIC, COMPLETED, null, null))
       .compose(v -> createJournalRecord(createdJobExecution.getId(), sourceRecordId2, null, null, null, 0, CREATE, INSTANCE, COMPLETED, null, null))
-      .compose(v -> createJournalRecord(createdJobExecution.getId(), sourceRecordId3, null, null, "title3", 3, CREATE, MARC_BIBLIOGRAPHIC, COMPLETED, null, null))
+      .compose(v -> createJournalRecord(createdJobExecution.getId(), sourceRecordId3, marcBibEntityId3, null, "title3", 3, CREATE, MARC_BIBLIOGRAPHIC, COMPLETED, null, null))
       .compose(v -> createJournalRecord(createdJobExecution.getId(), sourceRecordId3, null, null, null, 3, CREATE, INSTANCE, COMPLETED, null, null))
       .onFailure(context::fail);
 
@@ -648,7 +669,8 @@ public class MetaDataProviderRecordProcessingLogCollectionAPITest extends Abstra
         .body("entries.size()", is(1))
         .body("totalRecords", is(3))
         .body("entries[0].jobExecutionId", is(createdJobExecution.getId()))
-        .body("entries[0].sourceRecordId", is(sourceRecordId1))
+        .body("entries[0].sourceRecordId", is(marcBibEntityId1))
+        .body("entries[0].incomingRecordId", is(sourceRecordId1))
         .body("entries[0].sourceRecordTitle", is(recordTitle1))
         .body("entries[0].sourceRecordOrder", is("1"))
         .body("entries[0].relatedHoldingsInfo.hrid", is(empty()))
@@ -673,7 +695,7 @@ public class MetaDataProviderRecordProcessingLogCollectionAPITest extends Abstra
       .onFailure(context::fail);
 
     future.onComplete(ar -> context.verify(v -> {
-      RestAssured.given()
+      ValidatableResponse r = RestAssured.given()
         .spec(spec)
         .when()
         .get(GET_JOB_EXECUTION_JOURNAL_RECORDS_PATH + "/" + createdJobExecution.getId())
@@ -681,7 +703,8 @@ public class MetaDataProviderRecordProcessingLogCollectionAPITest extends Abstra
         .statusCode(HttpStatus.SC_OK)
         .body("entries.size()", is(1))
         .body("totalRecords", is(1))
-        .body("entries[0].sourceRecordId", is(sourceRecordId))
+        .body("entries[0].sourceRecordId", is(entityId))
+        .body("entries[0].incomingRecordId", is(sourceRecordId))
         .body("entries[0].sourceRecordTitle", is(recordTitle))
         .body("entries[0].sourceRecordActionStatus", is(ActionStatus.CREATED.value()))
         .body("entries[0].relatedAuthorityInfo.actionStatus", is(ActionStatus.CREATED.value()));
@@ -695,9 +718,10 @@ public class MetaDataProviderRecordProcessingLogCollectionAPITest extends Abstra
     JobExecution createdJobExecution = constructAndPostInitJobExecutionRqDto(1).getJobExecutions().get(0);
     String sourceRecordId = UUID.randomUUID().toString();
     String recordTitle = "test title";
+    String marcBibEntityId = UUID.randomUUID().toString();
 
     Future<JournalRecord> future = Future.succeededFuture()
-      .compose(v -> createJournalRecord(createdJobExecution.getId(), sourceRecordId, null, null, recordTitle, 0, CREATE, MARC_BIBLIOGRAPHIC, COMPLETED, null, null))
+      .compose(v -> createJournalRecord(createdJobExecution.getId(), sourceRecordId, marcBibEntityId, null, recordTitle, 0, CREATE, MARC_BIBLIOGRAPHIC, COMPLETED, null, null))
       .compose(v -> createJournalRecord(createdJobExecution.getId(), sourceRecordId, null, null, null, 0, UPDATE, MARC_BIBLIOGRAPHIC, COMPLETED, null, null))
       .onFailure(context::fail);
 
@@ -711,7 +735,8 @@ public class MetaDataProviderRecordProcessingLogCollectionAPITest extends Abstra
         .body("entries.size()", is(1))
         .body("totalRecords", is(1))
         .body("entries[0].jobExecutionId", is(createdJobExecution.getId()))
-        .body("entries[0].sourceRecordId", is(sourceRecordId))
+        .body("entries[0].sourceRecordId", is(marcBibEntityId))
+        .body("entries[0].incomingRecordId", is(sourceRecordId))
         .body("entries[0].sourceRecordTitle", is(recordTitle))
         .body("entries[0].sourceRecordOrder", is("0"))
         .body("entries[0].sourceRecordActionStatus", is(ActionStatus.CREATED.value()));
@@ -727,10 +752,11 @@ public class MetaDataProviderRecordProcessingLogCollectionAPITest extends Abstra
     String sourceRecordId = UUID.randomUUID().toString();
     String entityId = UUID.randomUUID().toString();
     String entityHrid = "001";
+    String marcBibEntityId = UUID.randomUUID().toString();
     String recordTitle = "test title";
 
     Future<JournalRecord> future = Future.succeededFuture()
-      .compose(v -> createJournalRecord(createdJobExecution.getId(), sourceRecordId, entityId, entityHrid, recordTitle, 0, CREATE, MARC_BIBLIOGRAPHIC, COMPLETED, null, null))
+      .compose(v -> createJournalRecord(createdJobExecution.getId(), sourceRecordId, marcBibEntityId, entityHrid, recordTitle, 0, CREATE, MARC_BIBLIOGRAPHIC, COMPLETED, null, null))
       .compose(v -> createJournalRecord(createdJobExecution.getId(), sourceRecordId, entityId, entityHrid, null, 0, CREATE, INSTANCE, ERROR, "error msg", null))
       .onFailure(context::fail);
 
@@ -744,7 +770,8 @@ public class MetaDataProviderRecordProcessingLogCollectionAPITest extends Abstra
         .body("entries.size()", is(1))
         .body("totalRecords", is(1))
         .body("entries[0].jobExecutionId", is(createdJobExecution.getId()))
-        .body("entries[0].sourceRecordId", is(sourceRecordId))
+        .body("entries[0].sourceRecordId", is(marcBibEntityId))
+        .body("entries[0].incomingRecordId", is(sourceRecordId))
         .body("entries[0].sourceRecordTitle", is(recordTitle))
         .body("entries[0].sourceRecordOrder", is("0"))
         .body("entries[0].error", emptyOrNullString())
@@ -762,9 +789,10 @@ public class MetaDataProviderRecordProcessingLogCollectionAPITest extends Abstra
     JobExecution createdJobExecution = constructAndPostInitJobExecutionRqDto(1).getJobExecutions().get(0);
     String sourceRecordId = UUID.randomUUID().toString();
     String recordTitle = "test title";
+    String marcBibEntityId = UUID.randomUUID().toString();
 
     Future<JournalRecord> future = Future.succeededFuture()
-      .compose(v -> createJournalRecord(createdJobExecution.getId(), sourceRecordId, null, null, recordTitle, 0, CREATE, MARC_BIBLIOGRAPHIC, ERROR, "MarcBib error msg", null))
+      .compose(v -> createJournalRecord(createdJobExecution.getId(), sourceRecordId, marcBibEntityId, null, recordTitle, 0, CREATE, MARC_BIBLIOGRAPHIC, ERROR, "MarcBib error msg", null))
       .onFailure(context::fail);
 
     future.onComplete(ar -> context.verify(v -> {
@@ -774,11 +802,11 @@ public class MetaDataProviderRecordProcessingLogCollectionAPITest extends Abstra
         .get(GET_JOB_EXECUTION_JOURNAL_RECORDS_PATH + "/" + createdJobExecution.getId())
         .then()
         .statusCode(HttpStatus.SC_OK)
-
         .body("entries.size()", is(1))
         .body("totalRecords", is(1))
         .body("entries[0].jobExecutionId", is(createdJobExecution.getId()))
-        .body("entries[0].sourceRecordId", is(sourceRecordId))
+        .body("entries[0].sourceRecordId", is(marcBibEntityId))
+        .body("entries[0].incomingRecordId", is(sourceRecordId))
         .body("entries[0].sourceRecordTitle", is(recordTitle))
         .body("entries[0].sourceRecordOrder", is("0"))
         .body("entries[0].error", is("MarcBib error msg"));
@@ -824,7 +852,7 @@ public class MetaDataProviderRecordProcessingLogCollectionAPITest extends Abstra
         .body("entries.size()", is(1))
         .body("totalRecords", is(1))
         .body("entries[0].jobExecutionId", is(createdJobExecution.getId()))
-        .body("entries[0].sourceRecordId", is(sourceRecordId))
+        .body("entries[0].incomingRecordId", is(sourceRecordId))
         .body("entries[0].sourceRecordTitle", is(recordTitle))
         .body("entries[0].sourceRecordOrder", is("0"))
         .body("entries[0].error", emptyOrNullString())
@@ -876,7 +904,7 @@ public class MetaDataProviderRecordProcessingLogCollectionAPITest extends Abstra
         .body("entries.size()", is(1))
         .body("totalRecords", is(1))
         .body("entries[0].jobExecutionId", is(createdJobExecution.getId()))
-        .body("entries[0].sourceRecordId", is(sourceRecordId))
+        .body("entries[0].incomingRecordId", is(sourceRecordId))
         .body("entries[0].sourceRecordTitle", is(recordTitle))
         .body("entries[0].sourceRecordOrder", is("0"))
         .body("entries[0].error", emptyOrNullString())
@@ -922,7 +950,7 @@ public class MetaDataProviderRecordProcessingLogCollectionAPITest extends Abstra
         .body("entries.size()", is(1))
         .body("totalRecords", is(1))
         .body("entries[0].jobExecutionId", is(createdJobExecution.getId()))
-        .body("entries[0].sourceRecordId", is(sourceRecordId))
+        .body("entries[0].incomingRecordId", is(sourceRecordId))
         .body("entries[0].sourceRecordTitle", is(recordTitle))
         .body("entries[0].sourceRecordOrder", is("0"))
         .body("entries[0].error", emptyOrNullString())
@@ -1360,7 +1388,7 @@ public class MetaDataProviderRecordProcessingLogCollectionAPITest extends Abstra
         .body("entries.size()", is(1))
         .body("totalRecords", is(1))
         .body("entries[0].jobExecutionId", is(createdJobExecution.getId()))
-        .body("entries[0].sourceRecordId", is(sourceRecordId))
+        .body("entries[0].incomingRecordId", is(sourceRecordId))
         .body("entries[0].sourceRecordTitle", is(recordTitle));
       async.complete();
     }));
@@ -1408,7 +1436,7 @@ public class MetaDataProviderRecordProcessingLogCollectionAPITest extends Abstra
         .body("entries.size()", is(1))
         .body("totalRecords", is(1))
         .body("entries[0].jobExecutionId", is(createdJobExecution.getId()))
-        .body("entries[0].sourceRecordId", is(sourceRecordId))
+        .body("entries[0].incomingRecordId", is(sourceRecordId))
         .body("entries[0].sourceRecordTitle", is(recordTitle))
         .body("entries[0].sourceRecordOrder", is("0"))
         .body("entries[0].error", emptyOrNullString())
@@ -1464,7 +1492,7 @@ public class MetaDataProviderRecordProcessingLogCollectionAPITest extends Abstra
         .body("entries.size()", is(1))
         .body("totalRecords", is(1))
         .body("entries[0].jobExecutionId", is(createdJobExecution.getId()))
-        .body("entries[0].sourceRecordId", is(sourceRecordId))
+        .body("entries[0].incomingRecordId", is(sourceRecordId))
         .body("entries[0].sourceRecordTitle", is(recordTitle))
         .body("entries[0].sourceRecordOrder", is("0"))
         .body("entries[0].error", emptyOrNullString())
@@ -1518,7 +1546,7 @@ public class MetaDataProviderRecordProcessingLogCollectionAPITest extends Abstra
         .body("entries.size()", is(1))
         .body("totalRecords", is(1))
         .body("entries[0].jobExecutionId", is(createdJobExecution.getId()))
-        .body("entries[0].sourceRecordId", is(sourceRecordId))
+        .body("entries[0].incomingRecordId", is(sourceRecordId))
         .body("entries[0].sourceRecordTitle", is(recordTitle))
         .body("entries[0].sourceRecordOrder", is("0"))
         .body("entries[0].error", emptyOrNullString())
@@ -1548,9 +1576,10 @@ public class MetaDataProviderRecordProcessingLogCollectionAPITest extends Abstra
     String instanceId = UUID.randomUUID().toString();
     String recordTitle = "test title";
     String expectedCentralTenantId = "mobius";
+    String marcBibEntityId = UUID.randomUUID().toString();
 
     Future<JournalRecord> future = Future.succeededFuture()
-      .compose(v -> createJournalRecord(createdJobExecution.getId(), sourceRecordId, null, null, recordTitle, 0, UPDATE, MARC_BIBLIOGRAPHIC, COMPLETED, null, null, expectedCentralTenantId))
+      .compose(v -> createJournalRecord(createdJobExecution.getId(), sourceRecordId, marcBibEntityId, null, recordTitle, 0, UPDATE, MARC_BIBLIOGRAPHIC, COMPLETED, null, null, expectedCentralTenantId))
       .compose(v -> createJournalRecord(createdJobExecution.getId(), sourceRecordId, instanceId, "in00000000001", null, 0, UPDATE, INSTANCE, COMPLETED, null, null, expectedCentralTenantId));
 
     future.onComplete(context.asyncAssertSuccess(v ->
@@ -1564,7 +1593,8 @@ public class MetaDataProviderRecordProcessingLogCollectionAPITest extends Abstra
         .body("entries.size()", is(1))
         .body("totalRecords", is(1))
         .body("entries[0].jobExecutionId", is(createdJobExecution.getId()))
-        .body("entries[0].sourceRecordId", is(sourceRecordId))
+        .body("entries[0].sourceRecordId", is(marcBibEntityId))
+        .body("entries[0].incomingRecordId", is(sourceRecordId))
         .body("entries[0].sourceRecordTitle", is(recordTitle))
         .body("entries[0].sourceRecordOrder", is("0"))
         .body("entries[0].sourceRecordTenantId", is(expectedCentralTenantId))

--- a/mod-source-record-manager-server/src/test/java/org/folio/services/JournalUtilTest.java
+++ b/mod-source-record-manager-server/src/test/java/org/folio/services/JournalUtilTest.java
@@ -1044,6 +1044,38 @@ public class JournalUtilTest {
   }
 
   @Test
+  public void shouldBuildJournalRecordForMarcBibliographicUpdate() throws JournalRecordMapperException {
+    String incomingRecordId = UUID.randomUUID().toString();
+
+    Record record = new Record()
+      .withId(UUID.randomUUID().toString())
+      .withSnapshotId(UUID.randomUUID().toString())
+      .withOrder(1);
+
+    HashMap<String, String> context = new HashMap<>() {{
+      put(MARC_BIBLIOGRAPHIC.value(), Json.encode(record));
+      put(INCOMING_RECORD_ID, incomingRecordId);
+    }};
+
+    DataImportEventPayload eventPayload = new DataImportEventPayload()
+      .withEventType(DI_SRS_MARC_BIB_RECORD_UPDATED.value())
+      .withContext(context);
+
+    List<JournalRecord> journalRecords = JournalUtil.buildJournalRecordsByEvent(eventPayload,
+      UPDATE, MARC_BIBLIOGRAPHIC, COMPLETED);
+
+    Assert.assertEquals(1, journalRecords.size());
+    Assert.assertEquals(incomingRecordId, journalRecords.get(0).getSourceId());
+    Assert.assertEquals(1, journalRecords.get(0).getSourceRecordOrder().intValue());
+    Assert.assertEquals(record.getId(), journalRecords.get(0).getEntityId());
+    Assert.assertEquals(MARC_BIBLIOGRAPHIC, journalRecords.get(0).getEntityType());
+    Assert.assertEquals(UPDATE, journalRecords.get(0).getActionType());
+    Assert.assertEquals(COMPLETED, journalRecords.get(0).getActionStatus());
+    Assert.assertEquals(MARC_BIBLIOGRAPHIC, journalRecords.get(0).getEntityType());
+  }
+
+
+  @Test
   public void shouldBuildJournalRecordForNonMatchWithErrorAndMatchedNumberNotAvailable() throws JournalRecordMapperException {
     String recordId = UUID.randomUUID().toString();
     String snapshotId = UUID.randomUUID().toString();


### PR DESCRIPTION
## Purpose
Change get_job_log_entries sql function to retrieve sourceRecordId from existing bib

## Approach

- Update get_job_log_entries function to retrieve sourceRecordId from existing journal_record on MARC_BIB, or MARC_AUTHORITY, or MARC_HOLDING
- Updated logic for multiple holdings and item entries log formation
- Updated test