### PR TITLE
MODDATAIMP-1029 The authority record loaded via data-import using Default - Create SRS MARC Authority job profile is duplicated on the job-summary page

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,6 @@
+## 2024-xx-xx v3.9.0
+* [MODDATAIMP-1029](https://folio-org.atlassian.net/browse/MODDATAIMP-1029) The authority record loaded via data-import using Default - Create SRS MARC Authority job profile is duplicated on the job-summary page
+
 ## 2023-03-22 v3.8.0
 * [MODSOURMAN-1131](https://folio-org.atlassian.net/browse/MODSOURMAN-1131) The import of file for creating orders is completed with errors
 * [MODSOURMAN-1139](https://folio-org.atlassian.net/browse/MODSOURMAN-1139) Fix Kafka test failures in ChangeManagerAPITest

--- a/mod-source-record-manager-server/src/main/resources/templates/db_scripts/create_get_job_log_entries_function.sql
+++ b/mod-source-record-manager-server/src/main/resources/templates/db_scripts/create_get_job_log_entries_function.sql
@@ -293,7 +293,7 @@ FROM (
          marc_authority.title AS title,
          marc_authority.entity_id AS marc_authority_entity_id,
          marc_authority.error AS marc_authority_entity_error
-  FROM  marc_authority
+  FROM  marc_authority WHERE entity_id IS NOT NULL
 ) AS marc_authority_info ON marc_authority_info.source_id = records_actions.source_id
 
        LEFT JOIN (


### PR DESCRIPTION
## Purpose
[MODDATAIMP-1029](https://folio-org.atlassian.net/browse/MODDATAIMP-1029) The authority record loaded via data-import using Default - Create SRS MARC Authority job profile is duplicated on the job-summary page

## Approach
add  filter id is not null

## Checklist
- [ ] I have updated NEWS.md.
- [ ] I have added javadocs to new methods.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation e.g. README.md.
- [ ] I have ran karate tests against this feature.

