### PR TITLE
[MODSOURMAN-1134] Fix No action status on entities match and no action

### DIFF
--- a/mod-source-record-manager-server/src/main/java/org/folio/services/journal/JournalUtil.java
+++ b/mod-source-record-manager-server/src/main/java/org/folio/services/journal/JournalUtil.java
@@ -142,7 +142,8 @@ public class JournalUtil {
         return Lists.newArrayList(journalRecord, relatedEntityJournalRecord);
       }
 
-      if (actionType == JournalRecord.ActionType.NON_MATCH && (entityType == HOLDINGS || entityType == ITEM)) {
+      if ((actionType == JournalRecord.ActionType.MATCH || actionType == JournalRecord.ActionType.NON_MATCH)
+        && (entityType == HOLDINGS || entityType == ITEM)) {
         List<JournalRecord> resultedJournalRecords = new ArrayList<>();
 
         String notMatchedNumberField = eventPayloadContext.get(NOT_MATCHED_NUMBER);

--- a/mod-source-record-manager-server/src/main/java/org/folio/services/journal/JournalUtil.java
+++ b/mod-source-record-manager-server/src/main/java/org/folio/services/journal/JournalUtil.java
@@ -62,9 +62,9 @@ public class JournalUtil {
   public static final String MARC_BIB_RECORD_CREATED = "MARC_BIB_RECORD_CREATED";
   public static final String INCOMING_RECORD_ID = "INCOMING_RECORD_ID";
 
-  private final EnumMap<JournalRecord.EntityType, JournalRecord.EntityType> ENTITY_TO_RELATED_ENTITY;
+  private static final EnumMap<JournalRecord.EntityType, JournalRecord.EntityType> ENTITY_TO_RELATED_ENTITY;
 
-  {
+  static {
     ENTITY_TO_RELATED_ENTITY = new EnumMap<>(JournalRecord.EntityType.class);
     ENTITY_TO_RELATED_ENTITY.put(INSTANCE, MARC_BIBLIOGRAPHIC);
     ENTITY_TO_RELATED_ENTITY.put(MARC_BIBLIOGRAPHIC, INSTANCE);

--- a/mod-source-record-manager-server/src/main/java/org/folio/services/journal/JournalUtil.java
+++ b/mod-source-record-manager-server/src/main/java/org/folio/services/journal/JournalUtil.java
@@ -149,10 +149,12 @@ public class JournalUtil {
         String notMatchedNumberField = eventPayloadContext.get(NOT_MATCHED_NUMBER);
         boolean isNotMatchedNumberPresent = isNotBlank(notMatchedNumberField);
 
-        int notMatchedNumber = isNotMatchedNumberPresent ? Integer.parseInt(notMatchedNumberField) : 1;
-        for (int i = 0; i < notMatchedNumber; i++) {
-          resultedJournalRecords.add(constructBlankJournalRecord(record, entityType, actionStatus, journalRecord.getError(), incomingRecordId)
-            .withEntityType(entityType));
+        if (isNotMatchedNumberPresent || actionType == JournalRecord.ActionType.NON_MATCH) {
+          int notMatchedNumber = isNotMatchedNumberPresent ? Integer.parseInt(notMatchedNumberField) : 1;
+          for (int i = 0; i < notMatchedNumber; i++) {
+            resultedJournalRecords.add(constructBlankJournalRecord(record, entityType, actionStatus, journalRecord.getError(), incomingRecordId)
+              .withEntityType(entityType));
+          }
         }
         return resultedJournalRecords;
       }

--- a/mod-source-record-manager-server/src/main/java/org/folio/services/journal/JournalUtil.java
+++ b/mod-source-record-manager-server/src/main/java/org/folio/services/journal/JournalUtil.java
@@ -15,6 +15,7 @@ import org.folio.rest.jaxrs.model.Record;
 
 import java.util.ArrayList;
 import java.util.Date;
+import java.util.EnumMap;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -61,12 +62,15 @@ public class JournalUtil {
   public static final String MARC_BIB_RECORD_CREATED = "MARC_BIB_RECORD_CREATED";
   public static final String INCOMING_RECORD_ID = "INCOMING_RECORD_ID";
 
-  private static final HashMap<JournalRecord.EntityType, JournalRecord.EntityType> ENTITY_TO_RELATED_ENTITY = new HashMap<>(){{
-    put(INSTANCE, MARC_BIBLIOGRAPHIC);
-    put(MARC_BIBLIOGRAPHIC, INSTANCE);
-    put(AUTHORITY, MARC_AUTHORITY);
-    put(MARC_AUTHORITY, AUTHORITY);
-  }};
+  private final EnumMap<JournalRecord.EntityType, JournalRecord.EntityType> ENTITY_TO_RELATED_ENTITY;
+
+  {
+    ENTITY_TO_RELATED_ENTITY = new EnumMap<>(JournalRecord.EntityType.class);
+    ENTITY_TO_RELATED_ENTITY.put(INSTANCE, MARC_BIBLIOGRAPHIC);
+    ENTITY_TO_RELATED_ENTITY.put(MARC_BIBLIOGRAPHIC, INSTANCE);
+    ENTITY_TO_RELATED_ENTITY.put(AUTHORITY, MARC_AUTHORITY);
+    ENTITY_TO_RELATED_ENTITY.put(MARC_AUTHORITY, AUTHORITY);
+  }
 
   private JournalUtil() {
 

--- a/mod-source-record-manager-server/src/main/java/org/folio/verticle/DataImportJournalConsumersVerticle.java
+++ b/mod-source-record-manager-server/src/main/java/org/folio/verticle/DataImportJournalConsumersVerticle.java
@@ -9,6 +9,7 @@ import static org.folio.rest.jaxrs.model.DataImportEventTypes.DI_INVENTORY_HOLDI
 import static org.folio.rest.jaxrs.model.DataImportEventTypes.DI_INVENTORY_HOLDING_NOT_MATCHED;
 import static org.folio.rest.jaxrs.model.DataImportEventTypes.DI_INVENTORY_HOLDING_UPDATED;
 import static org.folio.rest.jaxrs.model.DataImportEventTypes.DI_INVENTORY_INSTANCE_CREATED;
+import static org.folio.rest.jaxrs.model.DataImportEventTypes.DI_INVENTORY_INSTANCE_MATCHED;
 import static org.folio.rest.jaxrs.model.DataImportEventTypes.DI_INVENTORY_INSTANCE_NOT_MATCHED;
 import static org.folio.rest.jaxrs.model.DataImportEventTypes.DI_INVENTORY_INSTANCE_UPDATED;
 import static org.folio.rest.jaxrs.model.DataImportEventTypes.DI_INVENTORY_ITEM_CREATED;
@@ -65,6 +66,7 @@ public class DataImportJournalConsumersVerticle extends AbstractConsumersVerticl
       DI_INVENTORY_INSTANCE_CREATED.value(),
       DI_INVENTORY_INSTANCE_UPDATED.value(),
       DI_INVENTORY_INSTANCE_NOT_MATCHED.value(),
+      DI_INVENTORY_INSTANCE_MATCHED.value(),
       DI_SRS_MARC_BIB_RECORD_MODIFIED_READY_FOR_POST_PROCESSING.value(),
       DI_INVENTORY_HOLDING_CREATED.value(),
       DI_INVENTORY_HOLDING_UPDATED.value(),

--- a/mod-source-record-manager-server/src/main/java/org/folio/verticle/consumers/util/JournalParams.java
+++ b/mod-source-record-manager-server/src/main/java/org/folio/verticle/consumers/util/JournalParams.java
@@ -157,6 +157,14 @@ public class JournalParams {
           JournalRecord.ActionStatus.COMPLETED));
       }
     },
+    DI_INVENTORY_INSTANCE_MATCHED {
+      @Override
+      public Optional<JournalParams> getJournalParams(DataImportEventPayload eventPayload) {
+        return Optional.of(new JournalParams(JournalRecord.ActionType.MATCH,
+          JournalRecord.EntityType.INSTANCE,
+          JournalRecord.ActionStatus.COMPLETED));
+      }
+    },
     DI_INVENTORY_HOLDING_CREATED {
       @Override
       public Optional<JournalParams> getJournalParams(DataImportEventPayload eventPayload) {

--- a/mod-source-record-manager-server/src/main/resources/templates/db_scripts/create_get_job_execution_summary_function.sql
+++ b/mod-source-record-manager-server/src/main/resources/templates/db_scripts/create_get_job_execution_summary_function.sql
@@ -19,46 +19,53 @@ BEGIN
       COUNT(DISTINCT(source_id)) FILTER (WHERE action_status = 'ERROR') AS total_errors,
       COUNT(DISTINCT(source_id)) FILTER (WHERE entity_type IN ('MARC_BIBLIOGRAPHIC', 'MARC_HOLDINGS', 'MARC_AUTHORITY') AND action_type = 'CREATE' AND action_status = 'COMPLETED') AS total_created_source_records,
       COUNT(DISTINCT(source_id)) FILTER (WHERE entity_type IN ('MARC_BIBLIOGRAPHIC', 'MARC_HOLDINGS', 'MARC_AUTHORITY') AND action_type = 'UPDATE' AND action_status = 'COMPLETED') AS total_updated_source_records,
-      COUNT(*) FILTER (WHERE entity_type IN ('MARC_BIBLIOGRAPHIC', 'MARC_HOLDINGS', 'MARC_AUTHORITY') AND ((action_type = 'NON_MATCH' AND action_type_max = 'NON_MATCH') OR action_status = 'ERROR')) AS total_discarded_source_records,
+      COUNT(*) FILTER (WHERE entity_type IN ('MARC_BIBLIOGRAPHIC', 'MARC_HOLDINGS', 'MARC_AUTHORITY') AND ((action_type = 'NON_MATCH' AND action_type_max = 'NON_MATCH') OR (action_type = 'MATCH' AND action_type_max = 'MATCH') OR action_status = 'ERROR')) AS total_discarded_source_records,
       COUNT(*) FILTER (WHERE entity_type IN ('MARC_BIBLIOGRAPHIC', 'MARC_HOLDINGS', 'MARC_AUTHORITY') AND action_status = 'ERROR') AS total_source_records_errors,
 
       COUNT(DISTINCT(entity_id)) FILTER (WHERE entity_type = 'INSTANCE' AND action_type = 'CREATE' AND action_status = 'COMPLETED') AS total_created_instances,
       COUNT(DISTINCT(entity_id)) FILTER (WHERE entity_type = 'INSTANCE' AND action_type = 'UPDATE' AND action_status = 'COMPLETED') AS total_updated_instances,
-      COUNT(*) FILTER (WHERE entity_type = 'INSTANCE' AND ((action_type = 'NON_MATCH' AND action_type_max = 'NON_MATCH') OR action_status = 'ERROR')) AS total_discarded_instances,
+      COUNT(*) FILTER (WHERE entity_type = 'INSTANCE' AND ((action_type = 'NON_MATCH' AND action_type_max = 'NON_MATCH') OR (action_type = 'MATCH' AND action_type_max = 'MATCH') OR action_status = 'ERROR')) AS total_discarded_instances,
       COUNT(*) FILTER (WHERE entity_type = 'INSTANCE' AND action_status = 'ERROR') AS total_instances_errors,
 
       COUNT(*) FILTER (WHERE entity_type = 'HOLDINGS' AND action_type = 'CREATE' AND action_status = 'COMPLETED') AS total_created_holdings,
       COUNT(*) FILTER (WHERE entity_type = 'HOLDINGS' AND action_type = 'UPDATE' AND action_status = 'COMPLETED') AS total_updated_holdings,
-      COUNT(*) FILTER (WHERE entity_type = 'HOLDINGS' AND ((action_type = 'NON_MATCH' AND action_type_max = 'NON_MATCH') OR action_status = 'ERROR')) AS total_discarded_holdings,
+      COUNT(*) FILTER (WHERE entity_type = 'HOLDINGS' AND ((action_type = 'NON_MATCH' AND action_type_max = 'NON_MATCH') OR (action_type = 'MATCH' AND action_type_max = 'MATCH') OR action_status = 'ERROR')) AS total_discarded_holdings,
       COUNT(*) FILTER (WHERE entity_type = 'HOLDINGS' AND action_status = 'ERROR') AS total_holdings_errors,
 
       COUNT(*) FILTER (WHERE entity_type = 'ITEM' AND action_type = 'CREATE' AND action_status = 'COMPLETED') AS total_created_items,
       COUNT(*) FILTER (WHERE entity_type = 'ITEM' AND action_type = 'UPDATE' AND action_status = 'COMPLETED') AS total_updated_items,
-      COUNT(*) FILTER (WHERE entity_type = 'ITEM' AND ((action_type = 'NON_MATCH' AND action_type_max = 'NON_MATCH') OR action_status = 'ERROR')) AS total_discarded_items,
+      COUNT(*) FILTER (WHERE entity_type = 'ITEM' AND ((action_type = 'NON_MATCH' AND action_type_max = 'NON_MATCH') OR (action_type = 'MATCH' AND action_type_max = 'MATCH') OR action_status = 'ERROR')) AS total_discarded_items,
       COUNT(*) FILTER (WHERE entity_type = 'ITEM' AND action_status = 'ERROR') AS total_items_errors,
 
       COUNT(*) FILTER (WHERE entity_type = 'AUTHORITY' AND action_type = 'CREATE' AND action_status = 'COMPLETED') AS total_created_authorities,
       COUNT(*) FILTER (WHERE entity_type = 'AUTHORITY' AND action_type = 'UPDATE' AND action_status = 'COMPLETED') AS total_updated_authorities,
-      COUNT(*) FILTER (WHERE entity_type = 'AUTHORITY' AND ((action_type = 'NON_MATCH' AND action_type_max = 'NON_MATCH')OR action_status = 'ERROR')) AS total_discarded_authorities,
+      COUNT(*) FILTER (WHERE entity_type = 'AUTHORITY' AND ((action_type = 'NON_MATCH' AND action_type_max = 'NON_MATCH') OR (action_type = 'MATCH' AND action_type_max = 'MATCH') OR action_status = 'ERROR')) AS total_discarded_authorities,
       COUNT(*) FILTER (WHERE entity_type = 'AUTHORITY' AND action_status = 'ERROR') AS total_authorities_errors,
 
       COUNT(DISTINCT(source_id)) FILTER (WHERE entity_type = 'PO_LINE' AND action_type = 'CREATE' AND action_status = 'COMPLETED') AS total_created_orders,
       0 AS total_updated_orders,
-      COUNT(DISTINCT(source_id)) FILTER (WHERE entity_type = 'PO_LINE' AND ((action_type = 'NON_MATCH' AND action_type_max = 'NON_MATCH') OR action_status = 'ERROR')) AS total_discarded_orders,
+      COUNT(DISTINCT(source_id)) FILTER (WHERE entity_type = 'PO_LINE' AND ((action_type = 'NON_MATCH' AND action_type_max = 'NON_MATCH') OR (action_type = 'MATCH' AND action_type_max = 'MATCH') OR action_status = 'ERROR')) AS total_discarded_orders,
       COUNT(DISTINCT(source_id)) FILTER (WHERE entity_type = 'PO_LINE' AND action_status = 'ERROR') AS total_orders_errors,
 
       COUNT(DISTINCT(source_id)) FILTER (WHERE entity_type = 'INVOICE' AND action_status = 'COMPLETED') AS total_created_invoices,
       0 AS total_updated_invoices,
-      COUNT(DISTINCT(source_id)) FILTER (WHERE entity_type = 'INVOICE' AND ((action_type = 'NON_MATCH' AND action_type_max = 'NON_MATCH') OR action_status = 'ERROR')) AS total_discarded_invoices,
+      COUNT(DISTINCT(source_id)) FILTER (WHERE entity_type = 'INVOICE' AND ((action_type = 'NON_MATCH' AND action_type_max = 'NON_MATCH') OR (action_type = 'MATCH' AND action_type_max = 'MATCH') OR action_status = 'ERROR')) AS total_discarded_invoices,
       COUNT(DISTINCT(source_id)) FILTER (WHERE entity_type = 'INVOICE' AND action_status = 'ERROR') AS total_invoices_errors
     FROM journal_records
 	    INNER JOIN (SELECT entity_id as entity_id_max, entity_type as entity_type_max, action_status as action_status_max,(array_agg(id ORDER BY array_position(array['CREATE', 'UPDATE', 'MODIFY', 'NON_MATCH'], action_type)))[1] as id,
 	    source_id as temp_source_id
         FROM journal_records
-        WHERE journal_records.job_execution_id = job_id
-			  GROUP BY source_id, entity_id, entity_type, action_status) AS actions
+        WHERE journal_records.job_execution_id = job_id AND action_type != 'MATCH'
+			  GROUP BY source_id, entity_id, entity_type, action_status
+			  UNION ALL
+			  SELECT entity_id as entity_id_max, entity_type as entity_type_max, action_status as action_status_max,(array_agg(id ORDER BY array_position(array['MATCH'], action_type)))[1] as id,
+        	    source_id as temp_source_id
+        FROM journal_records
+        WHERE journal_records.job_execution_id = job_id AND action_type = 'MATCH'
+        AND NOT EXISTS (SELECT 1 FROM journal_records WHERE journal_records.job_execution_id = job_id AND action_type NOT IN ('MATCH', 'PARSE'))
+        GROUP BY source_id, entity_id, entity_type, action_status) AS actions
       ON actions.id = journal_records.id AND actions.temp_source_id = journal_records.source_id
-      INNER JOIN (SELECT (array_agg(action_type ORDER BY array_position(array['CREATE', 'UPDATE', 'MODIFY', 'NON_MATCH'], action_type)))[1] as action_type_max, source_id as source_id_max, entity_type as entity_type_max
+      INNER JOIN (SELECT (array_agg(action_type ORDER BY array_position(array['CREATE', 'UPDATE', 'MODIFY', 'NON_MATCH', 'MATCH'], action_type)))[1] as action_type_max, source_id as source_id_max, entity_type as entity_type_max
         FROM journal_records
         WHERE journal_records.job_execution_id = job_id
         GROUP BY entity_type_max, source_id_max) AS action_type_by_source

--- a/mod-source-record-manager-server/src/main/resources/templates/db_scripts/create_get_job_log_entries_function.sql
+++ b/mod-source-record-manager-server/src/main/resources/templates/db_scripts/create_get_job_log_entries_function.sql
@@ -159,7 +159,14 @@ WHERE tmp.entity_type = ''ITEM''
   ),
   authorities AS (
     SELECT action_type, entity_id, temp_result.source_id, error, temp_result.job_execution_id, temp_result.title, temp_result.source_record_order
-    FROM temp_result WHERE entity_type = ''AUTHORITY''
+    FROM temp_result WHERE entity_type = ''AUTHORITY'' AND entity_id IS NOT NULL
+    UNION ALL
+    SELECT action_type, entity_id, temp_result.source_id, error, temp_result.job_execution_id, temp_result.title, temp_result.source_record_order
+    FROM temp_result
+    WHERE entity_type = ''AUTHORITY'' AND entity_id IS NULL AND NOT EXISTS
+        (SELECT 1
+         FROM temp_result as tr2
+         WHERE tr2.entity_type = ''AUTHORITY'' AND tr2.source_id = temp_result.source_id and tr2.entity_id IS NOT NULL)
   ),
   marc_authority AS (
     SELECT temp_result.job_execution_id, entity_id, title, source_record_order, action_type, error, source_id, tenant_id

--- a/mod-source-record-manager-server/src/main/resources/templates/db_scripts/create_get_job_log_entries_function.sql
+++ b/mod-source-record-manager-server/src/main/resources/templates/db_scripts/create_get_job_log_entries_function.sql
@@ -63,7 +63,7 @@ WITH
       SELECT entity_type as entity_type_max, entity_id as entity_id_max, action_status as action_status_max, max(error) AS error_max,
              (array_agg(id ORDER BY array_position(array[''CREATE'', ''UPDATE'', ''MODIFY''], action_type)))[1] AS id_max
       FROM journal_records
-      WHERE job_execution_id = ''%1$s'' AND entity_type NOT IN (''EDIFACT'', ''INVOICE'') AND action_type NOT IN (''NON_MATCH'', ''MATCH'', ''PARSE'')
+      WHERE job_execution_id = ''%1$s'' AND entity_type NOT IN (''EDIFACT'', ''INVOICE'') AND action_type NOT IN (''NON_MATCH'', ''MATCH'')
       GROUP BY entity_type, entity_id, action_status, source_id, source_record_order
     ) AS action_type_by_source ON journal_records.id = action_type_by_source.id_max
     UNION ALL
@@ -326,7 +326,7 @@ FROM (
          marc_holdings.title AS title,
          marc_holdings.entity_id AS marc_holdings_entity_id,
          marc_holdings.error AS marc_holdings_entity_error
-  FROM  marc_holdings WHERE entity_id IS NOT NULL
+  FROM  marc_holdings
 ) AS marc_holdings_info ON marc_holdings_info.source_id = records_actions.source_id
 
       LEFT JOIN (

--- a/mod-source-record-manager-server/src/main/resources/templates/db_scripts/create_get_job_log_entries_function.sql
+++ b/mod-source-record-manager-server/src/main/resources/templates/db_scripts/create_get_job_log_entries_function.sql
@@ -163,7 +163,14 @@ WHERE tmp.entity_type = ''ITEM''
   ),
   marc_authority AS (
     SELECT temp_result.job_execution_id, entity_id, title, source_record_order, action_type, error, source_id, tenant_id
-    FROM temp_result WHERE entity_type = ''MARC_AUTHORITY''
+    FROM temp_result WHERE entity_type = ''MARC_AUTHORITY'' AND entity_id IS NOT NULL
+    UNION ALL
+    SELECT temp_result.job_execution_id, entity_id, title, source_record_order, action_type, error, source_id, tenant_id
+    FROM temp_result
+    WHERE entity_type = ''MARC_AUTHORITY'' AND entity_id IS NULL AND NOT EXISTS
+        (SELECT 1
+         FROM temp_result as tr2
+         WHERE tr2.entity_type = ''MARC_AUTHORITY'' AND tr2.source_id = temp_result.source_id and tr2.entity_id IS NOT NULL)
   ),
   marc_holdings AS (
     SELECT temp_result.job_execution_id, entity_id, title, source_record_order, action_type, error, source_id, tenant_id

--- a/mod-source-record-manager-server/src/main/resources/templates/db_scripts/create_get_job_log_entries_function.sql
+++ b/mod-source-record-manager-server/src/main/resources/templates/db_scripts/create_get_job_log_entries_function.sql
@@ -53,7 +53,7 @@ WITH
   temp_result AS (
     SELECT id, job_execution_id, source_id, entity_type, entity_id, entity_hrid,
            CASE
-             WHEN error_max != '''' OR action_type = ''NON_MATCH'' THEN ''DISCARDED''
+             WHEN error_max != '''' OR action_type = ''NON_MATCH'' OR action_type = ''MATCH'' THEN ''DISCARDED''
              WHEN action_type = ''CREATE'' THEN ''CREATED''
              WHEN action_type IN (''UPDATE'', ''MODIFY'') THEN ''UPDATED''
              END AS action_type,
@@ -61,7 +61,7 @@ WITH
     FROM journal_records
            INNER JOIN (
       SELECT entity_type as entity_type_max, entity_id as entity_id_max, action_status as action_status_max, max(error) AS error_max,
-             (array_agg(id ORDER BY array_position(array[''CREATE'', ''UPDATE'', ''MODIFY'', ''NON_MATCH''], action_type)))[1] AS id_max
+             (array_agg(id ORDER BY array_position(array[''CREATE'', ''UPDATE'', ''MODIFY'', ''NON_MATCH'', ''MATCH''], action_type)))[1] AS id_max
       FROM journal_records
       WHERE job_execution_id = ''%1$s'' AND entity_type NOT IN (''EDIFACT'', ''INVOICE'')
       GROUP BY entity_type, entity_id, action_status, source_id, source_record_order
@@ -158,7 +158,7 @@ SELECT records_actions.job_execution_id AS job_execution_id,
        '''' as invoiceline_number,
        coalesce(rec_titles.title, marc_holdings_info.title) AS title,
        CASE
-         WHEN marc_errors_number != 0 OR marc_actions[array_length(marc_actions, 1)] = ''NON_MATCH'' THEN ''DISCARDED''
+         WHEN marc_errors_number != 0 OR marc_actions[array_length(marc_actions, 1)] = ''NON_MATCH'' OR marc_actions[array_length(marc_actions, 1)] = ''MATCH'' THEN ''DISCARDED''
          WHEN marc_actions[array_length(marc_actions, 1)] = ''CREATE'' THEN ''CREATED''
          WHEN marc_actions[array_length(marc_actions, 1)] = ''UPDATE'' THEN ''UPDATED''
          END AS source_record_action_status,

--- a/mod-source-record-manager-server/src/main/resources/templates/db_scripts/create_get_record_processing_log_function.sql
+++ b/mod-source-record-manager-server/src/main/resources/templates/db_scripts/create_get_record_processing_log_function.sql
@@ -6,7 +6,7 @@ AS $$
 BEGIN
     RETURN QUERY
         WITH temp_result AS (SELECT id, journal_records.job_execution_id, journal_records.source_id, journal_records.entity_type, journal_records.entity_id, journal_records.entity_hrid,
-    					 CASE WHEN error_max != ''  OR action_type = 'NON_MATCH'
+    					 CASE WHEN error_max != '' OR action_type = 'NON_MATCH' OR action_type = 'MATCH'
                     		THEN 'DISCARDED'
                     WHEN action_type = 'CREATE'
                     		THEN 'CREATED'
@@ -17,14 +17,31 @@ BEGIN
                  END AS action_type, journal_records.action_status, journal_records.action_date, journal_records.source_record_order, journal_records.error, journal_records.title, journal_records.tenant_id, journal_records.instance_id, journal_records.holdings_id, journal_records.order_id, journal_records.permanent_location_id
     		FROM journal_records
     		INNER JOIN
-    		(SELECT entity_type as entity_type_max, entity_id as entity_id_max,action_status as action_status_max, max(error) AS error_max,(array_agg(id ORDER BY array_position(array['CREATE', 'UPDATE', 'MODIFY', 'NON_MATCH'], action_type)))[1] AS id_max
+    		(SELECT entity_type as entity_type_max, entity_id as entity_id_max,action_status as action_status_max, max(error) AS error_max,(array_agg(id ORDER BY array_position(array['CREATE', 'UPDATE', 'MODIFY'], action_type)))[1] AS id_max
             	FROM journal_records
-    			WHERE journal_records.job_execution_id = jobExecutionId AND journal_records.source_id = recordId AND journal_records.entity_type NOT IN ('EDIFACT', 'INVOICE')
-            	GROUP BY entity_type,entity_id,action_status) AS action_type_by_source
-    		ON journal_records.id = action_type_by_source.id_max)
+    			WHERE journal_records.job_execution_id = jobExecutionId AND journal_records.source_id = recordId AND journal_records.entity_type NOT IN ('EDIFACT', 'INVOICE') AND action_type NOT IN ('NON_MATCH', 'MATCH')
+            	GROUP BY entity_type,entity_id,action_status) AS action_type_by_source ON journal_records.id = action_type_by_source.id_max
+    		UNION ALL
+        SELECT id, journal_records.job_execution_id, journal_records.source_id, journal_records.entity_type, journal_records.entity_id, journal_records.entity_hrid,
+    					 CASE WHEN error_max != '' OR action_type = 'NON_MATCH' OR action_type = 'MATCH'
+                    		THEN 'DISCARDED'
+                    WHEN action_type = 'CREATE'
+                    		THEN 'CREATED'
+                    WHEN action_type = 'UPDATE'
+                    		THEN 'UPDATED'
+                    WHEN action_type = 'PARSE'
+                      then 'PARSED'
+                 END AS action_type, journal_records.action_status, journal_records.action_date, journal_records.source_record_order, journal_records.error, journal_records.title, journal_records.tenant_id, journal_records.instance_id, journal_records.holdings_id, journal_records.order_id, journal_records.permanent_location_id
+    		FROM journal_records
+    		INNER JOIN
+    		(SELECT entity_type as entity_type_max, entity_id as entity_id_max,action_status as action_status_max, max(error) AS error_max,(array_agg(id ORDER BY array_position(array['NON_MATCH', 'MATCH'], action_type)))[1] AS id_max
+            	FROM journal_records
+    			WHERE journal_records.job_execution_id = jobExecutionId AND journal_records.source_id = recordId AND journal_records.entity_type NOT IN ('EDIFACT', 'INVOICE') AND action_type IN ('NON_MATCH', 'MATCH')
+    			AND NOT EXISTS (SELECT 1 FROM journal_records WHERE journal_records.job_execution_id = jobExecutionId AND journal_records.source_id = recordId AND action_type NOT IN ('NON_MATCH', 'MATCH', 'PARSE'))
+            	GROUP BY entity_type,entity_id,action_status) AS action_type_by_source ON journal_records.id = action_type_by_source.id_max)
         (SELECT
     	      COALESCE(marc.job_execution_id,instances.job_execution_id,holdings.job_execution_id,items.job_execution_id) AS job_execution_id,
-    	      marc.source_id as incoming_record_id,
+    	      COALESCE(marc.source_id, instances.source_id, holdings.source_id, items.source_id, authority.source_id) as incoming_record_id,
             marc_entity_id::uuid AS source_id,
     	      COALESCE(marc.source_record_order,instances.source_record_order,holdings.source_record_order,items.source_record_order) AS source_record_order,
     	      COALESCE(marc.title,instances.title,holdings.title,items.title) AS title,

--- a/mod-source-record-manager-server/src/main/resources/templates/db_scripts/schema.json
+++ b/mod-source-record-manager-server/src/main/resources/templates/db_scripts/schema.json
@@ -290,7 +290,7 @@
     {
       "run": "after",
       "snippetPath": "create_get_job_log_entries_function.sql",
-      "fromModuleVersion": "mod-source-record-manager-3.8.2"
+      "fromModuleVersion": "mod-source-record-manager-3.8.3"
     },
     {
       "run": "after",

--- a/mod-source-record-manager-server/src/main/resources/templates/db_scripts/schema.json
+++ b/mod-source-record-manager-server/src/main/resources/templates/db_scripts/schema.json
@@ -296,6 +296,11 @@
       "run": "after",
       "snippetPath": "create_get_record_processing_log_function.sql",
       "fromModuleVersion": "mod-source-record-manager-3.8.3"
+    },
+    {
+      "run": "after",
+      "snippetPath": "create_get_job_execution_summary_function.sql",
+      "fromModuleVersion": "mod-source-record-manager-3.8.3"
     }
   ]
 }

--- a/mod-source-record-manager-server/src/main/resources/templates/db_scripts/schema.json
+++ b/mod-source-record-manager-server/src/main/resources/templates/db_scripts/schema.json
@@ -290,12 +290,12 @@
     {
       "run": "after",
       "snippetPath": "create_get_job_log_entries_function.sql",
-      "fromModuleVersion": "mod-source-record-manager-3.9.0"
+      "fromModuleVersion": "mod-source-record-manager-3.8.2"
     },
     {
       "run": "after",
       "snippetPath": "create_get_record_processing_log_function.sql",
-      "fromModuleVersion": "mod-source-record-manager-3.9.0"
+      "fromModuleVersion": "mod-source-record-manager-3.8.2"
     }
   ]
 }

--- a/mod-source-record-manager-server/src/main/resources/templates/db_scripts/schema.json
+++ b/mod-source-record-manager-server/src/main/resources/templates/db_scripts/schema.json
@@ -291,6 +291,11 @@
       "run": "after",
       "snippetPath": "create_get_job_log_entries_function.sql",
       "fromModuleVersion": "mod-source-record-manager-3.9.0"
+    },
+    {
+      "run": "after",
+      "snippetPath": "create_get_record_processing_log_function.sql",
+      "fromModuleVersion": "mod-source-record-manager-3.9.0"
     }
   ]
 }

--- a/mod-source-record-manager-server/src/main/resources/templates/db_scripts/schema.json
+++ b/mod-source-record-manager-server/src/main/resources/templates/db_scripts/schema.json
@@ -286,6 +286,11 @@
       "run": "after",
       "snippetPath": "create_get_job_log_entries_function.sql",
       "fromModuleVersion": "mod-source-record-manager-3.8.0"
+    },
+    {
+      "run": "after",
+      "snippetPath": "create_get_job_log_entries_function.sql",
+      "fromModuleVersion": "mod-source-record-manager-3.9.0"
     }
   ]
 }

--- a/mod-source-record-manager-server/src/main/resources/templates/db_scripts/schema.json
+++ b/mod-source-record-manager-server/src/main/resources/templates/db_scripts/schema.json
@@ -295,7 +295,7 @@
     {
       "run": "after",
       "snippetPath": "create_get_record_processing_log_function.sql",
-      "fromModuleVersion": "mod-source-record-manager-3.8.2"
+      "fromModuleVersion": "mod-source-record-manager-3.8.3"
     }
   ]
 }

--- a/mod-source-record-manager-server/src/test/java/org/folio/rest/impl/metadataProvider/MetaDataProviderRecordProcessingLogCollectionAPITest.java
+++ b/mod-source-record-manager-server/src/test/java/org/folio/rest/impl/metadataProvider/MetaDataProviderRecordProcessingLogCollectionAPITest.java
@@ -401,7 +401,7 @@ public class MetaDataProviderRecordProcessingLogCollectionAPITest extends Abstra
 
     Future<JournalRecord> future = Future.succeededFuture()
       .compose(v -> createJournalRecord(createdJobExecution.getId(), sourceRecordId, null, null, recordTitle, 0, CREATE, MARC_BIBLIOGRAPHIC, COMPLETED, null, null))
-      .compose(v -> createJournalRecord(createdJobExecution.getId(), sourceRecordId, null, "in00000000001", null, 0, NON_MATCH, INSTANCE, COMPLETED, null, null))
+      .compose(v -> createJournalRecord(createdJobExecution.getId(), sourceRecordId, null, null, null, 0, NON_MATCH, INSTANCE, COMPLETED, null, null))
       .onSuccess(v -> async.complete())
       .onFailure(context::fail);
 
@@ -535,7 +535,7 @@ public class MetaDataProviderRecordProcessingLogCollectionAPITest extends Abstra
     String authorityEntityId = UUID.randomUUID().toString();
 
     Future<JournalRecord> future = Future.succeededFuture()
-      .compose(v -> createJournalRecord(createdJobExecution.getId(), sourceRecordId, authorityEntityId, null, recordTitle, 0, MATCH, MARC_AUTHORITY, ERROR, "errorMsg", null))
+      .compose(v -> createJournalRecord(createdJobExecution.getId(), sourceRecordId, null, null, recordTitle, 0, MATCH, MARC_AUTHORITY, ERROR, "errorMsg", null))
       .onFailure(context::fail);
 
     future.onComplete(ar -> context.verify(v -> {
@@ -548,7 +548,6 @@ public class MetaDataProviderRecordProcessingLogCollectionAPITest extends Abstra
         .body("entries.size()", is(1))
         .body("totalRecords", is(1))
         .body("entries[0].jobExecutionId", is(createdJobExecution.getId()))
-        .body("entries[0].sourceRecordId", is(authorityEntityId))
         .body("entries[0].incomingRecordId", is(sourceRecordId))
         .body("entries[0].sourceRecordType", is(MARC_AUTHORITY.value()))
         .body("entries[0].sourceRecordTitle", is(recordTitle))
@@ -1683,7 +1682,7 @@ public class MetaDataProviderRecordProcessingLogCollectionAPITest extends Abstra
 
     Future<JournalRecord> future = Future.succeededFuture()
       .compose(v -> createJournalRecord(createdJobExecution.getId(), sourceRecordId, null, null, recordTitle, 0, MATCH, MARC_BIBLIOGRAPHIC, COMPLETED, null, null))
-      .compose(v -> createJournalRecord(createdJobExecution.getId(), sourceRecordId, instanceEntityId, null, recordTitle, 0, MATCH, INSTANCE, COMPLETED, null, null))
+      .compose(v -> createJournalRecord(createdJobExecution.getId(), sourceRecordId, null, null, recordTitle, 0, MATCH, INSTANCE, COMPLETED, null, null))
       .compose(v -> createJournalRecord(createdJobExecution.getId(), sourceRecordId, holdingsEntityId, holdingsHrId, recordTitle, 0, CREATE, HOLDINGS, COMPLETED, null, null))
       .onFailure(context::fail);
 
@@ -1725,7 +1724,7 @@ public class MetaDataProviderRecordProcessingLogCollectionAPITest extends Abstra
     String itemHrId = "itemHrid";
 
     Future<JournalRecord> future = Future.succeededFuture()
-      .compose(v -> createJournalRecord(createdJobExecution.getId(), sourceRecordId, holdingsEntityId, null, recordTitle, 0, MATCH, HOLDINGS, COMPLETED, null, null))
+      .compose(v -> createJournalRecord(createdJobExecution.getId(), sourceRecordId, null, null, recordTitle, 0, MATCH, HOLDINGS, COMPLETED, null, null))
       .compose(v -> createJournalRecord(createdJobExecution.getId(), sourceRecordId, itemEntityId, itemHrId, recordTitle, 0, CREATE, ITEM, COMPLETED, null, null))
       .onFailure(context::fail);
 

--- a/mod-source-record-manager-server/src/test/java/org/folio/rest/impl/metadataProvider/MetaDataProviderRecordProcessingLogCollectionAPITest.java
+++ b/mod-source-record-manager-server/src/test/java/org/folio/rest/impl/metadataProvider/MetaDataProviderRecordProcessingLogCollectionAPITest.java
@@ -237,6 +237,160 @@ public class MetaDataProviderRecordProcessingLogCollectionAPITest extends Abstra
   }
 
   @Test
+  public void shouldReturnDiscardedForMarcBibAndInstanceIfMarcBibMatchedAndNoOtherAction(TestContext context) {
+    Async async = context.async();
+    JobExecution createdJobExecution = constructAndPostInitJobExecutionRqDto(1).getJobExecutions().get(0);
+    String sourceRecordId = UUID.randomUUID().toString();
+    String recordTitle = "test title";
+
+    Future<JournalRecord> future = Future.succeededFuture()
+      .compose(v -> createJournalRecord(createdJobExecution.getId(), sourceRecordId, null, null, recordTitle, 0, MATCH, MARC_BIBLIOGRAPHIC, COMPLETED, null, null))
+      .compose(v -> createJournalRecord(createdJobExecution.getId(), sourceRecordId, null, null, recordTitle, 0, MATCH, INSTANCE, COMPLETED, null, null))
+      .onFailure(context::fail);
+
+    future.onComplete(ar -> context.verify(v -> {
+      RestAssured.given()
+        .spec(spec)
+        .when()
+        .get(GET_JOB_EXECUTION_JOURNAL_RECORDS_PATH + "/" + createdJobExecution.getId())
+        .then()
+        .statusCode(HttpStatus.SC_OK)
+        .body("entries", hasSize(1))
+        .body("totalRecords", is(1))
+        .body("entries[0].jobExecutionId", is(createdJobExecution.getId()))
+        .body("entries[0].incomingRecordId", is(sourceRecordId))
+        .body("entries[0].sourceRecordTitle", is(recordTitle))
+        .body("entries[0].sourceRecordActionStatus", is(ActionStatus.DISCARDED.value()))
+        .body("entries[0].relatedInstanceInfo.actionStatus", is(ActionStatus.DISCARDED.value()));
+
+      async.complete();
+    }));
+  }
+
+  @Test
+  public void shouldReturnDiscardedForMarcBibAndInstanceIfMarcBibNotMatched(TestContext context) {
+    Async async = context.async();
+    JobExecution createdJobExecution = constructAndPostInitJobExecutionRqDto(1).getJobExecutions().get(0);
+    String sourceRecordId = UUID.randomUUID().toString();
+    String recordTitle = "test title";
+
+    Future<JournalRecord> future = Future.succeededFuture()
+      .compose(v -> createJournalRecord(createdJobExecution.getId(), sourceRecordId, null, null, recordTitle, 0, NON_MATCH, MARC_BIBLIOGRAPHIC, COMPLETED, null, null))
+      .compose(v -> createJournalRecord(createdJobExecution.getId(), sourceRecordId, null, null, recordTitle, 0, NON_MATCH, INSTANCE, COMPLETED, null, null))
+      .onFailure(context::fail);
+
+    future.onComplete(ar -> context.verify(v -> {
+      RestAssured.given()
+        .spec(spec)
+        .when()
+        .get(GET_JOB_EXECUTION_JOURNAL_RECORDS_PATH + "/" + createdJobExecution.getId())
+        .then()
+        .statusCode(HttpStatus.SC_OK)
+        .body("entries", hasSize(1))
+        .body("totalRecords", is(1))
+        .body("entries[0].jobExecutionId", is(createdJobExecution.getId()))
+        .body("entries[0].incomingRecordId", is(sourceRecordId))
+        .body("entries[0].sourceRecordTitle", is(recordTitle))
+        .body("entries[0].sourceRecordActionStatus", is(ActionStatus.DISCARDED.value()))
+        .body("entries[0].relatedInstanceInfo.actionStatus", is(ActionStatus.DISCARDED.value()));
+
+      async.complete();
+    }));
+  }
+
+  @Test
+  public void shouldReturnDiscardedForHoldingsIfHoldingsMatchedAndNoOtherAction(TestContext context) {
+    Async async = context.async();
+    JobExecution createdJobExecution = constructAndPostInitJobExecutionRqDto(1).getJobExecutions().get(0);
+    String sourceRecordId = UUID.randomUUID().toString();
+    String recordTitle = "test title";
+
+    Future<JournalRecord> future = Future.succeededFuture()
+      .compose(v -> createJournalRecord(createdJobExecution.getId(), sourceRecordId, null, null, recordTitle, 0, MATCH, HOLDINGS, COMPLETED, null, null))
+      .onFailure(context::fail);
+
+    future.onComplete(ar -> context.verify(v -> {
+      RestAssured.given()
+        .spec(spec)
+        .when()
+        .get(GET_JOB_EXECUTION_JOURNAL_RECORDS_PATH + "/" + createdJobExecution.getId())
+        .then()
+        .statusCode(HttpStatus.SC_OK)
+        .body("entries", hasSize(1))
+        .body("totalRecords", is(1))
+        .body("entries[0].jobExecutionId", is(createdJobExecution.getId()))
+        .body("entries[0].incomingRecordId", is(sourceRecordId))
+        .body("entries[0].sourceRecordTitle", is(recordTitle))
+        .body("entries[0].sourceRecordActionStatus", is(emptyOrNullString()))
+        .body("entries[0].relatedHoldingsInfo.size()", is(1))
+        .body("entries[0].relatedHoldingsInfo[0].actionStatus", is(ActionStatus.DISCARDED.value()));
+
+      async.complete();
+    }));
+  }
+
+  @Test
+  public void shouldReturnDiscardedForItemIfItemMatchedAndNoOtherAction(TestContext context) {
+    Async async = context.async();
+    JobExecution createdJobExecution = constructAndPostInitJobExecutionRqDto(1).getJobExecutions().get(0);
+    String sourceRecordId = UUID.randomUUID().toString();
+    String recordTitle = "test title";
+
+    Future<JournalRecord> future = Future.succeededFuture()
+      .compose(v -> createJournalRecord(createdJobExecution.getId(), sourceRecordId, null, null, recordTitle, 0, MATCH, ITEM, COMPLETED, null, null))
+      .onFailure(context::fail);
+
+    future.onComplete(ar -> context.verify(v -> {
+      RestAssured.given()
+        .spec(spec)
+        .when()
+        .get(GET_JOB_EXECUTION_JOURNAL_RECORDS_PATH + "/" + createdJobExecution.getId())
+        .then()
+        .statusCode(HttpStatus.SC_OK)
+        .body("entries", hasSize(1))
+        .body("totalRecords", is(1))
+        .body("entries[0].jobExecutionId", is(createdJobExecution.getId()))
+        .body("entries[0].incomingRecordId", is(sourceRecordId))
+        .body("entries[0].sourceRecordTitle", is(recordTitle))
+        .body("entries[0].sourceRecordActionStatus", is(emptyOrNullString()))
+        .body("entries[0].relatedItemInfo.size()", is(1))
+        .body("entries[0].relatedItemInfo[0].actionStatus", is(ActionStatus.DISCARDED.value()));
+
+      async.complete();
+    }));
+  }
+
+  @Test
+  public void shouldReturnDiscardedForAuthorityIfAuthorityMatchedAndNoOtherAction(TestContext context) {
+    Async async = context.async();
+    JobExecution createdJobExecution = constructAndPostInitJobExecutionRqDto(1).getJobExecutions().get(0);
+    String sourceRecordId = UUID.randomUUID().toString();
+    String recordTitle = "test title";
+
+    Future<JournalRecord> future = Future.succeededFuture()
+      .compose(v -> createJournalRecord(createdJobExecution.getId(), sourceRecordId, null, null, recordTitle, 0, MATCH, AUTHORITY, COMPLETED, null, null))
+      .onFailure(context::fail);
+
+    future.onComplete(ar -> context.verify(v -> {
+      RestAssured.given()
+        .spec(spec)
+        .when()
+        .get(GET_JOB_EXECUTION_JOURNAL_RECORDS_PATH + "/" + createdJobExecution.getId())
+        .then()
+        .statusCode(HttpStatus.SC_OK)
+        .body("entries", hasSize(1))
+        .body("totalRecords", is(1))
+        .body("entries[0].jobExecutionId", is(createdJobExecution.getId()))
+        .body("entries[0].incomingRecordId", is(sourceRecordId))
+        .body("entries[0].sourceRecordTitle", is(recordTitle))
+        .body("entries[0].sourceRecordActionStatus", is(emptyOrNullString()))
+        .body("entries[0].relatedAuthorityInfo.actionStatus", is(ActionStatus.DISCARDED.value()));
+
+      async.complete();
+    }));
+  }
+
+  @Test
   public void shouldReturnInstanceDiscardedWhenInstanceWasNotMatched(TestContext context) {
     Async async = context.async();
     JobExecution createdJobExecution = constructAndPostInitJobExecutionRqDto(1).getJobExecutions().get(0);

--- a/mod-source-record-manager-server/src/test/java/org/folio/rest/impl/metadataProvider/MetaDataProviderRecordProcessingLogCollectionAPITest.java
+++ b/mod-source-record-manager-server/src/test/java/org/folio/rest/impl/metadataProvider/MetaDataProviderRecordProcessingLogCollectionAPITest.java
@@ -368,6 +368,7 @@ public class MetaDataProviderRecordProcessingLogCollectionAPITest extends Abstra
     String recordTitle = "test title";
 
     Future<JournalRecord> future = Future.succeededFuture()
+      .compose(v -> createJournalRecord(createdJobExecution.getId(), sourceRecordId, null, null, recordTitle, 0, MATCH, MARC_AUTHORITY, COMPLETED, null, null))
       .compose(v -> createJournalRecord(createdJobExecution.getId(), sourceRecordId, null, null, recordTitle, 0, MATCH, AUTHORITY, COMPLETED, null, null))
       .onFailure(context::fail);
 
@@ -383,7 +384,7 @@ public class MetaDataProviderRecordProcessingLogCollectionAPITest extends Abstra
         .body("entries[0].jobExecutionId", is(createdJobExecution.getId()))
         .body("entries[0].incomingRecordId", is(sourceRecordId))
         .body("entries[0].sourceRecordTitle", is(recordTitle))
-        .body("entries[0].sourceRecordActionStatus", is(emptyOrNullString()))
+        .body("entries[0].sourceRecordActionStatus", is(ActionStatus.DISCARDED.value()))
         .body("entries[0].relatedAuthorityInfo.actionStatus", is(ActionStatus.DISCARDED.value()));
 
       async.complete();

--- a/mod-source-record-manager-server/src/test/java/org/folio/rest/impl/metadataProvider/MetaDataProviderRecordProcessingLogCollectionAPITest.java
+++ b/mod-source-record-manager-server/src/test/java/org/folio/rest/impl/metadataProvider/MetaDataProviderRecordProcessingLogCollectionAPITest.java
@@ -247,6 +247,7 @@ public class MetaDataProviderRecordProcessingLogCollectionAPITest extends Abstra
 
     Future<JournalRecord> future = Future.succeededFuture()
       .compose(v -> createJournalRecord(createdJobExecution.getId(), sourceRecordId, null, null, recordTitle, 0, NON_MATCH, MARC_AUTHORITY, COMPLETED, null, null))
+      .compose(v -> createJournalRecord(createdJobExecution.getId(), sourceRecordId, null, null, recordTitle, 0, NON_MATCH, AUTHORITY, COMPLETED, null, null))
       .compose(v -> createJournalRecord(createdJobExecution.getId(), sourceRecordId, marcAuthorityEntityId, null, recordTitle, 0, CREATE, MARC_AUTHORITY, COMPLETED, null, null))
       .compose(v -> createJournalRecord(createdJobExecution.getId(), sourceRecordId, authorityEntityId, null, recordTitle, 0, CREATE, AUTHORITY, COMPLETED, null, null))
       .onFailure(context::fail);

--- a/mod-source-record-manager-server/src/test/java/org/folio/rest/impl/metadataProvider/MetadataProviderJobExecutionAPITest.java
+++ b/mod-source-record-manager-server/src/test/java/org/folio/rest/impl/metadataProvider/MetadataProviderJobExecutionAPITest.java
@@ -60,8 +60,10 @@ import static org.folio.rest.jaxrs.model.JobProfileInfo.DataType.MARC;
 import static org.folio.rest.jaxrs.model.JournalRecord.ActionStatus.COMPLETED;
 import static org.folio.rest.jaxrs.model.JournalRecord.ActionStatus.ERROR;
 import static org.folio.rest.jaxrs.model.JournalRecord.ActionType.CREATE;
+import static org.folio.rest.jaxrs.model.JournalRecord.ActionType.MATCH;
 import static org.folio.rest.jaxrs.model.JournalRecord.ActionType.MODIFY;
 import static org.folio.rest.jaxrs.model.JournalRecord.ActionType.NON_MATCH;
+import static org.folio.rest.jaxrs.model.JournalRecord.ActionType.PARSE;
 import static org.folio.rest.jaxrs.model.JournalRecord.ActionType.UPDATE;
 import static org.folio.rest.jaxrs.model.JournalRecord.EntityType.AUTHORITY;
 import static org.folio.rest.jaxrs.model.JournalRecord.EntityType.EDIFACT;
@@ -74,6 +76,7 @@ import static org.folio.rest.jaxrs.model.JournalRecord.EntityType.MARC_BIBLIOGRA
 import static org.folio.rest.jaxrs.model.JournalRecord.EntityType.PO_LINE;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.empty;
+import static org.hamcrest.Matchers.emptyOrNullString;
 import static org.hamcrest.Matchers.emptyString;
 import static org.hamcrest.Matchers.everyItem;
 import static org.hamcrest.Matchers.greaterThan;
@@ -81,6 +84,7 @@ import static org.hamcrest.Matchers.greaterThanOrEqualTo;
 import static org.hamcrest.Matchers.hasItem;
 import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.isEmptyString;
 import static org.hamcrest.Matchers.lessThan;
 import static org.hamcrest.Matchers.lessThanOrEqualTo;
 import static org.hamcrest.Matchers.not;
@@ -1230,6 +1234,201 @@ public class MetadataProviderJobExecutionAPITest extends AbstractRestTest {
         .body("instanceSummary.totalErrors", is(1))
         .body("totalErrors", is(1));
 
+      async.complete();
+    }));
+  }
+
+  @Test
+  public void shouldReturnDiscardedForMarcBibAndInstanceIfMarcBibMatchedAndNoOtherAction(TestContext context) {
+    Async async = context.async();
+    JobExecution createdJobExecution = constructAndPostInitJobExecutionRqDto(1).getJobExecutions().get(0);
+    String sourceRecordId = UUID.randomUUID().toString();
+    String recordTitle = "test title";
+
+    Future<JournalRecord> future = Future.succeededFuture()
+      .compose(v -> createJournalRecord(createdJobExecution.getId(), sourceRecordId, null, null, recordTitle, 0, MATCH, MARC_BIBLIOGRAPHIC, COMPLETED, null))
+      .compose(v -> createJournalRecord(createdJobExecution.getId(), sourceRecordId, null, null, recordTitle, 0, MATCH, INSTANCE, COMPLETED, null))
+      .onFailure(context::fail);
+
+    future.onComplete(ar -> context.verify(v -> {
+      RestAssured.given()
+        .spec(spec)
+        .when()
+        .get(GET_JOB_EXECUTION_SUMMARY_PATH + "/" + createdJobExecution.getId())
+        .then()
+        .statusCode(HttpStatus.SC_OK)
+        .body("sourceRecordSummary.totalCreatedEntities", is(0))
+        .body("sourceRecordSummary.totalUpdatedEntities", is(0))
+        .body("sourceRecordSummary.totalDiscardedEntities", is(1))
+        .body("sourceRecordSummary.totalErrors", is(0))
+        .body("instanceSummary.totalCreatedEntities", is(0))
+        .body("instanceSummary.totalUpdatedEntities", is(0))
+        .body("instanceSummary.totalDiscardedEntities", is(1))
+        .body("instanceSummary.totalErrors", is(0))
+        .body("totalErrors", is(0));
+
+      async.complete();
+    }));
+  }
+
+  @Test
+  public void shouldReturnDiscardedForHoldingsIfHoldingsMatchedAndNoOtherAction(TestContext context) {
+    Async async = context.async();
+    JobExecution createdJobExecution = constructAndPostInitJobExecutionRqDto(1).getJobExecutions().get(0);
+    String sourceRecordId = UUID.randomUUID().toString();
+    String recordTitle = "test title";
+
+    Future<JournalRecord> future = Future.succeededFuture()
+      .compose(v -> createJournalRecord(createdJobExecution.getId(), sourceRecordId, null, null, null, 0, PARSE, null, COMPLETED, null))
+      .compose(v -> createJournalRecord(createdJobExecution.getId(), sourceRecordId, null, null, recordTitle, 0, MATCH, HOLDINGS, COMPLETED, null))
+      .onFailure(context::fail);
+
+    future.onComplete(ar -> context.verify(v -> {
+      RestAssured.given()
+        .spec(spec)
+        .when()
+        .get(GET_JOB_EXECUTION_SUMMARY_PATH + "/" + createdJobExecution.getId())
+        .then()
+        .statusCode(HttpStatus.SC_OK)
+        .body("holdingSummary.totalCreatedEntities", is(0))
+        .body("holdingSummary.totalUpdatedEntities", is(0))
+        .body("holdingSummary.totalDiscardedEntities", is(1))
+        .body("holdingSummary.totalErrors", is(0))
+        .body("totalErrors", is(0));
+
+      async.complete();
+    }));
+  }
+
+  @Test
+  public void shouldReturnDiscardedForItemIfItemMatchedAndNoOtherAction(TestContext context) {
+    Async async = context.async();
+    JobExecution createdJobExecution = constructAndPostInitJobExecutionRqDto(1).getJobExecutions().get(0);
+    String sourceRecordId = UUID.randomUUID().toString();
+    String recordTitle = "test title";
+
+    Future<JournalRecord> future = Future.succeededFuture()
+      .compose(v -> createJournalRecord(createdJobExecution.getId(), sourceRecordId, null, null, null, 0, PARSE, null, COMPLETED, null))
+      .compose(v -> createJournalRecord(createdJobExecution.getId(), sourceRecordId, null, null, recordTitle, 0, MATCH, ITEM, COMPLETED, null))
+      .onFailure(context::fail);
+
+    future.onComplete(ar -> context.verify(v -> {
+      RestAssured.given()
+        .spec(spec)
+        .when()
+        .get(GET_JOB_EXECUTION_SUMMARY_PATH + "/" + createdJobExecution.getId())
+        .then()
+        .statusCode(HttpStatus.SC_OK)
+        .body("itemSummary.totalCreatedEntities", is(0))
+        .body("itemSummary.totalUpdatedEntities", is(0))
+        .body("itemSummary.totalDiscardedEntities", is(1))
+        .body("itemSummary.totalErrors", is(0))
+        .body("totalErrors", is(0));
+
+      async.complete();
+    }));
+  }
+
+  @Test
+  public void shouldReturnDiscardedForAuthorityIfAuthorityMatchedAndNoOtherAction(TestContext context) {
+    Async async = context.async();
+    JobExecution createdJobExecution = constructAndPostInitJobExecutionRqDto(1).getJobExecutions().get(0);
+    String sourceRecordId = UUID.randomUUID().toString();
+    String recordTitle = "test title";
+
+    Future<JournalRecord> future = Future.succeededFuture()
+      .compose(v -> createJournalRecord(createdJobExecution.getId(), sourceRecordId, null, null, null, 0, PARSE, null, COMPLETED, null))
+      .compose(v -> createJournalRecord(createdJobExecution.getId(), sourceRecordId, null, null, recordTitle, 0, MATCH, MARC_AUTHORITY, COMPLETED, null))
+      .compose(v -> createJournalRecord(createdJobExecution.getId(), sourceRecordId, null, null, recordTitle, 0, MATCH, AUTHORITY, COMPLETED, null))
+      .onFailure(context::fail);
+
+    future.onComplete(ar -> context.verify(v -> {
+      RestAssured.given()
+        .spec(spec)
+        .when()
+        .get(GET_JOB_EXECUTION_SUMMARY_PATH + "/" + createdJobExecution.getId())
+        .then()
+        .statusCode(HttpStatus.SC_OK)
+        .body("authoritySummary.totalCreatedEntities", is(0))
+        .body("authoritySummary.totalUpdatedEntities", is(0))
+        .body("authoritySummary.totalDiscardedEntities", is(1))
+        .body("authoritySummary.totalErrors", is(0))
+        .body("totalErrors", is(0));
+      async.complete();
+    }));
+  }
+
+  @Test
+  public void shouldNotReturnDiscardedForMarcBibAndInstanceIfHoldingsCreatedOnMatchByInstance(TestContext context) {
+    Async async = context.async();
+    JobExecution createdJobExecution = constructAndPostInitJobExecutionRqDto(1).getJobExecutions().get(0);
+    String sourceRecordId = UUID.randomUUID().toString();
+    String recordTitle = "test title";
+    String holdingsEntityId = UUID.randomUUID().toString();
+    String holdingsHrId = "holdingsHrid";
+
+    Future<JournalRecord> future = Future.succeededFuture()
+      .compose(v -> createJournalRecord(createdJobExecution.getId(), sourceRecordId, null, null, recordTitle, 0, MATCH, MARC_BIBLIOGRAPHIC, COMPLETED, null))
+      .compose(v -> createJournalRecord(createdJobExecution.getId(), sourceRecordId, null, null, recordTitle, 0, MATCH, INSTANCE, COMPLETED, null))
+      .compose(v -> createJournalRecord(createdJobExecution.getId(), sourceRecordId, holdingsEntityId, holdingsHrId, recordTitle, 0, CREATE, HOLDINGS, COMPLETED, null))
+      .onFailure(context::fail);
+
+    future.onComplete(ar -> context.verify(v -> {
+      RestAssured.given()
+        .spec(spec)
+        .when()
+        .get(GET_JOB_EXECUTION_SUMMARY_PATH + "/" + createdJobExecution.getId())
+        .then()
+        .statusCode(HttpStatus.SC_OK)
+        .body("sourceRecordSummary.totalCreatedEntities", emptyOrNullString())
+        .body("sourceRecordSummary.totalUpdatedEntities", emptyOrNullString())
+        .body("sourceRecordSummary.totalDiscardedEntities", emptyOrNullString())
+        .body("sourceRecordSummary.totalErrors", emptyOrNullString())
+        .body("instanceSummary.totalCreatedEntities", emptyOrNullString())
+        .body("instanceSummary.totalUpdatedEntities", emptyOrNullString())
+        .body("instanceSummary.totalDiscardedEntities", emptyOrNullString())
+        .body("instanceSummary.totalErrors", emptyOrNullString())
+        .body("holdingSummary.totalCreatedEntities", is(1))
+        .body("holdingSummary.totalUpdatedEntities", is(0))
+        .body("holdingSummary.totalDiscardedEntities", is(0))
+        .body("holdingSummary.totalErrors", is(0))
+        .body("totalErrors", is(0));
+      async.complete();
+    }));
+  }
+
+  @Test
+  public void shouldNotReturnDiscardedForHoldingsIfItemCreatedOnMatchByHoldings(TestContext context) {
+    Async async = context.async();
+    JobExecution createdJobExecution = constructAndPostInitJobExecutionRqDto(1).getJobExecutions().get(0);
+    String incomingRecordId = UUID.randomUUID().toString();
+    String recordTitle = "test title";
+
+    String itemEntityId = UUID.randomUUID().toString();
+    String itemHrId = "itemHrid";
+
+    Future<JournalRecord> future = Future.succeededFuture()
+      .compose(v -> createJournalRecord(createdJobExecution.getId(), incomingRecordId, null, null, null, 0, PARSE, null, COMPLETED, null))
+      .compose(v -> createJournalRecord(createdJobExecution.getId(), incomingRecordId, null, null, recordTitle, 0, MATCH, HOLDINGS, COMPLETED, null))
+      .compose(v -> createJournalRecord(createdJobExecution.getId(), incomingRecordId, itemEntityId, itemHrId, recordTitle, 0, CREATE, ITEM, COMPLETED, null))
+      .onFailure(context::fail);
+
+    future.onComplete(ar -> context.verify(v -> {
+      RestAssured.given()
+        .spec(spec)
+        .when()
+        .get(GET_JOB_EXECUTION_SUMMARY_PATH + "/" + createdJobExecution.getId())
+        .then()
+        .statusCode(HttpStatus.SC_OK)
+        .body("holdingSummary.totalCreatedEntities", emptyOrNullString())
+        .body("holdingSummary.totalUpdatedEntities", emptyOrNullString())
+        .body("holdingSummary.totalDiscardedEntities", emptyOrNullString())
+        .body("holdingSummary.totalErrors", emptyOrNullString())
+        .body("itemSummary.totalCreatedEntities", is(1))
+        .body("itemSummary.totalUpdatedEntities", is(0))
+        .body("itemSummary.totalDiscardedEntities", is(0))
+        .body("itemSummary.totalErrors", is(0))
+        .body("totalErrors", is(0));
       async.complete();
     }));
   }

--- a/mod-source-record-manager-server/src/test/java/org/folio/services/JournalUtilTest.java
+++ b/mod-source-record-manager-server/src/test/java/org/folio/services/JournalUtilTest.java
@@ -1163,7 +1163,7 @@ public class JournalUtilTest {
     context.put(INCOMING_RECORD_ID, incomingRecordId);
 
     DataImportEventPayload eventPayload = new DataImportEventPayload()
-      .withEventType("DI_ERROR")
+      .withEventType("DI_SRS_MARC_BIB_RECORD_NOT_MATCHED")
       .withContext(context);
 
     List<JournalRecord> journalRecords = JournalUtil.buildJournalRecordsByEvent(eventPayload,
@@ -1179,6 +1179,7 @@ public class JournalUtilTest {
     Assert.assertEquals(MARC_BIBLIOGRAPHIC, journalRecordMarcBib.getEntityType());
     Assert.assertEquals(NON_MATCH, journalRecordMarcBib.getActionType());
     Assert.assertEquals(COMPLETED, journalRecordMarcBib.getActionStatus());
+    Assert.assertNull(journalRecordMarcBib.getEntityId());
     Assert.assertNotNull(journalRecordMarcBib.getActionDate());
 
     JournalRecord journalRecordInstance= journalRecords.get(1);
@@ -1188,26 +1189,34 @@ public class JournalUtilTest {
     Assert.assertEquals(INSTANCE, journalRecordInstance.getEntityType());
     Assert.assertEquals(NON_MATCH, journalRecordInstance.getActionType());
     Assert.assertEquals(COMPLETED, journalRecordInstance.getActionStatus());
+    Assert.assertNull(journalRecordInstance.getEntityId());
     Assert.assertNotNull(journalRecordInstance.getActionDate());
   }
 
   @Test
   public void shouldBuildJournalRecordForMatchMarcBibliographic() throws JournalRecordMapperException {
     String recordId = UUID.randomUUID().toString();
+    String matchedId = UUID.randomUUID().toString();
     String snapshotId = UUID.randomUUID().toString();
+    String instanceId = UUID.randomUUID().toString();
     String incomingRecordId = UUID.randomUUID().toString();
 
     JsonObject recordJson = new JsonObject()
       .put("id", recordId)
       .put("snapshotId", snapshotId)
+      .put("matchedId", matchedId)
       .put("order", 1);
+
+    JsonObject instance = new JsonObject()
+      .put("id", instanceId);
 
     HashMap<String, String> context = new HashMap<>();
     context.put(MARC_BIBLIOGRAPHIC.value(), recordJson.encode());
+    context.put(INSTANCE.value(), instance.encode());
     context.put(INCOMING_RECORD_ID, incomingRecordId);
 
     DataImportEventPayload eventPayload = new DataImportEventPayload()
-      .withEventType("DI_ERROR")
+      .withEventType("DI_SRS_MARC_BIB_RECORD_MATCHED")
       .withContext(context);
 
     List<JournalRecord> journalRecords = JournalUtil.buildJournalRecordsByEvent(eventPayload,
@@ -1223,6 +1232,7 @@ public class JournalUtilTest {
     Assert.assertEquals(MARC_BIBLIOGRAPHIC, journalRecordMarcBib.getEntityType());
     Assert.assertEquals(MATCH, journalRecordMarcBib.getActionType());
     Assert.assertEquals(COMPLETED, journalRecordMarcBib.getActionStatus());
+    Assert.assertEquals(matchedId, journalRecordMarcBib.getEntityId());
     Assert.assertNotNull(journalRecordMarcBib.getActionDate());
 
     JournalRecord journalRecordInstance= journalRecords.get(1);
@@ -1232,6 +1242,7 @@ public class JournalUtilTest {
     Assert.assertEquals(INSTANCE, journalRecordInstance.getEntityType());
     Assert.assertEquals(MATCH, journalRecordInstance.getActionType());
     Assert.assertEquals(COMPLETED, journalRecordInstance.getActionStatus());
+    Assert.assertEquals(instanceId, journalRecordInstance.getEntityId());
     Assert.assertNotNull(journalRecordInstance.getActionDate());
   }
 
@@ -1251,7 +1262,7 @@ public class JournalUtilTest {
     context.put(INCOMING_RECORD_ID, incomingRecordId);
 
     DataImportEventPayload eventPayload = new DataImportEventPayload()
-      .withEventType("DI_ERROR")
+      .withEventType("DI_INVENTORY_INSTANCE_NOT_MATCHED")
       .withContext(context);
 
     List<JournalRecord> journalRecords = JournalUtil.buildJournalRecordsByEvent(eventPayload,
@@ -1267,6 +1278,7 @@ public class JournalUtilTest {
     Assert.assertEquals(INSTANCE, journalRecordInstance.getEntityType());
     Assert.assertEquals(NON_MATCH, journalRecordInstance.getActionType());
     Assert.assertEquals(COMPLETED, journalRecordInstance.getActionStatus());
+    Assert.assertNull(journalRecordInstance.getEntityId());
     Assert.assertNotNull(journalRecordInstance.getActionDate());
 
     JournalRecord journalRecordMarcBib = journalRecords.get(1);
@@ -1276,26 +1288,34 @@ public class JournalUtilTest {
     Assert.assertEquals(MARC_BIBLIOGRAPHIC, journalRecordMarcBib.getEntityType());
     Assert.assertEquals(NON_MATCH, journalRecordMarcBib.getActionType());
     Assert.assertEquals(COMPLETED, journalRecordMarcBib.getActionStatus());
+    Assert.assertNull(journalRecordMarcBib.getEntityId());
     Assert.assertNotNull(journalRecordMarcBib.getActionDate());
   }
 
   @Test
   public void shouldBuildJournalRecordForMatchInstance() throws JournalRecordMapperException {
     String recordId = UUID.randomUUID().toString();
+    String matchedId = UUID.randomUUID().toString();
+    String instanceId = UUID.randomUUID().toString();
     String snapshotId = UUID.randomUUID().toString();
     String incomingRecordId = UUID.randomUUID().toString();
 
     JsonObject recordJson = new JsonObject()
       .put("id", recordId)
       .put("snapshotId", snapshotId)
+      .put("matchedId", matchedId)
       .put("order", 1);
+
+    JsonObject instanceJson = new JsonObject()
+      .put("id", instanceId);
 
     HashMap<String, String> context = new HashMap<>();
     context.put(MARC_BIBLIOGRAPHIC.value(), recordJson.encode());
     context.put(INCOMING_RECORD_ID, incomingRecordId);
+    context.put(INSTANCE.value(), instanceJson.encode());
 
     DataImportEventPayload eventPayload = new DataImportEventPayload()
-      .withEventType("DI_ERROR")
+      .withEventType("DI_INVENTORY_INSTANCE_MATCHED")
       .withContext(context);
 
     List<JournalRecord> journalRecords = JournalUtil.buildJournalRecordsByEvent(eventPayload,
@@ -1311,6 +1331,7 @@ public class JournalUtilTest {
     Assert.assertEquals(INSTANCE, journalRecordInstance.getEntityType());
     Assert.assertEquals(MATCH, journalRecordInstance.getActionType());
     Assert.assertEquals(COMPLETED, journalRecordInstance.getActionStatus());
+    Assert.assertEquals(instanceId, journalRecordInstance.getEntityId());
     Assert.assertNotNull(journalRecordInstance.getActionDate());
 
     JournalRecord journalRecordMarcBib = journalRecords.get(1);
@@ -1320,6 +1341,7 @@ public class JournalUtilTest {
     Assert.assertEquals(MARC_BIBLIOGRAPHIC, journalRecordMarcBib.getEntityType());
     Assert.assertEquals(MATCH, journalRecordMarcBib.getActionType());
     Assert.assertEquals(COMPLETED, journalRecordMarcBib.getActionStatus());
+    Assert.assertEquals(matchedId, journalRecordMarcBib.getEntityId());
     Assert.assertNotNull(journalRecordMarcBib.getActionDate());
   }
   @Test
@@ -1334,11 +1356,11 @@ public class JournalUtilTest {
       .put("order", 1);
 
     HashMap<String, String> context = new HashMap<>();
-    context.put(MARC_BIBLIOGRAPHIC.value(), recordJson.encode());
+    context.put(MARC_AUTHORITY.value(), recordJson.encode());
     context.put(INCOMING_RECORD_ID, incomingRecordId);
 
     DataImportEventPayload eventPayload = new DataImportEventPayload()
-      .withEventType("DI_ERROR")
+      .withEventType("DI_SRS_MARC_AUTHORITY_RECORD_NOT_MATCHED")
       .withContext(context);
 
     List<JournalRecord> journalRecords = JournalUtil.buildJournalRecordsByEvent(eventPayload,
@@ -1347,42 +1369,51 @@ public class JournalUtilTest {
     Assert.assertNotNull(journalRecords);
     Assert.assertEquals(2, journalRecords.size());
 
-    JournalRecord journalRecordMarcBib = journalRecords.get(0);
-    Assert.assertEquals(snapshotId, journalRecordMarcBib.getJobExecutionId());
-    Assert.assertEquals(incomingRecordId, journalRecordMarcBib.getSourceId());
-    Assert.assertEquals(1, journalRecordMarcBib.getSourceRecordOrder().intValue());
-    Assert.assertEquals(MARC_AUTHORITY, journalRecordMarcBib.getEntityType());
-    Assert.assertEquals(NON_MATCH, journalRecordMarcBib.getActionType());
-    Assert.assertEquals(COMPLETED, journalRecordMarcBib.getActionStatus());
-    Assert.assertNotNull(journalRecordMarcBib.getActionDate());
+    JournalRecord journalRecordMarcAuthority = journalRecords.get(0);
+    Assert.assertEquals(snapshotId, journalRecordMarcAuthority.getJobExecutionId());
+    Assert.assertEquals(incomingRecordId, journalRecordMarcAuthority.getSourceId());
+    Assert.assertEquals(1, journalRecordMarcAuthority.getSourceRecordOrder().intValue());
+    Assert.assertEquals(MARC_AUTHORITY, journalRecordMarcAuthority.getEntityType());
+    Assert.assertEquals(NON_MATCH, journalRecordMarcAuthority.getActionType());
+    Assert.assertEquals(COMPLETED, journalRecordMarcAuthority.getActionStatus());
+    Assert.assertNull(journalRecordMarcAuthority.getEntityId());
+    Assert.assertNotNull(journalRecordMarcAuthority.getActionDate());
 
-    JournalRecord journalRecordInstance= journalRecords.get(1);
-    Assert.assertEquals(snapshotId, journalRecordInstance.getJobExecutionId());
-    Assert.assertEquals(incomingRecordId, journalRecordInstance.getSourceId());
-    Assert.assertEquals(1, journalRecordInstance.getSourceRecordOrder().intValue());
-    Assert.assertEquals(AUTHORITY, journalRecordInstance.getEntityType());
-    Assert.assertEquals(NON_MATCH, journalRecordInstance.getActionType());
-    Assert.assertEquals(COMPLETED, journalRecordInstance.getActionStatus());
-    Assert.assertNotNull(journalRecordInstance.getActionDate());
+    JournalRecord journalRecordAuthority= journalRecords.get(1);
+    Assert.assertEquals(snapshotId, journalRecordAuthority.getJobExecutionId());
+    Assert.assertEquals(incomingRecordId, journalRecordAuthority.getSourceId());
+    Assert.assertEquals(1, journalRecordAuthority.getSourceRecordOrder().intValue());
+    Assert.assertEquals(AUTHORITY, journalRecordAuthority.getEntityType());
+    Assert.assertEquals(NON_MATCH, journalRecordAuthority.getActionType());
+    Assert.assertEquals(COMPLETED, journalRecordAuthority.getActionStatus());
+    Assert.assertNull(journalRecordAuthority.getEntityId());
+    Assert.assertNotNull(journalRecordAuthority.getActionDate());
   }
 
   @Test
   public void shouldBuildJournalRecordForMatchMarcAuthority() throws JournalRecordMapperException {
     String recordId = UUID.randomUUID().toString();
+    String matchedId = UUID.randomUUID().toString();
+    String authorityId = UUID.randomUUID().toString();
     String snapshotId = UUID.randomUUID().toString();
     String incomingRecordId = UUID.randomUUID().toString();
 
     JsonObject recordJson = new JsonObject()
       .put("id", recordId)
+      .put("matchedId", matchedId)
       .put("snapshotId", snapshotId)
       .put("order", 1);
 
+    JsonObject authorityJson = new JsonObject()
+      .put("id", authorityId);
+
     HashMap<String, String> context = new HashMap<>();
-    context.put(MARC_BIBLIOGRAPHIC.value(), recordJson.encode());
+    context.put(MARC_AUTHORITY.value(), recordJson.encode());
     context.put(INCOMING_RECORD_ID, incomingRecordId);
+    context.put(AUTHORITY.value(), authorityJson.encode());
 
     DataImportEventPayload eventPayload = new DataImportEventPayload()
-      .withEventType("DI_ERROR")
+      .withEventType("DI_SRS_MARC_AUTHORITY_RECORD_MATCHED")
       .withContext(context);
 
     List<JournalRecord> journalRecords = JournalUtil.buildJournalRecordsByEvent(eventPayload,
@@ -1391,23 +1422,25 @@ public class JournalUtilTest {
     Assert.assertNotNull(journalRecords);
     Assert.assertEquals(2, journalRecords.size());
 
-    JournalRecord journalRecordMarcBib = journalRecords.get(0);
-    Assert.assertEquals(snapshotId, journalRecordMarcBib.getJobExecutionId());
-    Assert.assertEquals(incomingRecordId, journalRecordMarcBib.getSourceId());
-    Assert.assertEquals(1, journalRecordMarcBib.getSourceRecordOrder().intValue());
-    Assert.assertEquals(MARC_AUTHORITY, journalRecordMarcBib.getEntityType());
-    Assert.assertEquals(MATCH, journalRecordMarcBib.getActionType());
-    Assert.assertEquals(COMPLETED, journalRecordMarcBib.getActionStatus());
-    Assert.assertNotNull(journalRecordMarcBib.getActionDate());
+    JournalRecord journalRecordMarcAuthority = journalRecords.get(0);
+    Assert.assertEquals(snapshotId, journalRecordMarcAuthority.getJobExecutionId());
+    Assert.assertEquals(incomingRecordId, journalRecordMarcAuthority.getSourceId());
+    Assert.assertEquals(1, journalRecordMarcAuthority.getSourceRecordOrder().intValue());
+    Assert.assertEquals(MARC_AUTHORITY, journalRecordMarcAuthority.getEntityType());
+    Assert.assertEquals(MATCH, journalRecordMarcAuthority.getActionType());
+    Assert.assertEquals(COMPLETED, journalRecordMarcAuthority.getActionStatus());
+    Assert.assertEquals(matchedId, journalRecordMarcAuthority.getEntityId());
+    Assert.assertNotNull(journalRecordMarcAuthority.getActionDate());
 
-    JournalRecord journalRecordInstance= journalRecords.get(1);
-    Assert.assertEquals(snapshotId, journalRecordInstance.getJobExecutionId());
-    Assert.assertEquals(incomingRecordId, journalRecordInstance.getSourceId());
-    Assert.assertEquals(1, journalRecordInstance.getSourceRecordOrder().intValue());
-    Assert.assertEquals(AUTHORITY, journalRecordInstance.getEntityType());
-    Assert.assertEquals(MATCH, journalRecordInstance.getActionType());
-    Assert.assertEquals(COMPLETED, journalRecordInstance.getActionStatus());
-    Assert.assertNotNull(journalRecordInstance.getActionDate());
+    JournalRecord journalRecordAuthority= journalRecords.get(1);
+    Assert.assertEquals(snapshotId, journalRecordAuthority.getJobExecutionId());
+    Assert.assertEquals(incomingRecordId, journalRecordAuthority.getSourceId());
+    Assert.assertEquals(1, journalRecordAuthority.getSourceRecordOrder().intValue());
+    Assert.assertEquals(AUTHORITY, journalRecordAuthority.getEntityType());
+    Assert.assertEquals(MATCH, journalRecordAuthority.getActionType());
+    Assert.assertEquals(COMPLETED, journalRecordAuthority.getActionStatus());
+    Assert.assertEquals(authorityId, journalRecordAuthority.getEntityId());
+    Assert.assertNotNull(journalRecordAuthority.getActionDate());
   }
   @Test
   public void shouldReturnUpdatedInstanceAndCreatedMarcBibJournalRecordInMarcBibStatusTrue() throws JournalRecordMapperException {

--- a/mod-source-record-manager-server/src/test/java/org/folio/services/JournalUtilTest.java
+++ b/mod-source-record-manager-server/src/test/java/org/folio/services/JournalUtilTest.java
@@ -1232,7 +1232,7 @@ public class JournalUtilTest {
     Assert.assertEquals(MARC_BIBLIOGRAPHIC, journalRecordMarcBib.getEntityType());
     Assert.assertEquals(MATCH, journalRecordMarcBib.getActionType());
     Assert.assertEquals(COMPLETED, journalRecordMarcBib.getActionStatus());
-    Assert.assertEquals(matchedId, journalRecordMarcBib.getEntityId());
+    Assert.assertNull(journalRecordMarcBib.getEntityId());
     Assert.assertNotNull(journalRecordMarcBib.getActionDate());
 
     JournalRecord journalRecordInstance= journalRecords.get(1);
@@ -1242,7 +1242,7 @@ public class JournalUtilTest {
     Assert.assertEquals(INSTANCE, journalRecordInstance.getEntityType());
     Assert.assertEquals(MATCH, journalRecordInstance.getActionType());
     Assert.assertEquals(COMPLETED, journalRecordInstance.getActionStatus());
-    Assert.assertEquals(instanceId, journalRecordInstance.getEntityId());
+    Assert.assertNull(journalRecordInstance.getEntityId());
     Assert.assertNotNull(journalRecordInstance.getActionDate());
   }
 
@@ -1331,7 +1331,7 @@ public class JournalUtilTest {
     Assert.assertEquals(INSTANCE, journalRecordInstance.getEntityType());
     Assert.assertEquals(MATCH, journalRecordInstance.getActionType());
     Assert.assertEquals(COMPLETED, journalRecordInstance.getActionStatus());
-    Assert.assertEquals(instanceId, journalRecordInstance.getEntityId());
+    Assert.assertNull(journalRecordInstance.getEntityId());
     Assert.assertNotNull(journalRecordInstance.getActionDate());
 
     JournalRecord journalRecordMarcBib = journalRecords.get(1);
@@ -1341,7 +1341,7 @@ public class JournalUtilTest {
     Assert.assertEquals(MARC_BIBLIOGRAPHIC, journalRecordMarcBib.getEntityType());
     Assert.assertEquals(MATCH, journalRecordMarcBib.getActionType());
     Assert.assertEquals(COMPLETED, journalRecordMarcBib.getActionStatus());
-    Assert.assertEquals(matchedId, journalRecordMarcBib.getEntityId());
+    Assert.assertNull(journalRecordMarcBib.getEntityId());
     Assert.assertNotNull(journalRecordMarcBib.getActionDate());
   }
   @Test
@@ -1429,7 +1429,7 @@ public class JournalUtilTest {
     Assert.assertEquals(MARC_AUTHORITY, journalRecordMarcAuthority.getEntityType());
     Assert.assertEquals(MATCH, journalRecordMarcAuthority.getActionType());
     Assert.assertEquals(COMPLETED, journalRecordMarcAuthority.getActionStatus());
-    Assert.assertEquals(matchedId, journalRecordMarcAuthority.getEntityId());
+    Assert.assertNull(journalRecordMarcAuthority.getEntityId());
     Assert.assertNotNull(journalRecordMarcAuthority.getActionDate());
 
     JournalRecord journalRecordAuthority= journalRecords.get(1);
@@ -1439,7 +1439,7 @@ public class JournalUtilTest {
     Assert.assertEquals(AUTHORITY, journalRecordAuthority.getEntityType());
     Assert.assertEquals(MATCH, journalRecordAuthority.getActionType());
     Assert.assertEquals(COMPLETED, journalRecordAuthority.getActionStatus());
-    Assert.assertEquals(authorityId, journalRecordAuthority.getEntityId());
+    Assert.assertNull(journalRecordAuthority.getEntityId());
     Assert.assertNotNull(journalRecordAuthority.getActionDate());
   }
   @Test

--- a/mod-source-record-manager-server/src/test/java/org/folio/services/JournalUtilTest.java
+++ b/mod-source-record-manager-server/src/test/java/org/folio/services/JournalUtilTest.java
@@ -28,12 +28,14 @@ import static org.folio.DataImportEventTypes.DI_SRS_MARC_BIB_RECORD_UPDATED;
 import static org.folio.rest.jaxrs.model.JournalRecord.ActionStatus.COMPLETED;
 import static org.folio.rest.jaxrs.model.JournalRecord.ActionStatus.ERROR;
 import static org.folio.rest.jaxrs.model.JournalRecord.ActionType.CREATE;
+import static org.folio.rest.jaxrs.model.JournalRecord.ActionType.MATCH;
 import static org.folio.rest.jaxrs.model.JournalRecord.ActionType.NON_MATCH;
 import static org.folio.rest.jaxrs.model.JournalRecord.ActionType.UPDATE;
 import static org.folio.rest.jaxrs.model.JournalRecord.EntityType.AUTHORITY;
 import static org.folio.rest.jaxrs.model.JournalRecord.EntityType.INSTANCE;
 import static org.folio.rest.jaxrs.model.JournalRecord.EntityType.ITEM;
 import static org.folio.rest.jaxrs.model.JournalRecord.EntityType.HOLDINGS;
+import static org.folio.rest.jaxrs.model.JournalRecord.EntityType.MARC_AUTHORITY;
 import static org.folio.rest.jaxrs.model.JournalRecord.EntityType.MARC_BIBLIOGRAPHIC;
 import static org.folio.rest.jaxrs.model.JournalRecord.EntityType.MARC_HOLDINGS;
 import static org.folio.rest.jaxrs.model.JournalRecord.EntityType.PO_LINE;
@@ -1145,6 +1147,268 @@ public class JournalUtilTest {
     Assert.assertNotNull(journalRecord.getActionDate());
   }
 
+  @Test
+  public void shouldBuildJournalRecordForNonMatchMarcBibliographic() throws JournalRecordMapperException {
+    String recordId = UUID.randomUUID().toString();
+    String snapshotId = UUID.randomUUID().toString();
+    String incomingRecordId = UUID.randomUUID().toString();
+
+    JsonObject recordJson = new JsonObject()
+      .put("id", recordId)
+      .put("snapshotId", snapshotId)
+      .put("order", 1);
+
+    HashMap<String, String> context = new HashMap<>();
+    context.put(MARC_BIBLIOGRAPHIC.value(), recordJson.encode());
+    context.put(INCOMING_RECORD_ID, incomingRecordId);
+
+    DataImportEventPayload eventPayload = new DataImportEventPayload()
+      .withEventType("DI_ERROR")
+      .withContext(context);
+
+    List<JournalRecord> journalRecords = JournalUtil.buildJournalRecordsByEvent(eventPayload,
+      NON_MATCH, MARC_BIBLIOGRAPHIC, COMPLETED);
+
+    Assert.assertNotNull(journalRecords);
+    Assert.assertEquals(2, journalRecords.size());
+
+    JournalRecord journalRecordMarcBib = journalRecords.get(0);
+    Assert.assertEquals(snapshotId, journalRecordMarcBib.getJobExecutionId());
+    Assert.assertEquals(incomingRecordId, journalRecordMarcBib.getSourceId());
+    Assert.assertEquals(1, journalRecordMarcBib.getSourceRecordOrder().intValue());
+    Assert.assertEquals(MARC_BIBLIOGRAPHIC, journalRecordMarcBib.getEntityType());
+    Assert.assertEquals(NON_MATCH, journalRecordMarcBib.getActionType());
+    Assert.assertEquals(COMPLETED, journalRecordMarcBib.getActionStatus());
+    Assert.assertNotNull(journalRecordMarcBib.getActionDate());
+
+    JournalRecord journalRecordInstance= journalRecords.get(1);
+    Assert.assertEquals(snapshotId, journalRecordInstance.getJobExecutionId());
+    Assert.assertEquals(incomingRecordId, journalRecordInstance.getSourceId());
+    Assert.assertEquals(1, journalRecordInstance.getSourceRecordOrder().intValue());
+    Assert.assertEquals(INSTANCE, journalRecordInstance.getEntityType());
+    Assert.assertEquals(NON_MATCH, journalRecordInstance.getActionType());
+    Assert.assertEquals(COMPLETED, journalRecordInstance.getActionStatus());
+    Assert.assertNotNull(journalRecordInstance.getActionDate());
+  }
+
+  @Test
+  public void shouldBuildJournalRecordForMatchMarcBibliographic() throws JournalRecordMapperException {
+    String recordId = UUID.randomUUID().toString();
+    String snapshotId = UUID.randomUUID().toString();
+    String incomingRecordId = UUID.randomUUID().toString();
+
+    JsonObject recordJson = new JsonObject()
+      .put("id", recordId)
+      .put("snapshotId", snapshotId)
+      .put("order", 1);
+
+    HashMap<String, String> context = new HashMap<>();
+    context.put(MARC_BIBLIOGRAPHIC.value(), recordJson.encode());
+    context.put(INCOMING_RECORD_ID, incomingRecordId);
+
+    DataImportEventPayload eventPayload = new DataImportEventPayload()
+      .withEventType("DI_ERROR")
+      .withContext(context);
+
+    List<JournalRecord> journalRecords = JournalUtil.buildJournalRecordsByEvent(eventPayload,
+      MATCH, MARC_BIBLIOGRAPHIC, COMPLETED);
+
+    Assert.assertNotNull(journalRecords);
+    Assert.assertEquals(2, journalRecords.size());
+
+    JournalRecord journalRecordMarcBib = journalRecords.get(0);
+    Assert.assertEquals(snapshotId, journalRecordMarcBib.getJobExecutionId());
+    Assert.assertEquals(incomingRecordId, journalRecordMarcBib.getSourceId());
+    Assert.assertEquals(1, journalRecordMarcBib.getSourceRecordOrder().intValue());
+    Assert.assertEquals(MARC_BIBLIOGRAPHIC, journalRecordMarcBib.getEntityType());
+    Assert.assertEquals(MATCH, journalRecordMarcBib.getActionType());
+    Assert.assertEquals(COMPLETED, journalRecordMarcBib.getActionStatus());
+    Assert.assertNotNull(journalRecordMarcBib.getActionDate());
+
+    JournalRecord journalRecordInstance= journalRecords.get(1);
+    Assert.assertEquals(snapshotId, journalRecordInstance.getJobExecutionId());
+    Assert.assertEquals(incomingRecordId, journalRecordInstance.getSourceId());
+    Assert.assertEquals(1, journalRecordInstance.getSourceRecordOrder().intValue());
+    Assert.assertEquals(INSTANCE, journalRecordInstance.getEntityType());
+    Assert.assertEquals(MATCH, journalRecordInstance.getActionType());
+    Assert.assertEquals(COMPLETED, journalRecordInstance.getActionStatus());
+    Assert.assertNotNull(journalRecordInstance.getActionDate());
+  }
+
+  @Test
+  public void shouldBuildJournalRecordForNonMatchInstance() throws JournalRecordMapperException {
+    String recordId = UUID.randomUUID().toString();
+    String snapshotId = UUID.randomUUID().toString();
+    String incomingRecordId = UUID.randomUUID().toString();
+
+    JsonObject recordJson = new JsonObject()
+      .put("id", recordId)
+      .put("snapshotId", snapshotId)
+      .put("order", 1);
+
+    HashMap<String, String> context = new HashMap<>();
+    context.put(MARC_BIBLIOGRAPHIC.value(), recordJson.encode());
+    context.put(INCOMING_RECORD_ID, incomingRecordId);
+
+    DataImportEventPayload eventPayload = new DataImportEventPayload()
+      .withEventType("DI_ERROR")
+      .withContext(context);
+
+    List<JournalRecord> journalRecords = JournalUtil.buildJournalRecordsByEvent(eventPayload,
+      NON_MATCH, INSTANCE, COMPLETED);
+
+    Assert.assertNotNull(journalRecords);
+    Assert.assertEquals(2, journalRecords.size());
+
+    JournalRecord journalRecordInstance= journalRecords.get(0);
+    Assert.assertEquals(snapshotId, journalRecordInstance.getJobExecutionId());
+    Assert.assertEquals(incomingRecordId, journalRecordInstance.getSourceId());
+    Assert.assertEquals(1, journalRecordInstance.getSourceRecordOrder().intValue());
+    Assert.assertEquals(INSTANCE, journalRecordInstance.getEntityType());
+    Assert.assertEquals(NON_MATCH, journalRecordInstance.getActionType());
+    Assert.assertEquals(COMPLETED, journalRecordInstance.getActionStatus());
+    Assert.assertNotNull(journalRecordInstance.getActionDate());
+
+    JournalRecord journalRecordMarcBib = journalRecords.get(1);
+    Assert.assertEquals(snapshotId, journalRecordMarcBib.getJobExecutionId());
+    Assert.assertEquals(incomingRecordId, journalRecordMarcBib.getSourceId());
+    Assert.assertEquals(1, journalRecordMarcBib.getSourceRecordOrder().intValue());
+    Assert.assertEquals(MARC_BIBLIOGRAPHIC, journalRecordMarcBib.getEntityType());
+    Assert.assertEquals(NON_MATCH, journalRecordMarcBib.getActionType());
+    Assert.assertEquals(COMPLETED, journalRecordMarcBib.getActionStatus());
+    Assert.assertNotNull(journalRecordMarcBib.getActionDate());
+  }
+
+  @Test
+  public void shouldBuildJournalRecordForMatchInstance() throws JournalRecordMapperException {
+    String recordId = UUID.randomUUID().toString();
+    String snapshotId = UUID.randomUUID().toString();
+    String incomingRecordId = UUID.randomUUID().toString();
+
+    JsonObject recordJson = new JsonObject()
+      .put("id", recordId)
+      .put("snapshotId", snapshotId)
+      .put("order", 1);
+
+    HashMap<String, String> context = new HashMap<>();
+    context.put(MARC_BIBLIOGRAPHIC.value(), recordJson.encode());
+    context.put(INCOMING_RECORD_ID, incomingRecordId);
+
+    DataImportEventPayload eventPayload = new DataImportEventPayload()
+      .withEventType("DI_ERROR")
+      .withContext(context);
+
+    List<JournalRecord> journalRecords = JournalUtil.buildJournalRecordsByEvent(eventPayload,
+      MATCH, INSTANCE, COMPLETED);
+
+    Assert.assertNotNull(journalRecords);
+    Assert.assertEquals(2, journalRecords.size());
+
+    JournalRecord journalRecordInstance= journalRecords.get(0);
+    Assert.assertEquals(snapshotId, journalRecordInstance.getJobExecutionId());
+    Assert.assertEquals(incomingRecordId, journalRecordInstance.getSourceId());
+    Assert.assertEquals(1, journalRecordInstance.getSourceRecordOrder().intValue());
+    Assert.assertEquals(INSTANCE, journalRecordInstance.getEntityType());
+    Assert.assertEquals(MATCH, journalRecordInstance.getActionType());
+    Assert.assertEquals(COMPLETED, journalRecordInstance.getActionStatus());
+    Assert.assertNotNull(journalRecordInstance.getActionDate());
+
+    JournalRecord journalRecordMarcBib = journalRecords.get(1);
+    Assert.assertEquals(snapshotId, journalRecordMarcBib.getJobExecutionId());
+    Assert.assertEquals(incomingRecordId, journalRecordMarcBib.getSourceId());
+    Assert.assertEquals(1, journalRecordMarcBib.getSourceRecordOrder().intValue());
+    Assert.assertEquals(MARC_BIBLIOGRAPHIC, journalRecordMarcBib.getEntityType());
+    Assert.assertEquals(MATCH, journalRecordMarcBib.getActionType());
+    Assert.assertEquals(COMPLETED, journalRecordMarcBib.getActionStatus());
+    Assert.assertNotNull(journalRecordMarcBib.getActionDate());
+  }
+  @Test
+  public void shouldBuildJournalRecordForNonMatchMarcAuthority() throws JournalRecordMapperException {
+    String recordId = UUID.randomUUID().toString();
+    String snapshotId = UUID.randomUUID().toString();
+    String incomingRecordId = UUID.randomUUID().toString();
+
+    JsonObject recordJson = new JsonObject()
+      .put("id", recordId)
+      .put("snapshotId", snapshotId)
+      .put("order", 1);
+
+    HashMap<String, String> context = new HashMap<>();
+    context.put(MARC_BIBLIOGRAPHIC.value(), recordJson.encode());
+    context.put(INCOMING_RECORD_ID, incomingRecordId);
+
+    DataImportEventPayload eventPayload = new DataImportEventPayload()
+      .withEventType("DI_ERROR")
+      .withContext(context);
+
+    List<JournalRecord> journalRecords = JournalUtil.buildJournalRecordsByEvent(eventPayload,
+      NON_MATCH, MARC_AUTHORITY, COMPLETED);
+
+    Assert.assertNotNull(journalRecords);
+    Assert.assertEquals(2, journalRecords.size());
+
+    JournalRecord journalRecordMarcBib = journalRecords.get(0);
+    Assert.assertEquals(snapshotId, journalRecordMarcBib.getJobExecutionId());
+    Assert.assertEquals(incomingRecordId, journalRecordMarcBib.getSourceId());
+    Assert.assertEquals(1, journalRecordMarcBib.getSourceRecordOrder().intValue());
+    Assert.assertEquals(MARC_AUTHORITY, journalRecordMarcBib.getEntityType());
+    Assert.assertEquals(NON_MATCH, journalRecordMarcBib.getActionType());
+    Assert.assertEquals(COMPLETED, journalRecordMarcBib.getActionStatus());
+    Assert.assertNotNull(journalRecordMarcBib.getActionDate());
+
+    JournalRecord journalRecordInstance= journalRecords.get(1);
+    Assert.assertEquals(snapshotId, journalRecordInstance.getJobExecutionId());
+    Assert.assertEquals(incomingRecordId, journalRecordInstance.getSourceId());
+    Assert.assertEquals(1, journalRecordInstance.getSourceRecordOrder().intValue());
+    Assert.assertEquals(AUTHORITY, journalRecordInstance.getEntityType());
+    Assert.assertEquals(NON_MATCH, journalRecordInstance.getActionType());
+    Assert.assertEquals(COMPLETED, journalRecordInstance.getActionStatus());
+    Assert.assertNotNull(journalRecordInstance.getActionDate());
+  }
+
+  @Test
+  public void shouldBuildJournalRecordForMatchMarcAuthority() throws JournalRecordMapperException {
+    String recordId = UUID.randomUUID().toString();
+    String snapshotId = UUID.randomUUID().toString();
+    String incomingRecordId = UUID.randomUUID().toString();
+
+    JsonObject recordJson = new JsonObject()
+      .put("id", recordId)
+      .put("snapshotId", snapshotId)
+      .put("order", 1);
+
+    HashMap<String, String> context = new HashMap<>();
+    context.put(MARC_BIBLIOGRAPHIC.value(), recordJson.encode());
+    context.put(INCOMING_RECORD_ID, incomingRecordId);
+
+    DataImportEventPayload eventPayload = new DataImportEventPayload()
+      .withEventType("DI_ERROR")
+      .withContext(context);
+
+    List<JournalRecord> journalRecords = JournalUtil.buildJournalRecordsByEvent(eventPayload,
+      MATCH, MARC_AUTHORITY, COMPLETED);
+
+    Assert.assertNotNull(journalRecords);
+    Assert.assertEquals(2, journalRecords.size());
+
+    JournalRecord journalRecordMarcBib = journalRecords.get(0);
+    Assert.assertEquals(snapshotId, journalRecordMarcBib.getJobExecutionId());
+    Assert.assertEquals(incomingRecordId, journalRecordMarcBib.getSourceId());
+    Assert.assertEquals(1, journalRecordMarcBib.getSourceRecordOrder().intValue());
+    Assert.assertEquals(MARC_AUTHORITY, journalRecordMarcBib.getEntityType());
+    Assert.assertEquals(MATCH, journalRecordMarcBib.getActionType());
+    Assert.assertEquals(COMPLETED, journalRecordMarcBib.getActionStatus());
+    Assert.assertNotNull(journalRecordMarcBib.getActionDate());
+
+    JournalRecord journalRecordInstance= journalRecords.get(1);
+    Assert.assertEquals(snapshotId, journalRecordInstance.getJobExecutionId());
+    Assert.assertEquals(incomingRecordId, journalRecordInstance.getSourceId());
+    Assert.assertEquals(1, journalRecordInstance.getSourceRecordOrder().intValue());
+    Assert.assertEquals(AUTHORITY, journalRecordInstance.getEntityType());
+    Assert.assertEquals(MATCH, journalRecordInstance.getActionType());
+    Assert.assertEquals(COMPLETED, journalRecordInstance.getActionStatus());
+    Assert.assertNotNull(journalRecordInstance.getActionDate());
+  }
   @Test
   public void shouldReturnUpdatedInstanceAndCreatedMarcBibJournalRecordInMarcBibStatusTrue() throws JournalRecordMapperException {
     String instanceId = UUID.randomUUID().toString();

--- a/mod-source-record-manager-server/src/test/java/org/folio/verticle/consumers/util/JournalParamsTest.java
+++ b/mod-source-record-manager-server/src/test/java/org/folio/verticle/consumers/util/JournalParamsTest.java
@@ -9,6 +9,7 @@ import static org.folio.rest.jaxrs.model.DataImportEventTypes.DI_INVENTORY_HOLDI
 import static org.folio.rest.jaxrs.model.DataImportEventTypes.DI_INVENTORY_HOLDING_UPDATED;
 import static org.folio.rest.jaxrs.model.DataImportEventTypes.DI_INVENTORY_AUTHORITY_CREATED;
 import static org.folio.rest.jaxrs.model.DataImportEventTypes.DI_INVENTORY_INSTANCE_CREATED;
+import static org.folio.rest.jaxrs.model.DataImportEventTypes.DI_INVENTORY_INSTANCE_MATCHED;
 import static org.folio.rest.jaxrs.model.DataImportEventTypes.DI_INVENTORY_INSTANCE_NOT_MATCHED;
 import static org.folio.rest.jaxrs.model.DataImportEventTypes.DI_INVENTORY_INSTANCE_UPDATED;
 import static org.folio.rest.jaxrs.model.DataImportEventTypes.DI_INVENTORY_ITEM_CREATED;
@@ -255,6 +256,11 @@ public class JournalParamsTest {
   @Test
   public void shouldPopulateEntityTypeInstanceWhenEventTypeIsDiInventoryInstanceNonMatched() {
     populateEntityTypeAndActionTypeByEventType(DI_INVENTORY_INSTANCE_NOT_MATCHED, JournalRecord.EntityType.INSTANCE, JournalRecord.ActionType.NON_MATCH);
+  }
+
+  @Test
+  public void shouldPopulateEntityTypeInstanceWhenEventTypeIsDiInventoryInstanceMatched() {
+    populateEntityTypeAndActionTypeByEventType(DI_INVENTORY_INSTANCE_MATCHED, JournalRecord.EntityType.INSTANCE, JournalRecord.ActionType.MATCH);
   }
 
   @Test


### PR DESCRIPTION
## Purpose
When the entity matched and no action is performed, should be shown status 'No action' for the underlying entity
## Approach
- Modified JournalUtil logic to save journal_record for match action for marc bib/instance
- Modified get_job_log_entries and get_record_processing_log functions to return Discarded for MATCH journal record if no other record with other status exists

