### PR TITLE
MODSOURMAN-1151: Records are not displayed under their original numbers and are constantly changing by places

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,6 @@
 ## 2024-xx-xx v3.9.0
 * [MODDATAIMP-1029](https://folio-org.atlassian.net/browse/MODDATAIMP-1029) The authority record loaded via data-import using Default - Create SRS MARC Authority job profile is duplicated on the job-summary page
+* [MODSOURMAN-1151](https://folio-org.atlassian.net/browse/MODSOURMAN-1151) Records are not displayed under their original numbers and are constantly changing by places
 
 ## 2023-03-22 v3.8.0
 * [MODSOURMAN-1131](https://folio-org.atlassian.net/browse/MODSOURMAN-1131) The import of file for creating orders is completed with errors

--- a/mod-source-record-manager-server/src/main/resources/templates/db_scripts/create_get_job_log_entries_function.sql
+++ b/mod-source-record-manager-server/src/main/resources/templates/db_scripts/create_get_job_log_entries_function.sql
@@ -311,7 +311,7 @@ FROM (
          marc_holdings.title AS title,
          marc_holdings.entity_id AS marc_holdings_entity_id,
          marc_holdings.error AS marc_holdings_entity_error
-  FROM  marc_holdings
+  FROM  marc_holdings WHERE entity_id IS NOT NULL
 ) AS marc_holdings_info ON marc_holdings_info.source_id = records_actions.source_id
 
        LEFT JOIN (SELECT journal_records.source_id,


### PR DESCRIPTION
## Purpose
Records are not displayed under their original numbers and are constantly changing by places
## Approach
Adjusted log entries script including not null entiy id
## Learning
[MODSOURMAN-1151](https://folio-org.atlassian.net/browse/MODSOURMAN-1151)
## Is this change testable? If not - why?


## Checklist
- [x] I have updated NEWS.md.
- [ ] I have added javadocs to new methods.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation e.g. README.md.
- [ ] I have ran karate tests against this feature.

