### PR TITLE
MODSOURMAN-1162: (ECS) The 'source-storage.snapshots.post' permission is absent

### DIFF
--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -314,6 +314,7 @@
             "orders.po-lines.collection.get",
             "source-storage.records.get",
             "source-storage.snapshots.get",
+            "source-storage.snapshots.post",
             "source-storage.snapshots.put",
             "source-storage.verified.records",
             "users.collection.get",


### PR DESCRIPTION
## Purpose
(ECS) The 'source-storage.snapshots.post' permission is absent
## Approach
 Added permission 'source-storage.snapshots.post' to /change-manager/jobExecutions/{id}/records endpoint

## Learning
[MODSOURMAN-1162](https://folio-org.atlassian.net/browse/MODSOURMAN-1162)