### PR TITLE
MODSOURMAN-1120: Updated default mapping to include mapping for Cancelled LCCN

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -2,6 +2,7 @@
 * [MODDATAIMP-1029](https://folio-org.atlassian.net/browse/MODDATAIMP-1029) The authority record loaded via data-import using Default - Create SRS MARC Authority job profile is duplicated on the job-summary page
 * [MODSOURMAN-1152](https://folio-org.atlassian.net/browse/MODSOURMAN-1152) The error message is not displayed in the di log summary
 * [MODSOURMAN-1151](https://folio-org.atlassian.net/browse/MODSOURMAN-1151) Records are not displayed under their original numbers and are constantly changing by places
+* [MODSOURMAN-1120](https://folio-org.atlassian.net/browse/MODSOURMAN-1120) Update default mapping to include mapping for Cancelled LCCN
 
 ## 2023-03-22 v3.8.0
 * [MODSOURMAN-1131](https://folio-org.atlassian.net/browse/MODSOURMAN-1131) The import of file for creating orders is completed with errors

--- a/mod-source-record-manager-server/src/main/resources/rules/marc_bib_rules.json
+++ b/mod-source-record-manager-server/src/main/resources/rules/marc_bib_rules.json
@@ -109,6 +109,41 @@
               ]
             }
           ]
+        },
+        {
+          "target": "identifiers.identifierTypeId",
+          "description": "Type for Cancelled LCCN",
+          "subfield": [
+            "z"
+          ],
+          "rules": [
+            {
+              "conditions": [
+                {
+                  "type": "set_identifier_type_id_by_name",
+                  "parameter": {
+                    "name": "Cancelled LCCN"
+                  }
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "target": "identifiers.value",
+          "description": "Type for Cancelled LCCN",
+          "subfield": [
+            "z"
+          ],
+          "rules": [
+            {
+              "conditions": [
+                {
+                  "type": "trim"
+                }
+              ]
+            }
+          ]
         }
       ]
     }

--- a/mod-source-record-manager-server/src/test/resources/org/folio/services/marc_bib_rules.json
+++ b/mod-source-record-manager-server/src/test/resources/org/folio/services/marc_bib_rules.json
@@ -109,6 +109,41 @@
               ]
             }
           ]
+        },
+        {
+          "target": "identifiers.identifierTypeId",
+          "description": "Type for Cancelled LCCN",
+          "subfield": [
+            "z"
+          ],
+          "rules": [
+            {
+              "conditions": [
+                {
+                  "type": "set_identifier_type_id_by_name",
+                  "parameter": {
+                    "name": "Cancelled LCCN"
+                  }
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "target": "identifiers.value",
+          "description": "Type for Cancelled LCCN",
+          "subfield": [
+            "z"
+          ],
+          "rules": [
+            {
+              "conditions": [
+                {
+                  "type": "trim"
+                }
+              ]
+            }
+          ]
         }
       ]
     }


### PR DESCRIPTION
## Purpose
 Update default mapping rule to include mapping for Cancelled LCCN
## Approach
Updated default mapping to include mapping for Cancelled LCCN

## Learning
[MODSOURMAN-1120](https://folio-org.atlassian.net/browse/MODSOURMAN-1120)
