### PR TITLE
[MODSOURMAN-1168] Adjust job execution summary table to count MATCH action

### DIFF
--- a/mod-source-record-manager-server/src/main/resources/templates/db_scripts/create_get_job_execution_summary_function.sql
+++ b/mod-source-record-manager-server/src/main/resources/templates/db_scripts/create_get_job_execution_summary_function.sql
@@ -19,46 +19,53 @@ BEGIN
       COUNT(DISTINCT(source_id)) FILTER (WHERE action_status = 'ERROR') AS total_errors,
       COUNT(DISTINCT(source_id)) FILTER (WHERE entity_type IN ('MARC_BIBLIOGRAPHIC', 'MARC_HOLDINGS', 'MARC_AUTHORITY') AND action_type = 'CREATE' AND action_status = 'COMPLETED') AS total_created_source_records,
       COUNT(DISTINCT(source_id)) FILTER (WHERE entity_type IN ('MARC_BIBLIOGRAPHIC', 'MARC_HOLDINGS', 'MARC_AUTHORITY') AND action_type = 'UPDATE' AND action_status = 'COMPLETED') AS total_updated_source_records,
-      COUNT(*) FILTER (WHERE entity_type IN ('MARC_BIBLIOGRAPHIC', 'MARC_HOLDINGS', 'MARC_AUTHORITY') AND ((action_type = 'NON_MATCH' AND action_type_max = 'NON_MATCH') OR action_status = 'ERROR')) AS total_discarded_source_records,
+      COUNT(*) FILTER (WHERE entity_type IN ('MARC_BIBLIOGRAPHIC', 'MARC_HOLDINGS', 'MARC_AUTHORITY') AND ((action_type = 'NON_MATCH' AND action_type_max = 'NON_MATCH') OR (action_type = 'MATCH' AND action_type_max = 'MATCH') OR action_status = 'ERROR')) AS total_discarded_source_records,
       COUNT(*) FILTER (WHERE entity_type IN ('MARC_BIBLIOGRAPHIC', 'MARC_HOLDINGS', 'MARC_AUTHORITY') AND action_status = 'ERROR') AS total_source_records_errors,
 
       COUNT(DISTINCT(entity_id)) FILTER (WHERE entity_type = 'INSTANCE' AND action_type = 'CREATE' AND action_status = 'COMPLETED') AS total_created_instances,
       COUNT(DISTINCT(entity_id)) FILTER (WHERE entity_type = 'INSTANCE' AND action_type = 'UPDATE' AND action_status = 'COMPLETED') AS total_updated_instances,
-      COUNT(*) FILTER (WHERE entity_type = 'INSTANCE' AND ((action_type = 'NON_MATCH' AND action_type_max = 'NON_MATCH') OR action_status = 'ERROR')) AS total_discarded_instances,
+      COUNT(*) FILTER (WHERE entity_type = 'INSTANCE' AND ((action_type = 'NON_MATCH' AND action_type_max = 'NON_MATCH') OR (action_type = 'MATCH' AND action_type_max = 'MATCH') OR action_status = 'ERROR')) AS total_discarded_instances,
       COUNT(*) FILTER (WHERE entity_type = 'INSTANCE' AND action_status = 'ERROR') AS total_instances_errors,
 
       COUNT(*) FILTER (WHERE entity_type = 'HOLDINGS' AND action_type = 'CREATE' AND action_status = 'COMPLETED') AS total_created_holdings,
       COUNT(*) FILTER (WHERE entity_type = 'HOLDINGS' AND action_type = 'UPDATE' AND action_status = 'COMPLETED') AS total_updated_holdings,
-      COUNT(*) FILTER (WHERE entity_type = 'HOLDINGS' AND ((action_type = 'NON_MATCH' AND action_type_max = 'NON_MATCH') OR action_status = 'ERROR')) AS total_discarded_holdings,
+      COUNT(*) FILTER (WHERE entity_type = 'HOLDINGS' AND ((action_type = 'NON_MATCH' AND action_type_max = 'NON_MATCH') OR (action_type = 'MATCH' AND action_type_max = 'MATCH') OR action_status = 'ERROR')) AS total_discarded_holdings,
       COUNT(*) FILTER (WHERE entity_type = 'HOLDINGS' AND action_status = 'ERROR') AS total_holdings_errors,
 
       COUNT(*) FILTER (WHERE entity_type = 'ITEM' AND action_type = 'CREATE' AND action_status = 'COMPLETED') AS total_created_items,
       COUNT(*) FILTER (WHERE entity_type = 'ITEM' AND action_type = 'UPDATE' AND action_status = 'COMPLETED') AS total_updated_items,
-      COUNT(*) FILTER (WHERE entity_type = 'ITEM' AND ((action_type = 'NON_MATCH' AND action_type_max = 'NON_MATCH') OR action_status = 'ERROR')) AS total_discarded_items,
+      COUNT(*) FILTER (WHERE entity_type = 'ITEM' AND ((action_type = 'NON_MATCH' AND action_type_max = 'NON_MATCH') OR (action_type = 'MATCH' AND action_type_max = 'MATCH') OR action_status = 'ERROR')) AS total_discarded_items,
       COUNT(*) FILTER (WHERE entity_type = 'ITEM' AND action_status = 'ERROR') AS total_items_errors,
 
       COUNT(*) FILTER (WHERE entity_type = 'AUTHORITY' AND action_type = 'CREATE' AND action_status = 'COMPLETED') AS total_created_authorities,
       COUNT(*) FILTER (WHERE entity_type = 'AUTHORITY' AND action_type = 'UPDATE' AND action_status = 'COMPLETED') AS total_updated_authorities,
-      COUNT(*) FILTER (WHERE entity_type = 'AUTHORITY' AND ((action_type = 'NON_MATCH' AND action_type_max = 'NON_MATCH')OR action_status = 'ERROR')) AS total_discarded_authorities,
+      COUNT(*) FILTER (WHERE entity_type = 'AUTHORITY' AND ((action_type = 'NON_MATCH' AND action_type_max = 'NON_MATCH') OR (action_type = 'MATCH' AND action_type_max = 'MATCH') OR action_status = 'ERROR')) AS total_discarded_authorities,
       COUNT(*) FILTER (WHERE entity_type = 'AUTHORITY' AND action_status = 'ERROR') AS total_authorities_errors,
 
       COUNT(DISTINCT(source_id)) FILTER (WHERE entity_type = 'PO_LINE' AND action_type = 'CREATE' AND action_status = 'COMPLETED') AS total_created_orders,
       0 AS total_updated_orders,
-      COUNT(DISTINCT(source_id)) FILTER (WHERE entity_type = 'PO_LINE' AND ((action_type = 'NON_MATCH' AND action_type_max = 'NON_MATCH') OR action_status = 'ERROR')) AS total_discarded_orders,
+      COUNT(DISTINCT(source_id)) FILTER (WHERE entity_type = 'PO_LINE' AND ((action_type = 'NON_MATCH' AND action_type_max = 'NON_MATCH') OR (action_type = 'MATCH' AND action_type_max = 'MATCH') OR action_status = 'ERROR')) AS total_discarded_orders,
       COUNT(DISTINCT(source_id)) FILTER (WHERE entity_type = 'PO_LINE' AND action_status = 'ERROR') AS total_orders_errors,
 
       COUNT(DISTINCT(source_id)) FILTER (WHERE entity_type = 'INVOICE' AND action_status = 'COMPLETED') AS total_created_invoices,
       0 AS total_updated_invoices,
-      COUNT(DISTINCT(source_id)) FILTER (WHERE entity_type = 'INVOICE' AND ((action_type = 'NON_MATCH' AND action_type_max = 'NON_MATCH') OR action_status = 'ERROR')) AS total_discarded_invoices,
+      COUNT(DISTINCT(source_id)) FILTER (WHERE entity_type = 'INVOICE' AND ((action_type = 'NON_MATCH' AND action_type_max = 'NON_MATCH') OR (action_type = 'MATCH' AND action_type_max = 'MATCH') OR action_status = 'ERROR')) AS total_discarded_invoices,
       COUNT(DISTINCT(source_id)) FILTER (WHERE entity_type = 'INVOICE' AND action_status = 'ERROR') AS total_invoices_errors
     FROM journal_records
 	    INNER JOIN (SELECT entity_id as entity_id_max, entity_type as entity_type_max, action_status as action_status_max,(array_agg(id ORDER BY array_position(array['CREATE', 'UPDATE', 'MODIFY', 'NON_MATCH'], action_type)))[1] as id,
 	    source_id as temp_source_id
         FROM journal_records
-        WHERE journal_records.job_execution_id = job_id
-			  GROUP BY source_id, entity_id, entity_type, action_status) AS actions
+        WHERE journal_records.job_execution_id = job_id AND action_type != 'MATCH'
+			  GROUP BY source_id, entity_id, entity_type, action_status
+			  UNION ALL
+			  SELECT entity_id as entity_id_max, entity_type as entity_type_max, action_status as action_status_max,(array_agg(id ORDER BY array_position(array['MATCH'], action_type)))[1] as id,
+        	    source_id as temp_source_id
+        FROM journal_records
+        WHERE journal_records.job_execution_id = job_id AND action_type = 'MATCH'
+        AND NOT EXISTS (SELECT 1 FROM journal_records WHERE journal_records.job_execution_id = job_id AND action_type NOT IN ('MATCH', 'PARSE'))
+        GROUP BY source_id, entity_id, entity_type, action_status) AS actions
       ON actions.id = journal_records.id AND actions.temp_source_id = journal_records.source_id
-      INNER JOIN (SELECT (array_agg(action_type ORDER BY array_position(array['CREATE', 'UPDATE', 'MODIFY', 'NON_MATCH'], action_type)))[1] as action_type_max, source_id as source_id_max, entity_type as entity_type_max
+      INNER JOIN (SELECT (array_agg(action_type ORDER BY array_position(array['CREATE', 'UPDATE', 'MODIFY', 'NON_MATCH', 'MATCH'], action_type)))[1] as action_type_max, source_id as source_id_max, entity_type as entity_type_max
         FROM journal_records
         WHERE journal_records.job_execution_id = job_id
         GROUP BY entity_type_max, source_id_max) AS action_type_by_source

--- a/mod-source-record-manager-server/src/main/resources/templates/db_scripts/schema.json
+++ b/mod-source-record-manager-server/src/main/resources/templates/db_scripts/schema.json
@@ -296,6 +296,11 @@
       "run": "after",
       "snippetPath": "create_get_record_processing_log_function.sql",
       "fromModuleVersion": "mod-source-record-manager-3.9.0"
+    },
+    {
+      "run": "after",
+      "snippetPath": "create_get_job_execution_summary_function.sql",
+      "fromModuleVersion": "mod-source-record-manager-3.8.2"
     }
   ]
 }

--- a/mod-source-record-manager-server/src/main/resources/templates/db_scripts/schema.json
+++ b/mod-source-record-manager-server/src/main/resources/templates/db_scripts/schema.json
@@ -300,7 +300,7 @@
     {
       "run": "after",
       "snippetPath": "create_get_job_execution_summary_function.sql",
-      "fromModuleVersion": "mod-source-record-manager-3.8.2"
+      "fromModuleVersion": "mod-source-record-manager-3.8.3"
     }
   ]
 }

--- a/mod-source-record-manager-server/src/test/java/org/folio/rest/impl/metadataProvider/MetadataProviderJobExecutionAPITest.java
+++ b/mod-source-record-manager-server/src/test/java/org/folio/rest/impl/metadataProvider/MetadataProviderJobExecutionAPITest.java
@@ -60,8 +60,10 @@ import static org.folio.rest.jaxrs.model.JobProfileInfo.DataType.MARC;
 import static org.folio.rest.jaxrs.model.JournalRecord.ActionStatus.COMPLETED;
 import static org.folio.rest.jaxrs.model.JournalRecord.ActionStatus.ERROR;
 import static org.folio.rest.jaxrs.model.JournalRecord.ActionType.CREATE;
+import static org.folio.rest.jaxrs.model.JournalRecord.ActionType.MATCH;
 import static org.folio.rest.jaxrs.model.JournalRecord.ActionType.MODIFY;
 import static org.folio.rest.jaxrs.model.JournalRecord.ActionType.NON_MATCH;
+import static org.folio.rest.jaxrs.model.JournalRecord.ActionType.PARSE;
 import static org.folio.rest.jaxrs.model.JournalRecord.ActionType.UPDATE;
 import static org.folio.rest.jaxrs.model.JournalRecord.EntityType.AUTHORITY;
 import static org.folio.rest.jaxrs.model.JournalRecord.EntityType.EDIFACT;
@@ -74,6 +76,7 @@ import static org.folio.rest.jaxrs.model.JournalRecord.EntityType.MARC_BIBLIOGRA
 import static org.folio.rest.jaxrs.model.JournalRecord.EntityType.PO_LINE;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.empty;
+import static org.hamcrest.Matchers.emptyOrNullString;
 import static org.hamcrest.Matchers.emptyString;
 import static org.hamcrest.Matchers.everyItem;
 import static org.hamcrest.Matchers.greaterThan;
@@ -81,6 +84,7 @@ import static org.hamcrest.Matchers.greaterThanOrEqualTo;
 import static org.hamcrest.Matchers.hasItem;
 import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.isEmptyString;
 import static org.hamcrest.Matchers.lessThan;
 import static org.hamcrest.Matchers.lessThanOrEqualTo;
 import static org.hamcrest.Matchers.not;
@@ -1230,6 +1234,201 @@ public class MetadataProviderJobExecutionAPITest extends AbstractRestTest {
         .body("instanceSummary.totalErrors", is(1))
         .body("totalErrors", is(1));
 
+      async.complete();
+    }));
+  }
+
+  @Test
+  public void shouldReturnDiscardedForMarcBibAndInstanceIfMarcBibMatchedAndNoOtherAction(TestContext context) {
+    Async async = context.async();
+    JobExecution createdJobExecution = constructAndPostInitJobExecutionRqDto(1).getJobExecutions().get(0);
+    String sourceRecordId = UUID.randomUUID().toString();
+    String recordTitle = "test title";
+
+    Future<JournalRecord> future = Future.succeededFuture()
+      .compose(v -> createJournalRecord(createdJobExecution.getId(), sourceRecordId, null, null, recordTitle, 0, MATCH, MARC_BIBLIOGRAPHIC, COMPLETED, null))
+      .compose(v -> createJournalRecord(createdJobExecution.getId(), sourceRecordId, null, null, recordTitle, 0, MATCH, INSTANCE, COMPLETED, null))
+      .onFailure(context::fail);
+
+    future.onComplete(ar -> context.verify(v -> {
+      RestAssured.given()
+        .spec(spec)
+        .when()
+        .get(GET_JOB_EXECUTION_SUMMARY_PATH + "/" + createdJobExecution.getId())
+        .then()
+        .statusCode(HttpStatus.SC_OK)
+        .body("sourceRecordSummary.totalCreatedEntities", is(0))
+        .body("sourceRecordSummary.totalUpdatedEntities", is(0))
+        .body("sourceRecordSummary.totalDiscardedEntities", is(1))
+        .body("sourceRecordSummary.totalErrors", is(0))
+        .body("instanceSummary.totalCreatedEntities", is(0))
+        .body("instanceSummary.totalUpdatedEntities", is(0))
+        .body("instanceSummary.totalDiscardedEntities", is(1))
+        .body("instanceSummary.totalErrors", is(0))
+        .body("totalErrors", is(0));
+
+      async.complete();
+    }));
+  }
+
+  @Test
+  public void shouldReturnDiscardedForHoldingsIfHoldingsMatchedAndNoOtherAction(TestContext context) {
+    Async async = context.async();
+    JobExecution createdJobExecution = constructAndPostInitJobExecutionRqDto(1).getJobExecutions().get(0);
+    String sourceRecordId = UUID.randomUUID().toString();
+    String recordTitle = "test title";
+
+    Future<JournalRecord> future = Future.succeededFuture()
+      .compose(v -> createJournalRecord(createdJobExecution.getId(), sourceRecordId, null, null, null, 0, PARSE, null, COMPLETED, null))
+      .compose(v -> createJournalRecord(createdJobExecution.getId(), sourceRecordId, null, null, recordTitle, 0, MATCH, HOLDINGS, COMPLETED, null))
+      .onFailure(context::fail);
+
+    future.onComplete(ar -> context.verify(v -> {
+      RestAssured.given()
+        .spec(spec)
+        .when()
+        .get(GET_JOB_EXECUTION_SUMMARY_PATH + "/" + createdJobExecution.getId())
+        .then()
+        .statusCode(HttpStatus.SC_OK)
+        .body("holdingSummary.totalCreatedEntities", is(0))
+        .body("holdingSummary.totalUpdatedEntities", is(0))
+        .body("holdingSummary.totalDiscardedEntities", is(1))
+        .body("holdingSummary.totalErrors", is(0))
+        .body("totalErrors", is(0));
+
+      async.complete();
+    }));
+  }
+
+  @Test
+  public void shouldReturnDiscardedForItemIfItemMatchedAndNoOtherAction(TestContext context) {
+    Async async = context.async();
+    JobExecution createdJobExecution = constructAndPostInitJobExecutionRqDto(1).getJobExecutions().get(0);
+    String sourceRecordId = UUID.randomUUID().toString();
+    String recordTitle = "test title";
+
+    Future<JournalRecord> future = Future.succeededFuture()
+      .compose(v -> createJournalRecord(createdJobExecution.getId(), sourceRecordId, null, null, null, 0, PARSE, null, COMPLETED, null))
+      .compose(v -> createJournalRecord(createdJobExecution.getId(), sourceRecordId, null, null, recordTitle, 0, MATCH, ITEM, COMPLETED, null))
+      .onFailure(context::fail);
+
+    future.onComplete(ar -> context.verify(v -> {
+      RestAssured.given()
+        .spec(spec)
+        .when()
+        .get(GET_JOB_EXECUTION_SUMMARY_PATH + "/" + createdJobExecution.getId())
+        .then()
+        .statusCode(HttpStatus.SC_OK)
+        .body("itemSummary.totalCreatedEntities", is(0))
+        .body("itemSummary.totalUpdatedEntities", is(0))
+        .body("itemSummary.totalDiscardedEntities", is(1))
+        .body("itemSummary.totalErrors", is(0))
+        .body("totalErrors", is(0));
+
+      async.complete();
+    }));
+  }
+
+  @Test
+  public void shouldReturnDiscardedForAuthorityIfAuthorityMatchedAndNoOtherAction(TestContext context) {
+    Async async = context.async();
+    JobExecution createdJobExecution = constructAndPostInitJobExecutionRqDto(1).getJobExecutions().get(0);
+    String sourceRecordId = UUID.randomUUID().toString();
+    String recordTitle = "test title";
+
+    Future<JournalRecord> future = Future.succeededFuture()
+      .compose(v -> createJournalRecord(createdJobExecution.getId(), sourceRecordId, null, null, null, 0, PARSE, null, COMPLETED, null))
+      .compose(v -> createJournalRecord(createdJobExecution.getId(), sourceRecordId, null, null, recordTitle, 0, MATCH, MARC_AUTHORITY, COMPLETED, null))
+      .compose(v -> createJournalRecord(createdJobExecution.getId(), sourceRecordId, null, null, recordTitle, 0, MATCH, AUTHORITY, COMPLETED, null))
+      .onFailure(context::fail);
+
+    future.onComplete(ar -> context.verify(v -> {
+      RestAssured.given()
+        .spec(spec)
+        .when()
+        .get(GET_JOB_EXECUTION_SUMMARY_PATH + "/" + createdJobExecution.getId())
+        .then()
+        .statusCode(HttpStatus.SC_OK)
+        .body("authoritySummary.totalCreatedEntities", is(0))
+        .body("authoritySummary.totalUpdatedEntities", is(0))
+        .body("authoritySummary.totalDiscardedEntities", is(1))
+        .body("authoritySummary.totalErrors", is(0))
+        .body("totalErrors", is(0));
+      async.complete();
+    }));
+  }
+
+  @Test
+  public void shouldNotReturnDiscardedForMarcBibAndInstanceIfHoldingsCreatedOnMatchByInstance(TestContext context) {
+    Async async = context.async();
+    JobExecution createdJobExecution = constructAndPostInitJobExecutionRqDto(1).getJobExecutions().get(0);
+    String sourceRecordId = UUID.randomUUID().toString();
+    String recordTitle = "test title";
+    String holdingsEntityId = UUID.randomUUID().toString();
+    String holdingsHrId = "holdingsHrid";
+
+    Future<JournalRecord> future = Future.succeededFuture()
+      .compose(v -> createJournalRecord(createdJobExecution.getId(), sourceRecordId, null, null, recordTitle, 0, MATCH, MARC_BIBLIOGRAPHIC, COMPLETED, null))
+      .compose(v -> createJournalRecord(createdJobExecution.getId(), sourceRecordId, null, null, recordTitle, 0, MATCH, INSTANCE, COMPLETED, null))
+      .compose(v -> createJournalRecord(createdJobExecution.getId(), sourceRecordId, holdingsEntityId, holdingsHrId, recordTitle, 0, CREATE, HOLDINGS, COMPLETED, null))
+      .onFailure(context::fail);
+
+    future.onComplete(ar -> context.verify(v -> {
+      RestAssured.given()
+        .spec(spec)
+        .when()
+        .get(GET_JOB_EXECUTION_SUMMARY_PATH + "/" + createdJobExecution.getId())
+        .then()
+        .statusCode(HttpStatus.SC_OK)
+        .body("sourceRecordSummary.totalCreatedEntities", emptyOrNullString())
+        .body("sourceRecordSummary.totalUpdatedEntities", emptyOrNullString())
+        .body("sourceRecordSummary.totalDiscardedEntities", emptyOrNullString())
+        .body("sourceRecordSummary.totalErrors", emptyOrNullString())
+        .body("instanceSummary.totalCreatedEntities", emptyOrNullString())
+        .body("instanceSummary.totalUpdatedEntities", emptyOrNullString())
+        .body("instanceSummary.totalDiscardedEntities", emptyOrNullString())
+        .body("instanceSummary.totalErrors", emptyOrNullString())
+        .body("holdingSummary.totalCreatedEntities", is(1))
+        .body("holdingSummary.totalUpdatedEntities", is(0))
+        .body("holdingSummary.totalDiscardedEntities", is(0))
+        .body("holdingSummary.totalErrors", is(0))
+        .body("totalErrors", is(0));
+      async.complete();
+    }));
+  }
+
+  @Test
+  public void shouldNotReturnDiscardedForHoldingsIfItemCreatedOnMatchByHoldings(TestContext context) {
+    Async async = context.async();
+    JobExecution createdJobExecution = constructAndPostInitJobExecutionRqDto(1).getJobExecutions().get(0);
+    String incomingRecordId = UUID.randomUUID().toString();
+    String recordTitle = "test title";
+
+    String itemEntityId = UUID.randomUUID().toString();
+    String itemHrId = "itemHrid";
+
+    Future<JournalRecord> future = Future.succeededFuture()
+      .compose(v -> createJournalRecord(createdJobExecution.getId(), incomingRecordId, null, null, null, 0, PARSE, null, COMPLETED, null))
+      .compose(v -> createJournalRecord(createdJobExecution.getId(), incomingRecordId, null, null, recordTitle, 0, MATCH, HOLDINGS, COMPLETED, null))
+      .compose(v -> createJournalRecord(createdJobExecution.getId(), incomingRecordId, itemEntityId, itemHrId, recordTitle, 0, CREATE, ITEM, COMPLETED, null))
+      .onFailure(context::fail);
+
+    future.onComplete(ar -> context.verify(v -> {
+      RestAssured.given()
+        .spec(spec)
+        .when()
+        .get(GET_JOB_EXECUTION_SUMMARY_PATH + "/" + createdJobExecution.getId())
+        .then()
+        .statusCode(HttpStatus.SC_OK)
+        .body("holdingSummary.totalCreatedEntities", emptyOrNullString())
+        .body("holdingSummary.totalUpdatedEntities", emptyOrNullString())
+        .body("holdingSummary.totalDiscardedEntities", emptyOrNullString())
+        .body("holdingSummary.totalErrors", emptyOrNullString())
+        .body("itemSummary.totalCreatedEntities", is(1))
+        .body("itemSummary.totalUpdatedEntities", is(0))
+        .body("itemSummary.totalDiscardedEntities", is(0))
+        .body("itemSummary.totalErrors", is(0))
+        .body("totalErrors", is(0));
       async.complete();
     }));
   }


### PR DESCRIPTION
## Purpose
Adjust job execution summary table to count MATCH action
## Approach

- Count 'MATCH' journal_record as 'NO ACTION'
- Retrieve 'MATCH' record only if no other record with different action type