### PR TITLE
MODSOURMAN-1176 The 'User' filter is not updated after logs deletion

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -4,6 +4,7 @@
 * [MODSOURMAN-1152](https://folio-org.atlassian.net/browse/MODSOURMAN-1152) The error message is not displayed in the di log summary
 * [MODSOURMAN-1151](https://folio-org.atlassian.net/browse/MODSOURMAN-1151) Records are not displayed under their original numbers and are constantly changing by places
 * [MODSOURMAN-1120](https://folio-org.atlassian.net/browse/MODSOURMAN-1120) Update default mapping to include mapping for Cancelled LCCN
+* [MODSOURMAN-1176](https://folio-org.atlassian.net/browse/MODSOURMAN-1176) The 'User' filter is not updated after logs deletion
 
 ## 2023-03-22 v3.8.0
 * [MODSOURMAN-1131](https://folio-org.atlassian.net/browse/MODSOURMAN-1131) The import of file for creating orders is completed with errors

--- a/mod-source-record-manager-server/src/main/java/org/folio/dao/util/JobExecutionDBConstants.java
+++ b/mod-source-record-manager-server/src/main/java/org/folio/dao/util/JobExecutionDBConstants.java
@@ -101,7 +101,7 @@ public final class JobExecutionDBConstants {
   public static final String GET_UNIQUE_USERS = "WITH unique_users AS (SELECT DISTINCT user_id, " +
     "job_user_first_name, job_user_last_name " +
     "FROM %s " +
-    "WHERE job_profile_hidden = false AND is_deleted = false AND subordination_type NOT IN ('PARENT_MULTIPLE','COMPOSITE_PARENT')" +
+    "WHERE job_profile_hidden = false AND is_deleted = false AND subordination_type NOT IN ('PARENT_MULTIPLE','COMPOSITE_PARENT') " +
     "AND status IN ('COMMITTED', 'ERROR', 'CANCELLED'))," +
     "total AS (SELECT count(*) AS total_count FROM unique_users)" +
     "SELECT j.*, p.* FROM unique_users j LEFT JOIN total p ON true LIMIT $1 OFFSET $2";

--- a/mod-source-record-manager-server/src/main/java/org/folio/dao/util/JobExecutionDBConstants.java
+++ b/mod-source-record-manager-server/src/main/java/org/folio/dao/util/JobExecutionDBConstants.java
@@ -101,7 +101,7 @@ public final class JobExecutionDBConstants {
   public static final String GET_UNIQUE_USERS = "WITH unique_users AS (SELECT DISTINCT user_id, " +
     "job_user_first_name, job_user_last_name " +
     "FROM %s " +
-    "WHERE job_profile_hidden = false AND is_deleted = false AND subordination_type <> 'PARENT_MULTIPLE' " +
+    "WHERE job_profile_hidden = false AND is_deleted = false AND subordination_type NOT IN ('PARENT_MULTIPLE','COMPOSITE_PARENT')" +
     "AND status IN ('COMMITTED', 'ERROR', 'CANCELLED'))," +
     "total AS (SELECT count(*) AS total_count FROM unique_users)" +
     "SELECT j.*, p.* FROM unique_users j LEFT JOIN total p ON true LIMIT $1 OFFSET $2";


### PR DESCRIPTION
## Purpose
The 'User' filter is not updated after logs deletion

## Approach
- Adjusted condition for retrieving unique users;
- Added test case to ignore composite parent during retrieving unique users.


## Checklist
- [x] I have updated NEWS.md.
- [ ] I have added javadocs to new methods.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation e.g. README.md.
- [ ] I have ran karate tests against this feature.

