### PR TITLE
MODSOURMAN-1185 - Logs are duplicated on the import logs page for order import

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -9,6 +9,7 @@
 * [MODSOURMAN-1127](https://folio-org.atlassian.net/browse/MODSOURMAN-1127) Change mapping for 010 sub-fields to separate LCCN and Cancelled LCCN
 * [MODSOURMAN-1145](https://issues.folio.org/browse/MODSOURMAN-1145) Modify action before match breaks non match logs
 * [MODSOURMAN-1188](https://issues.folio.org/browse/MODSOURMAN-1188) Change MARC mappings of 010 $z from "Cancelled" LCCN to "Canceled LCCN"
+* [MODSOURMAN-1185](https://folio-org.atlassian.net/browse/MODSOURMAN-1185) Logs are duplicated on the import logs page for order import
 
 ## 2023-03-22 v3.8.0
 * [MODSOURMAN-1131](https://folio-org.atlassian.net/browse/MODSOURMAN-1131) The import of file for creating orders is completed with errors

--- a/mod-source-record-manager-server/src/main/java/org/folio/verticle/consumers/util/MarcImportEventsHandler.java
+++ b/mod-source-record-manager-server/src/main/java/org/folio/verticle/consumers/util/MarcImportEventsHandler.java
@@ -1,7 +1,6 @@
 package org.folio.verticle.consumers.util;
 
 import com.google.common.collect.Lists;
-import io.vertx.core.CompositeFuture;
 import io.vertx.core.Future;
 import io.vertx.core.json.Json;
 import io.vertx.core.json.JsonArray;
@@ -109,7 +108,7 @@ public class MarcImportEventsHandler implements SpecificEventHandler {
       List<JournalRecord> journalRecords = JournalUtil.buildJournalRecordsByEvent(eventPayload,
         journalParams.journalActionType, journalParams.journalEntityType, journalParams.journalActionStatus);
 
-      CompositeFuture.all(improveJournalRecordsIfNeeded(journalService, eventPayload, tenantId, journalRecords))
+      Future.all(improveJournalRecordsIfNeeded(journalService, eventPayload, tenantId, journalRecords))
         .onComplete(e ->
         {
           List<JsonObject> jsonObjects = new ArrayList<>();
@@ -119,7 +118,7 @@ public class MarcImportEventsHandler implements SpecificEventHandler {
     }
   }
 
-  private List<Future> improveJournalRecordsIfNeeded(JournalService journalService, DataImportEventPayload eventPayload, String tenantId, List<JournalRecord> journalRecords) {
+  private List<Future<JournalRecord>> improveJournalRecordsIfNeeded(JournalService journalService, DataImportEventPayload eventPayload, String tenantId, List<JournalRecord> journalRecords) {
     List<Future<JournalRecord>> futureRecords = new ArrayList<>();
     for (JournalRecord journalRecord : journalRecords) {
       futureRecords.add(populateRecordTitleIfNeeded(journalRecord, eventPayload));

--- a/mod-source-record-manager-server/src/test/java/org/folio/verticle/consumers/util/MarcImportEventsHandlerTest.java
+++ b/mod-source-record-manager-server/src/test/java/org/folio/verticle/consumers/util/MarcImportEventsHandlerTest.java
@@ -13,10 +13,8 @@ import static org.folio.rest.jaxrs.model.DataImportEventTypes.DI_ORDER_CREATED_R
 import static org.folio.rest.jaxrs.model.DataImportEventTypes.DI_PENDING_ORDER_CREATED;
 import static org.folio.rest.jaxrs.model.DataImportEventTypes.DI_SRS_MARC_AUTHORITY_RECORD_CREATED;
 import static org.folio.rest.jaxrs.model.DataImportEventTypes.DI_INCOMING_MARC_BIB_RECORD_PARSED;
-import static org.folio.verticle.consumers.util.MarcImportEventsHandler.NO_TITLE_MESSAGE;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
@@ -302,12 +300,12 @@ public class MarcImportEventsHandlerTest {
     String subfieldATitleValue = "The Journal";
     String subfieldBTitleValue = "of ecclesiastical history.";
     String expectedTitle = "The Journal of ecclesiastical history.";
-    when(mappingRuleCache.get(any())).thenReturn(Future.succeededFuture(Optional.of(new JsonObject(
-      Map.of("245", List.of(
-        Map.of("target", "title",
-          "subfield", List.of("a", "b"))
-      ))
-    ))));
+    when(mappingRuleCache.get(any())).thenReturn(Future.succeededFuture(Optional.of(new JsonObject()
+      .put("245", JsonArray.of(new JsonObject()
+        .put("target", "title")
+        .put("subfield", JsonArray.of("a", "b")))))
+    ));
+
     var marcRecord = marcFactory.newRecord();
     marcRecord.addVariableField(marcFactory.newDataField("245", '0', '0', "a", subfieldATitleValue));
     marcRecord.addVariableField(marcFactory.newDataField("245", '0', '0', "b", subfieldBTitleValue));

--- a/mod-source-record-manager-server/src/test/java/org/folio/verticle/consumers/util/MarcImportEventsHandlerTest.java
+++ b/mod-source-record-manager-server/src/test/java/org/folio/verticle/consumers/util/MarcImportEventsHandlerTest.java
@@ -77,7 +77,7 @@ public class MarcImportEventsHandlerTest {
   private AutoCloseable mocks;
 
   @Before
-  public void setUp() throws IOException {
+  public void setUp() {
     mocks = MockitoAnnotations.openMocks(this);
     handler = new MarcImportEventsHandler(mappingRuleCache, journalRecordService);
   }

--- a/mod-source-record-manager-server/src/test/java/org/folio/verticle/consumers/util/MarcImportEventsHandlerTest.java
+++ b/mod-source-record-manager-server/src/test/java/org/folio/verticle/consumers/util/MarcImportEventsHandlerTest.java
@@ -15,6 +15,7 @@ import static org.folio.rest.jaxrs.model.DataImportEventTypes.DI_SRS_MARC_AUTHOR
 import static org.folio.rest.jaxrs.model.DataImportEventTypes.DI_INCOMING_MARC_BIB_RECORD_PARSED;
 import static org.folio.verticle.consumers.util.MarcImportEventsHandler.NO_TITLE_MESSAGE;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
@@ -205,7 +206,7 @@ public class MarcImportEventsHandlerTest {
     var actualJournalRecord = journalRecordCaptor.getValue().getJsonObject(0).mapTo(JournalRecord.class);
     verify(journalRecordService, times(0)).updateErrorJournalRecordsByOrderIdAndJobExecution(anyString(), anyString(), anyString(), anyString());
 
-    assertNull(actualJournalRecord.getTitle());
+    assertNotNull(actualJournalRecord.getTitle());
   }
 
   @Test
@@ -230,7 +231,7 @@ public class MarcImportEventsHandlerTest {
 
     var actualJournalRecord = journalRecordCaptor.getValue().getJsonObject(0).mapTo(JournalRecord.class);
 
-    assertEquals(actualJournalRecord.getTitle(), NO_TITLE_MESSAGE);
+    assertEquals(title, actualJournalRecord.getTitle());
   }
 
   @Test


### PR DESCRIPTION
## Purpose
to avoid row duplication in the main table on the import job logs page for the case of order and instance import import
when imported order and imported instance contain different title


## Approach
* populate title for order line journal record with extracted data from MARC record field in compliance with marc bib mapping rules
* update test


## Learning
[MODSOURMAN-1185](https://issues.folio.org/browse/MODSOURMAN-1185)