### PR TITLE
[MODSOURMAN-1187] Set INCOMING_RECORD_ID at context if error during parsing of record

### DIFF
--- a/mod-source-record-manager-server/src/main/java/org/folio/services/RecordsPublishingServiceImpl.java
+++ b/mod-source-record-manager-server/src/main/java/org/folio/services/RecordsPublishingServiceImpl.java
@@ -35,6 +35,7 @@ import java.util.concurrent.atomic.AtomicInteger;
 
 import static java.lang.String.format;
 import static org.folio.rest.jaxrs.model.DataImportEventTypes.DI_ERROR;
+import static org.folio.services.journal.JournalUtil.INCOMING_RECORD_ID;
 import static org.folio.services.util.EventHandlingUtil.sendEventToKafka;
 
 @Service("recordsPublishingService")
@@ -177,8 +178,11 @@ import static org.folio.services.util.EventHandlingUtil.sendEventToKafka;
   private void sendDiError(Throwable throwable, String jobExecutionId, OkapiConnectionParams okapiParams, Record record) {
     HashMap<String, String> context = new HashMap<>();
     context.put(ERROR_KEY, throwable.getMessage());
-    if (record != null && record.getRecordType() != null) {
-      context.put(RecordConversionUtil.getEntityType(record).value(), Json.encode(record));
+    if (record != null) {
+      context.put(INCOMING_RECORD_ID, record.getId());
+      if (record.getRecordType() != null) {
+        context.put(RecordConversionUtil.getEntityType(record).value(), Json.encode(record));
+      }
     }
 
     DataImportEventPayload payload = new DataImportEventPayload()

--- a/mod-source-record-manager-server/src/main/java/org/folio/verticle/consumers/errorhandlers/RawMarcChunksErrorHandler.java
+++ b/mod-source-record-manager-server/src/main/java/org/folio/verticle/consumers/errorhandlers/RawMarcChunksErrorHandler.java
@@ -137,9 +137,11 @@ public class RawMarcChunksErrorHandler implements ProcessRecordErrorHandler<Stri
   private void sendDiError(Throwable throwable, String jobExecutionId, OkapiConnectionParams okapiParams, Record record) {
     HashMap<String, String> context = new HashMap<>();
     context.put(ERROR_KEY, throwable.getMessage());
-    if (record != null && record.getRecordType() != null) {
-      context.put(RecordConversionUtil.getEntityType(record).value(), Json.encode(record));
+    if (record != null) {
       context.put(INCOMING_RECORD_ID, record.getId());
+      if (record.getRecordType() != null) {
+        context.put(RecordConversionUtil.getEntityType(record).value(), Json.encode(record));
+      }
     }
 
     DataImportEventPayload payload = new DataImportEventPayload()

--- a/mod-source-record-manager-server/src/test/java/org/folio/verticle/consumers/RawMarcChunkConsumersVerticleTest.java
+++ b/mod-source-record-manager-server/src/test/java/org/folio/verticle/consumers/RawMarcChunkConsumersVerticleTest.java
@@ -374,6 +374,7 @@ public class RawMarcChunkConsumersVerticleTest extends AbstractRestTest {
     Event obtainedEvent = checkEventWithTypeSent(DI_ERROR);
     DataImportEventPayload eventPayload = Json.decodeValue(obtainedEvent.getEventPayload(), DataImportEventPayload.class);
     assertEquals(DI_ERROR.value(), eventPayload.getEventType());
+    assertNotNull(eventPayload.getContext().get(INCOMING_RECORD_ID_KEY));
   }
 
   @Test


### PR DESCRIPTION
## Purpose
Fix "Failed to decode" error message is not displayed in the SRS JSON page after opening JSON tab
## Approach
Set INCOMING_RECORD_ID at context if error during parsing of record