### PR TITLE
[FAT-16007] Do not form redundant null journal record during transform of PO_LINE event

### DIFF
--- a/mod-source-record-manager-server/src/main/java/org/folio/verticle/DataImportJournalBatchConsumerVerticle.java
+++ b/mod-source-record-manager-server/src/main/java/org/folio/verticle/DataImportJournalBatchConsumerVerticle.java
@@ -48,7 +48,6 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Objects;
 import java.util.Optional;
 import java.util.UUID;
 import java.util.concurrent.TimeUnit;
@@ -300,7 +299,6 @@ public class DataImportJournalBatchConsumerVerticle extends AbstractVerticle {
               Collection<JournalRecord> journalRecords = pairs
                 .stream()
                 .flatMap(pair -> pair.getRight().stream().map(BatchableJournalRecord::getJournalRecord))
-                .filter(Objects::nonNull)
                 .map(this::setDeterministicIdentifer)
                 .toList();
               // If no records or tenant ID is missing, complete without action

--- a/mod-source-record-manager-server/src/main/java/org/folio/verticle/DataImportJournalBatchConsumerVerticle.java
+++ b/mod-source-record-manager-server/src/main/java/org/folio/verticle/DataImportJournalBatchConsumerVerticle.java
@@ -48,6 +48,7 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.UUID;
 import java.util.concurrent.TimeUnit;
@@ -299,6 +300,7 @@ public class DataImportJournalBatchConsumerVerticle extends AbstractVerticle {
               Collection<JournalRecord> journalRecords = pairs
                 .stream()
                 .flatMap(pair -> pair.getRight().stream().map(BatchableJournalRecord::getJournalRecord))
+                .filter(Objects::nonNull)
                 .map(this::setDeterministicIdentifer)
                 .toList();
               // If no records or tenant ID is missing, complete without action

--- a/mod-source-record-manager-server/src/main/java/org/folio/verticle/consumers/util/MarcImportEventsHandler.java
+++ b/mod-source-record-manager-server/src/main/java/org/folio/verticle/consumers/util/MarcImportEventsHandler.java
@@ -13,7 +13,6 @@ import org.folio.rest.jaxrs.model.Record;
 import org.folio.services.JournalRecordService;
 import org.folio.services.MappingRuleCache;
 import org.folio.services.entity.MappingRuleCacheKey;
-import org.folio.services.journal.BatchJournalService;
 import org.folio.services.journal.JournalRecordMapperException;
 import org.folio.services.journal.JournalService;
 import org.folio.services.journal.JournalUtil;

--- a/mod-source-record-manager-server/src/main/java/org/folio/verticle/consumers/util/MarcImportEventsHandler.java
+++ b/mod-source-record-manager-server/src/main/java/org/folio/verticle/consumers/util/MarcImportEventsHandler.java
@@ -137,20 +137,19 @@ public class MarcImportEventsHandler implements SpecificEventHandler {
           return Future.all(improveJournalRecordsIfNeeded(journalService, eventPayload, tenantId, journalRecords))
             .map(ar -> ar.result().<JournalRecord>list());
         }
-        return Future.succeededFuture();
+        return Future.succeededFuture(new ArrayList<>());
   }
 
   private List<Future<JournalRecord>> improveJournalRecordsIfNeeded(JournalService journalService, DataImportEventPayload eventPayload, String tenantId, List<JournalRecord> journalRecords) {
     List<Future<JournalRecord>> futureRecords = new ArrayList<>();
     for (JournalRecord journalRecord : journalRecords) {
-      if(StringUtils.isBlank(journalRecord.getTenantId())) {
+      if (StringUtils.isBlank(journalRecord.getTenantId())) {
         journalRecord.setTenantId(tenantId);
       }
-      futureRecords.add(populateRecordTitleIfNeeded(journalRecord, eventPayload));
       if (Objects.equals(journalRecord.getEntityType(), PO_LINE)) {
         processJournalRecordForOrder(journalService, tenantId, journalRecord);
-        futureRecords.add(Future.succeededFuture());
       }
+      futureRecords.add(populateRecordTitleIfNeeded(journalRecord, eventPayload));
     }
     return Lists.newArrayList(futureRecords);
   }

--- a/mod-source-record-manager-server/src/test/java/org/folio/verticle/consumers/util/MarcImportEventsHandlerTest.java
+++ b/mod-source-record-manager-server/src/test/java/org/folio/verticle/consumers/util/MarcImportEventsHandlerTest.java
@@ -261,6 +261,22 @@ public class MarcImportEventsHandlerTest {
   }
 
   @Test
+  public void testTransformReturnEmptyListIfNoJournalParams(TestContext context) {
+    Async async = context.async();
+
+    var payload = new DataImportEventPayload()
+      .withEventType(DI_COMPLETED.value())
+      .withEventsChain(List.of("Test"));
+    handler.transform(journalService, payload, TEST_TENANT)
+      .onComplete(ar -> {
+        assertTrue(ar.succeeded());
+        assertEquals(0, ar.result().size());
+        async.complete();
+      });
+  }
+
+
+  @Test
   public void testSaveNonMatchHoldings() throws JournalRecordMapperException {
     String title = "The Journal of ecclesiastical history.";
     when(mappingRuleCache.get(any())).thenReturn(Future.succeededFuture(Optional.of(new JsonObject(


### PR DESCRIPTION
## Purpose
Fix failed karate tests 
https://jenkins-aws.indexdata.com/job/folioRancher/job/folioQualityGates/job/folioCiQualityGates/496/cucumber-html-reports/report-feature_206_3207137523.html
## Approach
Do not form redundant null journal record during transform of PO_LINE event