### PR TITLE
Fix DataImportConsumerVerticleTest in mod-inventory and Fix NPE in HoldingsItemMatcher, fix job log entries

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -13,6 +13,7 @@
 * [MODSOURMAN-1181](https://issues.folio.org/browse/MODSOURMAN-1181) Modify the get_job_log_entries function to increase performance.
 * [MODSOURMAN-1185](https://folio-org.atlassian.net/browse/MODSOURMAN-1185) Logs are duplicated on the import logs page for order import
 * [MODSOURMAN-1194](https://folio-org.atlassian.net/browse/MODSOURMAN-1194) Include subject metadata subfields in authority name fields
+* [MODSOURMAN-1215](https://folio-org.atlassian.net/browse/MODSOURMAN-1215) Upgrade Spring from 5 to 6.1.12
 
 ## 2023-03-22 v3.8.0
 * [MODSOURMAN-1131](https://folio-org.atlassian.net/browse/MODSOURMAN-1131) The import of file for creating orders is completed with errors

--- a/NEWS.md
+++ b/NEWS.md
@@ -14,6 +14,7 @@
 * [MODSOURMAN-1185](https://folio-org.atlassian.net/browse/MODSOURMAN-1185) Logs are duplicated on the import logs page for order import
 * [MODSOURMAN-1194](https://folio-org.atlassian.net/browse/MODSOURMAN-1194) Include subject metadata subfields in authority name fields
 * [MODSOURMAN-1215](https://folio-org.atlassian.net/browse/MODSOURMAN-1215) Upgrade Spring from 5 to 6.1.12
+* [MODINV-1069](https://folio-org.atlassian.net/browse/MODINV-1069) Fix DataImportConsumerVerticleTest in mod-inventory and Fix NPE in HoldingsItemMatcher, fix job log entries
 
 ## 2023-03-22 v3.8.0
 * [MODSOURMAN-1131](https://folio-org.atlassian.net/browse/MODSOURMAN-1131) The import of file for creating orders is completed with errors

--- a/mod-source-record-manager-server/src/main/resources/templates/db_scripts/create_get_job_log_entries_function.sql
+++ b/mod-source-record-manager-server/src/main/resources/templates/db_scripts/create_get_job_log_entries_function.sql
@@ -114,7 +114,7 @@ WITH
                  END
       FROM temp_result nested_result) AS joining_table
      ON tmp.id = joining_table.id
-WHERE tmp.entity_type = ''HOLDINGS''
+WHERE tmp.entity_type = ''HOLDINGS'' AND tmp.entity_id IS NOT NULL
   ),
   items AS (
     SELECT tmp.action_type, tmp.entity_id, tmp.holdings_id, tmp.entity_hrid, tmp.error, tmp.instance_id,
@@ -144,7 +144,7 @@ WHERE tmp.entity_type = ''HOLDINGS''
                  END
       FROM temp_result nested_result) AS joining_table
      ON tmp.id = joining_table.id
-WHERE tmp.entity_type = ''ITEM''
+WHERE tmp.entity_type = ''ITEM'' AND tmp.entity_id IS NOT NULL
   ),
   po_lines AS (
     SELECT action_type,entity_id,entity_hrid,temp_result.source_id,error,order_id,temp_result.job_execution_id,temp_result.title,temp_result.source_record_order

--- a/pom.xml
+++ b/pom.xml
@@ -21,7 +21,7 @@
   <properties>
     <raml-module-builder.version>35.2.0</raml-module-builder.version>
     <vertx.version>4.5.4</vertx.version>
-    <spring.version>5.3.30</spring.version>
+    <spring.version>6.1.12</spring.version>
     <junit.version>5.10.1</junit.version>
     <rest-assured.version>4.3.1</rest-assured.version>
     <wiremock.version>3.0.1</wiremock.version>


### PR DESCRIPTION
## Purpose
fix duplicate job log entries after update holdings and items with cascading profiles [MODINV-1069](https://folio-org.atlassian.net/browse/MODINV-1069)

## Approach
fix function job_log_entries

## Checklist
- [x] I have updated NEWS.md.
- [ ] I have added javadocs to new methods.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation e.g. README.md.
- [x] I have ran karate tests against this feature.

