### PR TITLE
[MODSOURMAN-1219] Set null parsed record for MARC_AUTHORITY di error journal record

### DIFF
--- a/mod-source-record-manager-server/src/main/java/org/folio/verticle/consumers/errorhandlers/payloadbuilders/MarcAuthorityDiErrorPayloadBuilder.java
+++ b/mod-source-record-manager-server/src/main/java/org/folio/verticle/consumers/errorhandlers/payloadbuilders/MarcAuthorityDiErrorPayloadBuilder.java
@@ -23,6 +23,6 @@ public class MarcAuthorityDiErrorPayloadBuilder implements DiErrorPayloadBuilder
                                                           String jobExecutionId,
                                                           Record currentRecord) {
     DataImportEventPayload diErrorPayload = DiErrorBuilderUtil.prepareDiErrorEventPayload(throwable, okapiParams, jobExecutionId, currentRecord);
-    return Future.succeededFuture(DiErrorBuilderUtil.makeLightweightPayload(currentRecord, NO_TITLE_MESSAGE, diErrorPayload));
+    return Future.succeededFuture(DiErrorBuilderUtil.makeLightweightPayload(currentRecord, null, diErrorPayload));
   }
 }

--- a/mod-source-record-manager-server/src/main/java/org/folio/verticle/consumers/errorhandlers/payloadbuilders/MarcAuthorityDiErrorPayloadBuilder.java
+++ b/mod-source-record-manager-server/src/main/java/org/folio/verticle/consumers/errorhandlers/payloadbuilders/MarcAuthorityDiErrorPayloadBuilder.java
@@ -8,7 +8,6 @@ import org.folio.verticle.consumers.util.DiErrorBuilderUtil;
 import org.springframework.stereotype.Component;
 
 import static org.folio.rest.jaxrs.model.Record.RecordType.MARC_AUTHORITY;
-import static org.folio.verticle.consumers.util.MarcImportEventsHandler.NO_TITLE_MESSAGE;
 
 @Component
 public class MarcAuthorityDiErrorPayloadBuilder implements DiErrorPayloadBuilder {

--- a/mod-source-record-manager-server/src/test/java/org/folio/verticle/consumers/errorhandlers/errorpayloadbuilders/MarcAuthorityPayloadBuilderTest.java
+++ b/mod-source-record-manager-server/src/test/java/org/folio/verticle/consumers/errorhandlers/errorpayloadbuilders/MarcAuthorityPayloadBuilderTest.java
@@ -3,7 +3,6 @@ package org.folio.verticle.consumers.errorhandlers.errorpayloadbuilders;
 import io.vertx.core.Future;
 import io.vertx.core.Vertx;
 import io.vertx.core.json.Json;
-import io.vertx.core.json.JsonObject;
 import io.vertx.ext.unit.Async;
 import io.vertx.ext.unit.TestContext;
 import io.vertx.ext.unit.junit.VertxUnitRunner;
@@ -14,8 +13,6 @@ import org.folio.dataimport.util.OkapiConnectionParams;
 import org.folio.rest.jaxrs.model.EntityType;
 import org.folio.rest.jaxrs.model.ParsedRecord;
 import org.folio.rest.jaxrs.model.Record;
-import org.folio.services.MappingRuleCache;
-import org.folio.services.entity.MappingRuleCacheKey;
 import org.folio.verticle.consumers.errorhandlers.payloadbuilders.MarcAuthorityDiErrorPayloadBuilder;
 import org.junit.Before;
 import org.junit.Test;
@@ -26,21 +23,17 @@ import org.mockito.MockitoAnnotations;
 
 import java.io.IOException;
 import java.util.HashMap;
-import java.util.Optional;
 import java.util.UUID;
 
 import static org.folio.dataimport.util.RestUtil.OKAPI_URL_HEADER;
 import static org.folio.rest.jaxrs.model.DataImportEventTypes.DI_ERROR;
 import static org.folio.rest.util.OkapiConnectionParams.OKAPI_TENANT_HEADER;
 import static org.folio.rest.util.OkapiConnectionParams.OKAPI_TOKEN_HEADER;
-import static org.folio.verticle.consumers.DataImportJournalConsumerVerticleMockTest.MAPPING_RULES_PATH;
 import static org.folio.verticle.consumers.errorhandlers.RawMarcChunksErrorHandler.ERROR_KEY;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
-import static org.mockito.Mockito.when;
 
 @RunWith(VertxUnitRunner.class)
 public class MarcAuthorityPayloadBuilderTest {

--- a/mod-source-record-manager-server/src/test/java/org/folio/verticle/consumers/errorhandlers/errorpayloadbuilders/MarcAuthorityPayloadBuilderTest.java
+++ b/mod-source-record-manager-server/src/test/java/org/folio/verticle/consumers/errorhandlers/errorpayloadbuilders/MarcAuthorityPayloadBuilderTest.java
@@ -87,7 +87,7 @@ public class MarcAuthorityPayloadBuilderTest {
       assertTrue(result.getContext().containsKey(ERROR_KEY));
 
       Record resRecordWithTitle = getRecordFromContext(result);
-      assertNotNull(resRecordWithTitle.getParsedRecord());
+      assertNull(resRecordWithTitle.getParsedRecord());
       async.complete();
     });
   }
@@ -106,8 +106,7 @@ public class MarcAuthorityPayloadBuilderTest {
       assertTrue(result.getContext().containsKey(ERROR_KEY));
 
       Record resRecordWithNoTitle = getRecordFromContext(result);
-      assertNotNull(resRecordWithNoTitle.getParsedRecord());
-      assertEquals( "No content", resRecordWithNoTitle.getParsedRecord().getContent());
+      assertNull(resRecordWithNoTitle.getParsedRecord());
       async.complete();
     });
   }


### PR DESCRIPTION
## Purpose
Marc authority records with 999$f field are not displayed after importing file for creating records
## Approach
Set null parsed record for MARC_AUTHORITY parsing error journal record

### Jira
https://folio-org.atlassian.net/browse/MODSOURMAN-1219

