### PR TITLE
MODSOURMAN-1226: New "Subject" doesn't display in Instance detail when it was added via quickmarc/data import update action

### DIFF
--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -606,7 +606,9 @@
             "inventory-storage.modes-of-issuance.collection.get",
             "inventory-storage.nature-of-content-terms.collection.get",
             "inventory-storage.statistical-code-types.collection.get",
-            "inventory-storage.statistical-codes.collection.get"
+            "inventory-storage.statistical-codes.collection.get",
+            "inventory-storage.subject-sources.collection.get",
+            "inventory-storage.subject-types.collection.get"
           ]
         }
       ]

--- a/mod-source-record-manager-server/src/main/resources/rules/marc_bib_rules.json
+++ b/mod-source-record-manager-server/src/main/resources/rules/marc_bib_rules.json
@@ -5752,6 +5752,94 @@
   ],
   "600": [
     {
+      "entity": [
+        {
+          "target": "subjects.value",
+          "description": "Subject Headings",
+          "applyRulesOnConcatenatedData": true,
+          "subfield": [
+            "a",
+            "b",
+            "c",
+            "d",
+            "e",
+            "f",
+            "g",
+            "h",
+            "j",
+            "k",
+            "l",
+            "m",
+            "n",
+            "o",
+            "p",
+            "q",
+            "r",
+            "s",
+            "t",
+            "u",
+            "v",
+            "x",
+            "y",
+            "z"
+          ],
+          "rules": [
+            {
+              "conditions": [
+                {
+                  "type": "trim_period, trim"
+                }
+              ]
+            }
+          ],
+          "subFieldDelimiter": [
+            {
+              "value": " ",
+              "subfields": [
+                "a",
+                "b",
+                "c",
+                "d",
+                "j",
+                "q",
+                "t",
+                "f",
+                "g",
+                "k",
+                "l",
+                "m",
+                "n",
+                "o",
+                "p",
+                "r",
+                "s"
+              ]
+            },
+            {
+              "value": "--",
+              "subfields": [
+                "x",
+                "y",
+                "z",
+                "v"
+              ]
+            },
+            {
+              "value": "--",
+              "subfields": []
+            }
+          ]
+        },
+        {
+          "target": "series.authorityId",
+          "description": "Authority ID that controlling the subject",
+          "subfield": [
+            "9"
+          ]
+        }
+      ]
+    },
+    {
       "indicators": {
         "ind1": "*",
         "ind2": "0"
@@ -7178,6 +7266,89 @@
   ],
   "610": [
     {
+      "entity": [
+        {
+          "target": "subjects.value",
+          "description": "Subject Headings",
+          "applyRulesOnConcatenatedData": true,
+          "subfield": [
+            "a",
+            "b",
+            "c",
+            "d",
+            "e",
+            "f",
+            "g",
+            "h",
+            "k",
+            "l",
+            "m",
+            "n",
+            "o",
+            "p",
+            "r",
+            "s",
+            "t",
+            "u",
+            "v",
+            "x",
+            "y",
+            "z"
+          ],
+          "rules": [
+            {
+              "conditions": [
+                {
+                  "type": "trim_period, trim"
+                }
+              ]
+            }
+          ],
+          "subFieldDelimiter": [
+            {
+              "value": " ",
+              "subfields": [
+                "a",
+                "b",
+                "c",
+                "d",
+                "t",
+                "f",
+                "g",
+                "k",
+                "l",
+                "m",
+                "n",
+                "o",
+                "p",
+                "s"
+              ]
+            },
+            {
+              "value": "--",
+              "subfields": [
+                "x",
+                "y",
+                "z",
+                "v"
+              ]
+            },
+            {
+              "value": "--",
+              "subfields": []
+            }
+          ]
+        },
+        {
+          "target": "series.authorityId",
+          "description": "Authority ID that controlling the subject",
+          "subfield": [
+            "9"
+          ]
+        }
+      ]
+    },
+    {
       "indicators": {
         "ind1": "*",
         "ind2": "0"
@@ -8531,6 +8702,89 @@
   ],
   "611": [
     {
+      "entity": [
+        {
+          "target": "subjects.value",
+          "description": "Subject Headings",
+          "applyRulesOnConcatenatedData": true,
+          "subfield": [
+            "a",
+            "c",
+            "d",
+            "e",
+            "f",
+            "g",
+            "h",
+            "j",
+            "k",
+            "l",
+            "n",
+            "p",
+            "q",
+            "s",
+            "t",
+            "u",
+            "v",
+            "x",
+            "y",
+            "z"
+          ],
+          "rules": [
+            {
+              "conditions": [
+                {
+                  "type": "trim_period, trim"
+                }
+              ]
+            }
+          ],
+          "subFieldDelimiter": [
+            {
+              "value": " ",
+              "subfields": [
+                "a",
+                "c",
+                "d",
+                "e",
+                "q",
+                "t",
+                "f",
+                "g",
+                "k",
+                "l",
+                "m",
+                "n",
+                "o",
+                "p",
+                "r",
+                "s"
+              ]
+            },
+            {
+              "value": "--",
+              "subfields": [
+                "x",
+                "y",
+                "z",
+                "v"
+              ]
+            },
+            {
+              "value": "--",
+              "subfields": []
+            }
+          ]
+        },
+        {
+          "target": "series.authorityId",
+          "description": "Authority ID that controlling the subject",
+          "subfield": [
+            "9"
+          ]
+        }
+      ]
+    },
+    {
       "indicators": {
         "ind1": "*",
         "ind2": "0"
@@ -9852,6 +10106,84 @@
   ],
   "630": [
     {
+      "entity": [
+        {
+          "target": "subjects.value",
+          "description": "Subject Headings",
+          "applyRulesOnConcatenatedData": true,
+          "subfield": [
+            "a",
+            "d",
+            "e",
+            "f",
+            "g",
+            "h",
+            "k",
+            "l",
+            "m",
+            "n",
+            "o",
+            "p",
+            "r",
+            "s",
+            "t",
+            "v",
+            "x",
+            "y",
+            "z"
+          ],
+          "rules": [
+            {
+              "conditions": [
+                {
+                  "type": "trim_period, trim"
+                }
+              ]
+            }
+          ],
+          "subFieldDelimiter": [
+            {
+              "value": " ",
+              "subfields": [
+                "a",
+                "d",
+                "f",
+                "g",
+                "k",
+                "l",
+                "m",
+                "n",
+                "o",
+                "p",
+                "r",
+                "s"
+              ]
+            },
+            {
+              "value": "--",
+              "subfields": [
+                "x",
+                "y",
+                "z",
+                "v"
+              ]
+            },
+            {
+              "value": "--",
+              "subfields": []
+            }
+          ]
+        },
+        {
+          "target": "series.authorityId",
+          "description": "Authority ID that controlling the subject",
+          "subfield": [
+            "9"
+          ]
+        }
+      ]
+    },
+    {
       "indicators": {
         "ind1": "*",
         "ind2": "0"
@@ -11118,6 +11450,60 @@
   ],
   "647": [
     {
+      "entity": [
+        {
+          "target": "subjects.value",
+          "description": "Subject Headings",
+          "applyRulesOnConcatenatedData": true,
+          "subfield": [
+            "a",
+            "c",
+            "d",
+            "g",
+            "x",
+            "y",
+            "z",
+            "v"
+          ],
+          "rules": [
+            {
+              "conditions": [
+                {
+                  "type": "trim_period, trim"
+                }
+              ]
+            }
+          ],
+          "subFieldDelimiter": [
+            {
+              "value": "--",
+              "subfields": [
+                "a",
+                "c",
+                "d",
+                "g",
+                "x",
+                "y",
+                "z",
+                "v"
+              ]
+            },
+            {
+              "value": "--",
+              "subfields": []
+            }
+          ]
+        },
+        {
+          "target": "series.authorityId",
+          "description": "Authority ID that controlling the subject",
+          "subfield": [
+            "9"
+          ]
+        }
+      ]
+    },
+    {
       "indicators": {
         "ind1": "*",
         "ind2": "0"
@@ -12016,6 +12402,50 @@
   ],
   "648": [
     {
+      "entity": [
+        {
+          "target": "subjects.value",
+          "description": "Subject Headings",
+          "applyRulesOnConcatenatedData": true,
+          "subfield": [
+            "a",
+            "x",
+            "y",
+            "z",
+            "v"
+          ],
+          "rules": [
+            {
+              "conditions": [
+                {
+                  "type": "trim_period, trim"
+                }
+              ]
+            }
+          ],
+          "subFieldDelimiter": [
+            {
+              "value": "--",
+              "subfields": [
+                "a",
+                "x",
+                "y",
+                "z",
+                "v"
+              ]
+            }
+          ]
+        },
+        {
+          "target": "series.authorityId",
+          "description": "Authority ID that controlling the subject",
+          "subfield": [
+            "9"
+          ]
+        }
+      ]
+    },
+    {
       "indicators": {
         "ind1": "*",
         "ind2": "0"
@@ -12785,6 +13215,60 @@
     }
   ],
   "650": [
+    {
+      "entity": [
+        {
+          "target": "subjects.value",
+          "description": "Subject Headings",
+          "applyRulesOnConcatenatedData": true,
+          "subfield": [
+            "a",
+            "b",
+            "c",
+            "d",
+            "e",
+            "g",
+            "v",
+            "x",
+            "y",
+            "z"
+          ],
+          "rules": [
+            {
+              "conditions": [
+                {
+                  "type": "trim_period, trim"
+                }
+              ]
+            }
+          ],
+          "subFieldDelimiter": [
+            {
+              "value": "--",
+              "subfields": [
+                "a",
+                "b",
+                "c",
+                "d",
+                "e",
+                "g",
+                "v",
+                "x",
+                "y",
+                "z"
+              ]
+            }
+          ]
+        },
+        {
+          "target": "series.authorityId",
+          "description": "Authority ID that controlling the subject",
+          "subfield": [
+            "9"
+          ]
+        }
+      ]
+    },
     {
       "indicators": {
         "ind1": "*",
@@ -13716,6 +14200,54 @@
   ],
   "651": [
     {
+      "entity": [
+        {
+          "target": "subjects.value",
+          "description": "Subject Headings",
+          "applyRulesOnConcatenatedData": true,
+          "subfield": [
+            "a",
+            "e",
+            "g",
+            "v",
+            "x",
+            "y",
+            "z"
+          ],
+          "rules": [
+            {
+              "conditions": [
+                {
+                  "type": "trim_period, trim"
+                }
+              ]
+            }
+          ],
+          "subFieldDelimiter": [
+            {
+              "value": "--",
+              "subfields": [
+                "a",
+                "e",
+                "g",
+                "v",
+                "x",
+                "y",
+                "z"
+              ]
+            }
+          ]
+        },
+        {
+          "target": "series.authorityId",
+          "description": "Authority ID that controlling the subject",
+          "subfield": [
+            "9"
+          ]
+        }
+      ]
+    },
+    {
       "indicators": {
         "ind1": "*",
         "ind2": "0"
@@ -14549,6 +15081,54 @@
     }
   ],
   "655": [
+    {
+      "entity": [
+        {
+          "target": "subjects.value",
+          "description": "Subject Headings",
+          "applyRulesOnConcatenatedData": true,
+          "subfield": [
+            "a",
+            "b",
+            "c",
+            "v",
+            "x",
+            "y",
+            "z"
+          ],
+          "rules": [
+            {
+              "conditions": [
+                {
+                  "type": "trim_period, trim"
+                }
+              ]
+            }
+          ],
+          "subFieldDelimiter": [
+            {
+              "value": "--",
+              "subfields": [
+                "a",
+                "e",
+                "g",
+                "v",
+                "x",
+                "y",
+                "z"
+              ]
+            }
+          ]
+        },
+        {
+          "target": "series.authorityId",
+          "description": "Authority ID that controlling the subject",
+          "subfield": [
+            "9"
+          ]
+        }
+      ]
+    },
     {
       "indicators": {
         "ind1": "*",

--- a/mod-source-record-manager-server/src/main/resources/rules/marc_bib_rules.json
+++ b/mod-source-record-manager-server/src/main/resources/rules/marc_bib_rules.json
@@ -5831,7 +5831,7 @@
           ]
         },
         {
-          "target": "series.authorityId",
+          "target": "subjects.authorityId",
           "description": "Authority ID that controlling the subject",
           "subfield": [
             "9"
@@ -7340,7 +7340,7 @@
           ]
         },
         {
-          "target": "series.authorityId",
+          "target": "subjects.authorityId",
           "description": "Authority ID that controlling the subject",
           "subfield": [
             "9"
@@ -8776,7 +8776,7 @@
           ]
         },
         {
-          "target": "series.authorityId",
+          "target": "subjects.authorityId",
           "description": "Authority ID that controlling the subject",
           "subfield": [
             "9"
@@ -10175,7 +10175,7 @@
           ]
         },
         {
-          "target": "series.authorityId",
+          "target": "subjects.authorityId",
           "description": "Authority ID that controlling the subject",
           "subfield": [
             "9"
@@ -11495,7 +11495,7 @@
           ]
         },
         {
-          "target": "series.authorityId",
+          "target": "subjects.authorityId",
           "description": "Authority ID that controlling the subject",
           "subfield": [
             "9"
@@ -12437,7 +12437,7 @@
           ]
         },
         {
-          "target": "series.authorityId",
+          "target": "subjects.authorityId",
           "description": "Authority ID that controlling the subject",
           "subfield": [
             "9"
@@ -13261,7 +13261,7 @@
           ]
         },
         {
-          "target": "series.authorityId",
+          "target": "subjects.authorityId",
           "description": "Authority ID that controlling the subject",
           "subfield": [
             "9"
@@ -14239,7 +14239,7 @@
           ]
         },
         {
-          "target": "series.authorityId",
+          "target": "subjects.authorityId",
           "description": "Authority ID that controlling the subject",
           "subfield": [
             "9"
@@ -15121,7 +15121,7 @@
           ]
         },
         {
-          "target": "series.authorityId",
+          "target": "subjects.authorityId",
           "description": "Authority ID that controlling the subject",
           "subfield": [
             "9"

--- a/mod-source-record-manager-server/src/test/resources/org/folio/services/marc_bib_rules.json
+++ b/mod-source-record-manager-server/src/test/resources/org/folio/services/marc_bib_rules.json
@@ -5752,6 +5752,94 @@
   ],
   "600": [
     {
+      "entity": [
+        {
+          "target": "subjects.value",
+          "description": "Subject Headings",
+          "applyRulesOnConcatenatedData": true,
+          "subfield": [
+            "a",
+            "b",
+            "c",
+            "d",
+            "e",
+            "f",
+            "g",
+            "h",
+            "j",
+            "k",
+            "l",
+            "m",
+            "n",
+            "o",
+            "p",
+            "q",
+            "r",
+            "s",
+            "t",
+            "u",
+            "v",
+            "x",
+            "y",
+            "z"
+          ],
+          "rules": [
+            {
+              "conditions": [
+                {
+                  "type": "trim_period, trim"
+                }
+              ]
+            }
+          ],
+          "subFieldDelimiter": [
+            {
+              "value": " ",
+              "subfields": [
+                "a",
+                "b",
+                "c",
+                "d",
+                "j",
+                "q",
+                "t",
+                "f",
+                "g",
+                "k",
+                "l",
+                "m",
+                "n",
+                "o",
+                "p",
+                "r",
+                "s"
+              ]
+            },
+            {
+              "value": "--",
+              "subfields": [
+                "x",
+                "y",
+                "z",
+                "v"
+              ]
+            },
+            {
+              "value": "--",
+              "subfields": []
+            }
+          ]
+        },
+        {
+          "target": "series.authorityId",
+          "description": "Authority ID that controlling the subject",
+          "subfield": [
+            "9"
+          ]
+        }
+      ]
+    },
+    {
       "indicators": {
         "ind1": "*",
         "ind2": "0"
@@ -7178,6 +7266,89 @@
   ],
   "610": [
     {
+      "entity": [
+        {
+          "target": "subjects.value",
+          "description": "Subject Headings",
+          "applyRulesOnConcatenatedData": true,
+          "subfield": [
+            "a",
+            "b",
+            "c",
+            "d",
+            "e",
+            "f",
+            "g",
+            "h",
+            "k",
+            "l",
+            "m",
+            "n",
+            "o",
+            "p",
+            "r",
+            "s",
+            "t",
+            "u",
+            "v",
+            "x",
+            "y",
+            "z"
+          ],
+          "rules": [
+            {
+              "conditions": [
+                {
+                  "type": "trim_period, trim"
+                }
+              ]
+            }
+          ],
+          "subFieldDelimiter": [
+            {
+              "value": " ",
+              "subfields": [
+                "a",
+                "b",
+                "c",
+                "d",
+                "t",
+                "f",
+                "g",
+                "k",
+                "l",
+                "m",
+                "n",
+                "o",
+                "p",
+                "s"
+              ]
+            },
+            {
+              "value": "--",
+              "subfields": [
+                "x",
+                "y",
+                "z",
+                "v"
+              ]
+            },
+            {
+              "value": "--",
+              "subfields": []
+            }
+          ]
+        },
+        {
+          "target": "series.authorityId",
+          "description": "Authority ID that controlling the subject",
+          "subfield": [
+            "9"
+          ]
+        }
+      ]
+    },
+    {
       "indicators": {
         "ind1": "*",
         "ind2": "0"
@@ -8531,6 +8702,89 @@
   ],
   "611": [
     {
+      "entity": [
+        {
+          "target": "subjects.value",
+          "description": "Subject Headings",
+          "applyRulesOnConcatenatedData": true,
+          "subfield": [
+            "a",
+            "c",
+            "d",
+            "e",
+            "f",
+            "g",
+            "h",
+            "j",
+            "k",
+            "l",
+            "n",
+            "p",
+            "q",
+            "s",
+            "t",
+            "u",
+            "v",
+            "x",
+            "y",
+            "z"
+          ],
+          "rules": [
+            {
+              "conditions": [
+                {
+                  "type": "trim_period, trim"
+                }
+              ]
+            }
+          ],
+          "subFieldDelimiter": [
+            {
+              "value": " ",
+              "subfields": [
+                "a",
+                "c",
+                "d",
+                "e",
+                "q",
+                "t",
+                "f",
+                "g",
+                "k",
+                "l",
+                "m",
+                "n",
+                "o",
+                "p",
+                "r",
+                "s"
+              ]
+            },
+            {
+              "value": "--",
+              "subfields": [
+                "x",
+                "y",
+                "z",
+                "v"
+              ]
+            },
+            {
+              "value": "--",
+              "subfields": []
+            }
+          ]
+        },
+        {
+          "target": "series.authorityId",
+          "description": "Authority ID that controlling the subject",
+          "subfield": [
+            "9"
+          ]
+        }
+      ]
+    },
+    {
       "indicators": {
         "ind1": "*",
         "ind2": "0"
@@ -9852,6 +10106,84 @@
   ],
   "630": [
     {
+      "entity": [
+        {
+          "target": "subjects.value",
+          "description": "Subject Headings",
+          "applyRulesOnConcatenatedData": true,
+          "subfield": [
+            "a",
+            "d",
+            "e",
+            "f",
+            "g",
+            "h",
+            "k",
+            "l",
+            "m",
+            "n",
+            "o",
+            "p",
+            "r",
+            "s",
+            "t",
+            "v",
+            "x",
+            "y",
+            "z"
+          ],
+          "rules": [
+            {
+              "conditions": [
+                {
+                  "type": "trim_period, trim"
+                }
+              ]
+            }
+          ],
+          "subFieldDelimiter": [
+            {
+              "value": " ",
+              "subfields": [
+                "a",
+                "d",
+                "f",
+                "g",
+                "k",
+                "l",
+                "m",
+                "n",
+                "o",
+                "p",
+                "r",
+                "s"
+              ]
+            },
+            {
+              "value": "--",
+              "subfields": [
+                "x",
+                "y",
+                "z",
+                "v"
+              ]
+            },
+            {
+              "value": "--",
+              "subfields": []
+            }
+          ]
+        },
+        {
+          "target": "series.authorityId",
+          "description": "Authority ID that controlling the subject",
+          "subfield": [
+            "9"
+          ]
+        }
+      ]
+    },
+    {
       "indicators": {
         "ind1": "*",
         "ind2": "0"
@@ -11118,6 +11450,60 @@
   ],
   "647": [
     {
+      "entity": [
+        {
+          "target": "subjects.value",
+          "description": "Subject Headings",
+          "applyRulesOnConcatenatedData": true,
+          "subfield": [
+            "a",
+            "c",
+            "d",
+            "g",
+            "x",
+            "y",
+            "z",
+            "v"
+          ],
+          "rules": [
+            {
+              "conditions": [
+                {
+                  "type": "trim_period, trim"
+                }
+              ]
+            }
+          ],
+          "subFieldDelimiter": [
+            {
+              "value": "--",
+              "subfields": [
+                "a",
+                "c",
+                "d",
+                "g",
+                "x",
+                "y",
+                "z",
+                "v"
+              ]
+            },
+            {
+              "value": "--",
+              "subfields": []
+            }
+          ]
+        },
+        {
+          "target": "series.authorityId",
+          "description": "Authority ID that controlling the subject",
+          "subfield": [
+            "9"
+          ]
+        }
+      ]
+    },
+    {
       "indicators": {
         "ind1": "*",
         "ind2": "0"
@@ -12016,6 +12402,50 @@
   ],
   "648": [
     {
+      "entity": [
+        {
+          "target": "subjects.value",
+          "description": "Subject Headings",
+          "applyRulesOnConcatenatedData": true,
+          "subfield": [
+            "a",
+            "x",
+            "y",
+            "z",
+            "v"
+          ],
+          "rules": [
+            {
+              "conditions": [
+                {
+                  "type": "trim_period, trim"
+                }
+              ]
+            }
+          ],
+          "subFieldDelimiter": [
+            {
+              "value": "--",
+              "subfields": [
+                "a",
+                "x",
+                "y",
+                "z",
+                "v"
+              ]
+            }
+          ]
+        },
+        {
+          "target": "series.authorityId",
+          "description": "Authority ID that controlling the subject",
+          "subfield": [
+            "9"
+          ]
+        }
+      ]
+    },
+    {
       "indicators": {
         "ind1": "*",
         "ind2": "0"
@@ -12785,6 +13215,60 @@
     }
   ],
   "650": [
+    {
+      "entity": [
+        {
+          "target": "subjects.value",
+          "description": "Subject Headings",
+          "applyRulesOnConcatenatedData": true,
+          "subfield": [
+            "a",
+            "b",
+            "c",
+            "d",
+            "e",
+            "g",
+            "v",
+            "x",
+            "y",
+            "z"
+          ],
+          "rules": [
+            {
+              "conditions": [
+                {
+                  "type": "trim_period, trim"
+                }
+              ]
+            }
+          ],
+          "subFieldDelimiter": [
+            {
+              "value": "--",
+              "subfields": [
+                "a",
+                "b",
+                "c",
+                "d",
+                "e",
+                "g",
+                "v",
+                "x",
+                "y",
+                "z"
+              ]
+            }
+          ]
+        },
+        {
+          "target": "series.authorityId",
+          "description": "Authority ID that controlling the subject",
+          "subfield": [
+            "9"
+          ]
+        }
+      ]
+    },
     {
       "indicators": {
         "ind1": "*",
@@ -13716,6 +14200,54 @@
   ],
   "651": [
     {
+      "entity": [
+        {
+          "target": "subjects.value",
+          "description": "Subject Headings",
+          "applyRulesOnConcatenatedData": true,
+          "subfield": [
+            "a",
+            "e",
+            "g",
+            "v",
+            "x",
+            "y",
+            "z"
+          ],
+          "rules": [
+            {
+              "conditions": [
+                {
+                  "type": "trim_period, trim"
+                }
+              ]
+            }
+          ],
+          "subFieldDelimiter": [
+            {
+              "value": "--",
+              "subfields": [
+                "a",
+                "e",
+                "g",
+                "v",
+                "x",
+                "y",
+                "z"
+              ]
+            }
+          ]
+        },
+        {
+          "target": "series.authorityId",
+          "description": "Authority ID that controlling the subject",
+          "subfield": [
+            "9"
+          ]
+        }
+      ]
+    },
+    {
       "indicators": {
         "ind1": "*",
         "ind2": "0"
@@ -14549,6 +15081,54 @@
     }
   ],
   "655": [
+    {
+      "entity": [
+        {
+          "target": "subjects.value",
+          "description": "Subject Headings",
+          "applyRulesOnConcatenatedData": true,
+          "subfield": [
+            "a",
+            "b",
+            "c",
+            "v",
+            "x",
+            "y",
+            "z"
+          ],
+          "rules": [
+            {
+              "conditions": [
+                {
+                  "type": "trim_period, trim"
+                }
+              ]
+            }
+          ],
+          "subFieldDelimiter": [
+            {
+              "value": "--",
+              "subfields": [
+                "a",
+                "e",
+                "g",
+                "v",
+                "x",
+                "y",
+                "z"
+              ]
+            }
+          ]
+        },
+        {
+          "target": "series.authorityId",
+          "description": "Authority ID that controlling the subject",
+          "subfield": [
+            "9"
+          ]
+        }
+      ]
+    },
     {
       "indicators": {
         "ind1": "*",

--- a/mod-source-record-manager-server/src/test/resources/org/folio/services/marc_bib_rules.json
+++ b/mod-source-record-manager-server/src/test/resources/org/folio/services/marc_bib_rules.json
@@ -5831,7 +5831,7 @@
           ]
         },
         {
-          "target": "series.authorityId",
+          "target": "subjects.authorityId",
           "description": "Authority ID that controlling the subject",
           "subfield": [
             "9"
@@ -7340,7 +7340,7 @@
           ]
         },
         {
-          "target": "series.authorityId",
+          "target": "subjects.authorityId",
           "description": "Authority ID that controlling the subject",
           "subfield": [
             "9"
@@ -8776,7 +8776,7 @@
           ]
         },
         {
-          "target": "series.authorityId",
+          "target": "subjects.authorityId",
           "description": "Authority ID that controlling the subject",
           "subfield": [
             "9"
@@ -10175,7 +10175,7 @@
           ]
         },
         {
-          "target": "series.authorityId",
+          "target": "subjects.authorityId",
           "description": "Authority ID that controlling the subject",
           "subfield": [
             "9"
@@ -11495,7 +11495,7 @@
           ]
         },
         {
-          "target": "series.authorityId",
+          "target": "subjects.authorityId",
           "description": "Authority ID that controlling the subject",
           "subfield": [
             "9"
@@ -12437,7 +12437,7 @@
           ]
         },
         {
-          "target": "series.authorityId",
+          "target": "subjects.authorityId",
           "description": "Authority ID that controlling the subject",
           "subfield": [
             "9"
@@ -13261,7 +13261,7 @@
           ]
         },
         {
-          "target": "series.authorityId",
+          "target": "subjects.authorityId",
           "description": "Authority ID that controlling the subject",
           "subfield": [
             "9"
@@ -14239,7 +14239,7 @@
           ]
         },
         {
-          "target": "series.authorityId",
+          "target": "subjects.authorityId",
           "description": "Authority ID that controlling the subject",
           "subfield": [
             "9"
@@ -15121,7 +15121,7 @@
           ]
         },
         {
-          "target": "series.authorityId",
+          "target": "subjects.authorityId",
           "description": "Authority ID that controlling the subject",
           "subfield": [
             "9"


### PR DESCRIPTION
## Purpose
The main goal is to fix the behavior when new "Subject" doesn't display in Instance detail when it was added via quickmarc/data import update action.


## Approach
Mapping rules improved.
This PR should be merged after this one will be merged: https://github.com/folio-org/data-import-processing-core/pull/361

JIRA: https://folio-org.atlassian.net/browse/MODSOURMAN-1226

