### PR TITLE
MODSOURMAN-1228: Update default mapping for Date type, Date 1, and Date 2 fields

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -17,6 +17,7 @@
 * [MODINV-1069](https://folio-org.atlassian.net/browse/MODINV-1069) Fix DataImportConsumerVerticleTest in mod-inventory and Fix NPE in HoldingsItemMatcher, fix job log entries
 * [MODSOURMAN-1212](https://folio-org.atlassian.net/browse/MODSOURMAN-1212) Update MARC bib-instance default mapping for subject source and subject type
 * [MODDATAIMP-1085](https://folio-org.atlassian.net/browse/MODDATAIMP-1085) Provide module permissions for subject types and sources
+* [MODSOURMAN-1228](https://folio-org.atlassian.net/browse/MODSOURMAN-1212) Update default mapping for Date type, Date 1, and Date 2 fields
 
 ## 2023-03-22 v3.8.0
 * [MODSOURMAN-1131](https://folio-org.atlassian.net/browse/MODSOURMAN-1131) The import of file for creating orders is completed with errors

--- a/RuleProcessorApi.md
+++ b/RuleProcessorApi.md
@@ -799,8 +799,7 @@ If ending punctuation of the last mapped subfield of the field is a period or co
 ##### **NOTE**: Regarding ending punctuation - if the mapped text ends with (".", ",", ";") then it will be(the last symbol) removed for the matching with Contributor Type.
 
 ####  Map single JsonObject
-If there is a need to map not arrays or string but JsonObject with simple fields inside (strings), there can be used "createSingleObject" rule:
-which process a record field:
+If there is a need to map not arrays or string but JsonObject with simple fields inside (strings), there can be used "createSingleObject" rule, which will create a single JsonObject with specified fields:
 
 ```json
 Building Dates JsonObject:

--- a/RuleProcessorApi.md
+++ b/RuleProcessorApi.md
@@ -810,7 +810,6 @@ Building Dates JsonObject:
 "createSingleObject": true,
 "rules": [
 {
-"description": "",
 "conditions": [
 {
 "type": "set_date_type_id"

--- a/RuleProcessorApi.md
+++ b/RuleProcessorApi.md
@@ -798,6 +798,67 @@ If ending punctuation of the last mapped subfield of the field is a period or co
 ```
 ##### **NOTE**: Regarding ending punctuation - if the mapped text ends with (".", ",", ";") then it will be(the last symbol) removed for the matching with Contributor Type.
 
+####  Map single JsonObject
+If there is a need to map not arrays or string but JsonObject with simple fields inside (strings), there can be used "createSingleObject" rule:
+which process a record field:
+
+```json
+Building Dates JsonObject:
+{
+"target": "dates.dateTypeId",
+"description": "Date type ID",
+"subfield": [],
+"createSingleObject": true,
+"rules": [
+{
+"description": "",
+"conditions": [
+{
+"type": "set_date_type_id"
+}
+]
+}
+]
+},
+{
+"target": "dates.date1",
+"description": "Date 1",
+"subfield": [],
+"createSingleObject": true,
+"rules": [
+{
+"conditions": [
+{
+"type": "char_select",
+"parameter": {
+"from": 7,
+"to": 11
+}
+}
+]
+}
+]
+},
+{
+"target": "dates.date2",
+"description": "Date 2",
+"subfield": [],
+"createSingleObject": true,
+"rules": [
+{
+"conditions": [
+{
+"type": "char_select",
+"parameter": {
+"from": 11,
+"to": 15
+}
+}
+]
+}
+]
+}
+```
 #
 ### REST API
 When the source-record-manager starts up, it performs initialization for default mapping rules for given tenant.

--- a/RuleProcessorApi.md
+++ b/RuleProcessorApi.md
@@ -799,10 +799,10 @@ If ending punctuation of the last mapped subfield of the field is a period or co
 ##### **NOTE**: Regarding ending punctuation - if the mapped text ends with (".", ",", ";") then it will be(the last symbol) removed for the matching with Contributor Type.
 
 ####  Map single JsonObject
-If there is a need to map not arrays or string but JsonObject with simple fields inside (strings), there can be used "createSingleObject" rule, which will create a single JsonObject with specified fields:
+If there is a need to map not arrays or string but json object with simple fields inside (strings), there can be used "createSingleObject" rule, which will create a single json object with specified fields:
 
 ```json
-Building Dates JsonObject:
+Building Dates json object:
 {
 "target": "dates.dateTypeId",
 "description": "Date type ID",

--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -312,6 +312,8 @@
             "inventory-storage.statistical-codes.collection.get",
             "inventory-storage.subject-sources.collection.get",
             "inventory-storage.subject-types.collection.get",
+            "inventory-storage.subject-types.collection.get",
+            "inventory-storage.instance-date-types.collection.get",
             "mapping-metadata.get",
             "orders.po-lines.collection.get",
             "source-storage.records.get",
@@ -608,7 +610,8 @@
             "inventory-storage.statistical-code-types.collection.get",
             "inventory-storage.statistical-codes.collection.get",
             "inventory-storage.subject-sources.collection.get",
-            "inventory-storage.subject-types.collection.get"
+            "inventory-storage.subject-types.collection.get",
+            "inventory-storage.instance-date-types.collection.get"
           ]
         }
       ]

--- a/mod-source-record-manager-server/src/main/java/org/folio/services/mappers/processor/MappingParametersProvider.java
+++ b/mod-source-record-manager-server/src/main/java/org/folio/services/mappers/processor/MappingParametersProvider.java
@@ -48,6 +48,8 @@ import org.folio.IdentifierType;
 import org.folio.Identifiertypes;
 import org.folio.IllPolicy;
 import org.folio.Illpolicies;
+import org.folio.InstanceDateType;
+import org.folio.InstanceDateTypes;
 import org.folio.InstanceFormat;
 import org.folio.InstanceNoteType;
 import org.folio.InstanceRelationshipType;
@@ -134,6 +136,7 @@ public class MappingParametersProvider {
   private static final String AUTHORITY_SOURCE_FILES_RESPONSE_PARAM = "authoritySourceFiles";
   private static final String SUBJECTS_SOURCES_RESPONSE_PARAM = "subjectSources";
   private static final String SUBJECTS_TYPES_RESPONSE_PARAM = "subjectTypes";
+  private static final String INSTANCE_DATE_TYPES_RESPONSE_PARAM = "instanceDateTypes";
 
   private static final String CONFIGS_VALUE_RESPONSE = "configs";
   private static final String VALUE_RESPONSE = "value";
@@ -193,6 +196,7 @@ public class MappingParametersProvider {
     Future<List<AuthoritySourceFile>> authoritySourceFilesFuture = getAuthoritySourceFiles(okapiParams);
     Future<List<SubjectSource>> subjectSourcesFuture = getSubjectSources(okapiParams);
     Future<List<SubjectType>> subjectTypesFuture = getSubjectTypes(okapiParams);
+    Future<List<InstanceDateType>> instanceDateTypesFuture = getInstanceDateTypes(okapiParams);
     Future<List<MarcFieldProtectionSetting>> marcFieldProtectionSettingsFuture = getMarcFieldProtectionSettings(okapiParams);
     Future<String> tenantConfigurationZoneFuture = getTenantConfigurationZone(okapiParams);
     Future<List<LinkingRuleDto>> linkingRulesFuture = getLinkingRules(okapiParams);
@@ -202,7 +206,7 @@ public class MappingParametersProvider {
         contributorTypesFuture, contributorNameTypesFuture, electronicAccessRelationshipsFuture, instanceNoteTypesFuture, alternativeTitleTypesFuture,
         issuanceModesFuture, instanceStatusesFuture, natureOfContentTermsFuture, instanceRelationshipTypesFuture, holdingsTypesFuture, holdingsNoteTypesFuture,
         illPoliciesFuture, callNumberTypesFuture, statisticalCodesFuture, statisticalCodeTypesFuture, locationsFuture, materialTypesFuture, itemDamagedStatusesFuture,
-        loanTypesFuture, itemNoteTypesFuture, authorityNoteTypesFuture, authoritySourceFilesFuture,subjectSourcesFuture, subjectTypesFuture, marcFieldProtectionSettingsFuture, tenantConfigurationZoneFuture,
+        loanTypesFuture, itemNoteTypesFuture, authorityNoteTypesFuture, authoritySourceFilesFuture,subjectSourcesFuture, subjectTypesFuture, instanceDateTypesFuture, marcFieldProtectionSettingsFuture, tenantConfigurationZoneFuture,
         linkingRulesFuture))
       .map(ar ->
         mappingParams
@@ -236,6 +240,7 @@ public class MappingParametersProvider {
           .withAuthoritySourceFiles(authoritySourceFilesFuture.result())
           .withSubjectSources(subjectSourcesFuture.result())
           .withSubjectTypes(subjectTypesFuture.result())
+          .withInstanceDateTypes(instanceDateTypesFuture.result())
           .withMarcFieldProtectionSettings(marcFieldProtectionSettingsFuture.result())
           .withTenantConfigurationZone(tenantConfigurationZoneFuture.result())
           .withLinkingRules(linkingRulesFuture.result())
@@ -484,6 +489,19 @@ public class MappingParametersProvider {
     String subjectTypesUrl = "/subject-types?limit=" + settingsLimit;
     return loadData(params, subjectTypesUrl, SUBJECTS_TYPES_RESPONSE_PARAM,
       response -> response.mapTo(SubjectTypes.class).getSubjectTypes());
+  }
+
+  /**
+   * Requests for Instance Date Types from application Settings (mod-inventory-storage)
+   * *
+   *
+   * @param params Okapi connection parameters
+   * @return List Instance date types
+   */
+  private Future<List<InstanceDateType>> getInstanceDateTypes(OkapiConnectionParams params) {
+    String instanceDateTypesUrl = "/instance-date-types?limit=" + settingsLimit;
+    return loadData(params, instanceDateTypesUrl, INSTANCE_DATE_TYPES_RESPONSE_PARAM,
+      response -> response.mapTo(InstanceDateTypes.class).getInstanceDateTypes());
   }
 
   /**

--- a/mod-source-record-manager-server/src/main/resources/rules/marc_bib_rules.json
+++ b/mod-source-record-manager-server/src/main/resources/rules/marc_bib_rules.json
@@ -77,7 +77,6 @@
       "createSingleObject": true,
       "rules": [
         {
-          "description": "",
           "conditions": [
             {
               "type": "set_date_type_id"

--- a/mod-source-record-manager-server/src/main/resources/rules/marc_bib_rules.json
+++ b/mod-source-record-manager-server/src/main/resources/rules/marc_bib_rules.json
@@ -69,6 +69,60 @@
           ]
         }
       ]
+    },
+    {
+      "target": "dates.dateTypeId",
+      "description": "Date type ID",
+      "subfield": [],
+      "createSingleObject": true,
+      "rules": [
+        {
+          "description": "",
+          "conditions": [
+            {
+              "type": "set_date_type_id"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "target": "dates.date1",
+      "description": "Date 1",
+      "subfield": [],
+      "createSingleObject": true,
+      "rules": [
+        {
+          "conditions": [
+            {
+              "type": "char_select",
+              "parameter": {
+                "from": 7,
+                "to": 11
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "target": "dates.date2",
+      "description": "Date 2",
+      "subfield": [],
+      "createSingleObject": true,
+      "rules": [
+        {
+          "conditions": [
+            {
+              "type": "char_select",
+              "parameter": {
+                "from": 11,
+                "to": 15
+              }
+            }
+          ]
+        }
+      ]
     }
   ],
   "010": [

--- a/mod-source-record-manager-server/src/test/java/org/folio/rest/impl/AbstractRestTest.java
+++ b/mod-source-record-manager-server/src/test/java/org/folio/rest/impl/AbstractRestTest.java
@@ -126,6 +126,8 @@ public abstract class AbstractRestTest {
   protected static final String FIELD_PROTECTION_SETTINGS_URL = "/field-protection-settings/marc?limit=1000";
   protected static final String SUBJECT_SOURCES_URL = "/subject-sources?limit=1000";
   protected static final String SUBJECT_TYPES_URL = "/subject-types?limit=1000";
+  protected static final String INSTANCE_DATE_TYPES_URL = "/instance-date-types?limit=1000";
+
 
   protected static final String TENANT_CONFIGURATION_ZONE_SETTINGS_URL = "/configurations/entries?query=" + URLEncoder.encode("(module==ORG and configName==localeSettings)", StandardCharsets.UTF_8);
 
@@ -504,6 +506,7 @@ public abstract class AbstractRestTest {
     WireMock.stubFor(get(AUTHORITY_SOURCE_FILES_URL).willReturn(okJson(new JsonObject().put("authoritySourceFiles", new JsonArray()).toString())));
     WireMock.stubFor(get(SUBJECT_SOURCES_URL).willReturn(okJson(new JsonObject().put("subjectSources", new JsonArray()).toString())));
     WireMock.stubFor(get(SUBJECT_TYPES_URL).willReturn(okJson(new JsonObject().put("subjectTypes", new JsonArray()).toString())));
+    WireMock.stubFor(get(INSTANCE_DATE_TYPES_URL).willReturn(okJson(new JsonObject().put("instanceDateTypes", new JsonArray()).toString())));
 
     WireMock.stubFor(get(FIELD_PROTECTION_SETTINGS_URL).willReturn(okJson(new JsonObject().put("marcFieldProtectionSettings", new JsonArray()).toString())));
     WireMock.stubFor(get(TENANT_CONFIGURATION_ZONE_SETTINGS_URL).willReturn(okJson(new JsonObject().put("configs", new JsonArray()).toString())));

--- a/mod-source-record-manager-server/src/test/java/org/folio/rest/impl/changeManager/ChangeManagerAPITest.java
+++ b/mod-source-record-manager-server/src/test/java/org/folio/rest/impl/changeManager/ChangeManagerAPITest.java
@@ -1366,6 +1366,7 @@ public class ChangeManagerAPITest extends AbstractRestTest {
     verify(1, getRequestedFor(urlEqualTo(AUTHORITY_SOURCE_FILES_URL)));
     verify(1, getRequestedFor(urlEqualTo(SUBJECT_SOURCES_URL)));
     verify(1, getRequestedFor(urlEqualTo(SUBJECT_TYPES_URL)));
+    verify(1, getRequestedFor(urlEqualTo(INSTANCE_DATE_TYPES_URL)));
     verify(1, getRequestedFor(urlEqualTo(FIELD_PROTECTION_SETTINGS_URL)));
     verify(1, getRequestedFor(urlEqualTo(TENANT_CONFIGURATION_ZONE_SETTINGS_URL)));
     async.complete();

--- a/mod-source-record-manager-server/src/test/java/org/folio/services/mappers/processor/MappingParametersProviderTest.java
+++ b/mod-source-record-manager-server/src/test/java/org/folio/services/mappers/processor/MappingParametersProviderTest.java
@@ -68,6 +68,7 @@ public class MappingParametersProviderTest {
   protected static final String AUTHORITY_SOURCE_FILES_URL = "/authority-source-files?limit=0";
   protected static final String SUBJECT_SOURCES_URL = "/subject-sources?limit=0";
   protected static final String SUBJECT_TYPES_URL = "/subject-types?limit=0";
+  protected static final String INSTANCE_DATE_TYPE_URL = "/instance-date-types?limit=0";
 
   protected static final String FIELD_PROTECTION_SETTINGS_URL =
     "/field-protection-settings/marc?limit=0";
@@ -211,6 +212,10 @@ public class MappingParametersProviderTest {
       get(SUBJECT_TYPES_URL)
         .willReturn(
           okJson(new JsonObject().put("subjectTypes", new JsonArray()).toString())));
+    WireMock.stubFor(
+      get(INSTANCE_DATE_TYPE_URL)
+        .willReturn(
+          okJson(new JsonObject().put("instanceDateTypes", new JsonArray()).toString())));
     WireMock.stubFor(
       get(FIELD_PROTECTION_SETTINGS_URL)
         .willReturn(

--- a/mod-source-record-manager-server/src/test/resources/org/folio/mapping/mappedBibRecord.json
+++ b/mod-source-record-manager-server/src/test/resources/org/folio/mapping/mappedBibRecord.json
@@ -149,6 +149,7 @@
   "publicationFrequency": [],
   "publicationRange": [],
   "electronicAccess": [],
+  "dates":{"date1":"1982","date2":"9999"},
   "instanceTypeId": "fe19bae4-da28-472b-be90-d442e2428ead",
   "instanceFormatIds": [],
   "physicalDescriptions": [

--- a/mod-source-record-manager-server/src/test/resources/org/folio/services/marc_bib_rules.json
+++ b/mod-source-record-manager-server/src/test/resources/org/folio/services/marc_bib_rules.json
@@ -77,7 +77,6 @@
       "createSingleObject": true,
       "rules": [
         {
-          "description": "",
           "conditions": [
             {
               "type": "set_date_type_id"

--- a/mod-source-record-manager-server/src/test/resources/org/folio/services/marc_bib_rules.json
+++ b/mod-source-record-manager-server/src/test/resources/org/folio/services/marc_bib_rules.json
@@ -69,6 +69,60 @@
           ]
         }
       ]
+    },
+    {
+      "target": "dates.dateTypeId",
+      "description": "Date type ID",
+      "subfield": [],
+      "createSingleObject": true,
+      "rules": [
+        {
+          "description": "",
+          "conditions": [
+            {
+              "type": "set_date_type_id"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "target": "dates.date1",
+      "description": "Date 1",
+      "subfield": [],
+      "createSingleObject": true,
+      "rules": [
+        {
+          "conditions": [
+            {
+              "type": "char_select",
+              "parameter": {
+                "from": 7,
+                "to": 11
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "target": "dates.date2",
+      "description": "Date 2",
+      "subfield": [],
+      "createSingleObject": true,
+      "rules": [
+        {
+          "conditions": [
+            {
+              "type": "char_select",
+              "parameter": {
+                "from": 11,
+                "to": 15
+              }
+            }
+          ]
+        }
+      ]
     }
   ],
   "010": [

--- a/mod-source-record-manager-server/src/test/resources/org/folio/services/marc_mapping_params.json
+++ b/mod-source-record-manager-server/src/test/resources/org/folio/services/marc_mapping_params.json
@@ -30,6 +30,7 @@
   "authoritySourceFiles": [],
   "subjectSources": [],
   "subjectTypes": [],
+  "instanceDateTypes": [],
   "organizations": null,
   "linkingRules": [],
   "acquisitionsUnits":null,


### PR DESCRIPTION
## Purpose
The main purpose is to update default mapping for Date type, Date 1, and Date 2 fields

## Approach
So there should be extended our default mapper. Previouslym we did NOT map simple JsonObjects, just String or Arrays. In our case, the "Dates" - is an object, and our mapper can't work with this type of Instance's field. So there was added a new property to rules named "createSingleObject". And if mapper find this rules - it will handle this rule via specific logic, building rules into 1 JsonObject. 

1. Mapping parameters extended via new Date data.
2. Default Mapping rules improved for 008 field.
3. Tests improved.
4. New permissions added.
5. Documentation for mapping rules extended via new property.
## Learning
JIRA: https://folio-org.atlassian.net/browse/MODSOURMAN-1228

**NOTE**: This PR should be merged **ONLY** with these 2: https://github.com/folio-org/data-import-processing-core/pull/367 AND https://github.com/folio-org/mod-data-import/pull/340
