### PR TITLE
MODDATAIMP-1100 Fix permissions

### DIFF
--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -315,7 +315,6 @@
             "inventory-storage.subject-types.collection.get",
             "inventory-storage.instance-date-types.collection.get",
             "mapping-metadata.item.get",
-            "mapping-metadata.type.item.get",
             "orders.po-lines.collection.get",
             "source-storage.records.collection.get",
             "source-storage.records.item.get",
@@ -411,7 +410,7 @@
           ],
           "modulePermissions": [
             "configuration.entries.collection.get",
-            "converter-storage.field-protection-settings.get",
+            "converter-storage.field-protection-settings.collection.get",
             "converter-storage.jobprofilesnapshots.get",
             "inventory-storage.alternative-title-types.collection.get",
             "inventory-storage.authorities.collection.get",
@@ -470,7 +469,6 @@
             "inventory-storage.subject-types.collection.get",
             "mapping-metadata.item.get",
             "mapping-metadata.type.item.get",
-            "source-storage.snapshots.get",
             "source-storage.snapshots.put",
             "source-storage.verified.records",
             "users.collection.get",
@@ -591,7 +589,7 @@
           ],
           "modulePermissions": [
             "configuration.entries.collection.get",
-            "converter-storage.field-protection-settings.get",
+            "converter-storage.field-protection-settings.collection.get",
             "instance-authority.linking-rules.collection.get",
             "inventory-storage.alternative-title-types.collection.get",
             "inventory-storage.authority-note-types.collection.get",


### PR DESCRIPTION
[MODDATAIMP-1100](https://folio-org.atlassian.net/browse/MODDATAIMP-1100)

## Purpose
Data-import karate tests falls into infinity loop, breaking CI Quality Gates pipeline

## Approach
Add missing permissions

## Learning
Old permission | New permissions
-- | --
data-import.uploaddefinitions.get | data-import.uploadDefinitions.item.get, data-import.uploadDefinitions.collection.get
data-import.uploaddefinitions.files.post | data-import.uploadDefinitions.files.item.post, data-import.uploadDefinitions.processFiles.item.post
data-import.fileExtensions.get | data-import.fileExtensions.item.get, data-import.fileExtensions.collection.get
data-import.fileExtensions.default | data-import.fileExtensions.default.post
data-import.uploadUrl.get | data-import.uploadUrl.item.get, data-import.uploadUrl.subsequent.item.get
converter-storage.jobprofile.get | converter-storage.jobprofile.item.get, converter-storage.jobprofile.collection.get
converter-storage.matchprofile.get | converter-storage.matchprofile.item.get, converter-storage.matchprofile.collection.get
converter-storage.actionprofile.get | converter-storage.action-profile.item.get, converter-storage.action-profile.collection.get
converter-storage.mappingprofile.get | converter-storage.mapping-profile.item.get, converter-storage.mapping-profile.collection.get
converter-storage.profileassociation.get | converter-storage.profile-association.item.get, converter-storage.profile-association.collection.get, converter-storage.profile-associations.details.item.get, converter-storage.profile-associations.masters.item.get
converter-storage.forms-configs.get | converter-storage.forms-configs.item.get, converter-storage.forms-configs.collection.get
converter-storage.field-protection-settings.get | converter-storage.field-protection-settings.item.get, converter-storage.field-protection-settings.collection.get
metadata-provider.jobexecutions.get | metadata-provider.jobExecutions.collection.get, metadata-provider.jobExecutions.users.collection.get, metadata-provider.jobExecutions.jobProfiles.collection.get
metadata-provider.logs.get | metadata-provider.jobLogEntries.collection.get, metadata-provider.jobLogEntries.records.item.get, metadata-provider.journalRecords.collection.get, metadata-provider.jobSummary.item.get
change-manager.jobexecutions.put | change-manager.jobExecutions.item.put, change-manager.jobExecutions.status.item.put, change-manager.jobExecutions.jobProfile.item.put
change-manager.jobexecutions.get | change-manager.jobExecutions.item.get, change-manager.jobExecutions.children.collection.get
mapping-metadata.get | mapping-metadata.item.get, mapping-metadata.type.item.get
source-storage.populate.records | source-storage.records.populate.collection.post
source-storage.snapshots.get | source-storage.snapshots.item.get, source-storage.snapshots.collection.get
source-storage.records.fetch | source-storage.parsed-records.fetch.collection.post
source-storage.sourceRecords.get | source-storage.stream.source-records.collection.get, source-storage.source-records.item.get, source-storage.source-records.collection.get
source-storage.records.get | source-storage.stream.marc-record-identifiers.collection.post, source-storage.records.collection.get, source-storage.records.item.get, source-storage.records.formatted.item.get, source-storage.stream.records.collection.get, source-storage.records.matching.collection.post
source-storage.migrations.get | source-storage.migrations.item.get

<p></p>
