### PR TITLE
MODSOURMAN-1249: "SRS MARC" and "Authority" tabs are empty in data import of MARC authority log

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,6 @@
+## 2024-11-15 3.10.0-SNAPSHOT
+* [MODSOURMAN-1249](https://folio-org.atlassian.net/browse/MODSOURMAN-1249) Added DI_MARC_FOR_UPDATE_RECEIVED log message handling
+
 ## 2024-10-29 v3.9.0
 * [MODSOURMAN-1232](https://folio-org.atlassian.net/browse/MODSOURMAN-1232) Add the option to exclude job profile names to GET "/metadata-provider/jobExecutions" endpoint
 * [MODSOURMAN-1195](https://folio-org.atlassian.net/browse/MODSOURMAN-1195) Save job execution progress in batches

--- a/mod-source-record-manager-server/src/main/java/org/folio/verticle/DataImportJournalBatchConsumerVerticle.java
+++ b/mod-source-record-manager-server/src/main/java/org/folio/verticle/DataImportJournalBatchConsumerVerticle.java
@@ -84,6 +84,7 @@ import static org.folio.rest.jaxrs.model.DataImportEventTypes.DI_SRS_MARC_HOLDIN
 import static org.folio.rest.jaxrs.model.DataImportEventTypes.DI_SRS_MARC_HOLDINGS_RECORD_NOT_MATCHED;
 import static org.folio.rest.jaxrs.model.DataImportEventTypes.DI_SRS_MARC_HOLDINGS_RECORD_UPDATED;
 import static org.folio.rest.jaxrs.model.DataImportEventTypes.DI_SRS_MARC_HOLDING_RECORD_CREATED;
+import static org.folio.rest.jaxrs.model.DataImportEventTypes.DI_MARC_FOR_UPDATE_RECEIVED;
 import static org.folio.services.RecordsPublishingServiceImpl.RECORD_ID_HEADER;
 import static org.folio.services.util.EventHandlingUtil.constructModuleName;
 import static org.springframework.beans.factory.config.BeanDefinition.SCOPE_PROTOTYPE;
@@ -158,6 +159,7 @@ public class DataImportJournalBatchConsumerVerticle extends AbstractVerticle {
       DI_SRS_MARC_AUTHORITY_RECORD_NOT_MATCHED.value(),
       DI_SRS_MARC_HOLDINGS_RECORD_NOT_MATCHED.value(),
       DI_SRS_MARC_HOLDINGS_RECORD_MATCHED.value(),
+      DI_MARC_FOR_UPDATE_RECEIVED.value(),
       DI_INVENTORY_INSTANCE_CREATED.value(),
       DI_INVENTORY_INSTANCE_UPDATED.value(),
       DI_INVENTORY_INSTANCE_NOT_MATCHED.value(),

--- a/mod-source-record-manager-server/src/main/java/org/folio/verticle/DataImportJournalBatchConsumerVerticle.java
+++ b/mod-source-record-manager-server/src/main/java/org/folio/verticle/DataImportJournalBatchConsumerVerticle.java
@@ -84,7 +84,6 @@ import static org.folio.rest.jaxrs.model.DataImportEventTypes.DI_SRS_MARC_HOLDIN
 import static org.folio.rest.jaxrs.model.DataImportEventTypes.DI_SRS_MARC_HOLDINGS_RECORD_NOT_MATCHED;
 import static org.folio.rest.jaxrs.model.DataImportEventTypes.DI_SRS_MARC_HOLDINGS_RECORD_UPDATED;
 import static org.folio.rest.jaxrs.model.DataImportEventTypes.DI_SRS_MARC_HOLDING_RECORD_CREATED;
-import static org.folio.rest.jaxrs.model.DataImportEventTypes.DI_MARC_FOR_UPDATE_RECEIVED;
 import static org.folio.services.RecordsPublishingServiceImpl.RECORD_ID_HEADER;
 import static org.folio.services.util.EventHandlingUtil.constructModuleName;
 import static org.springframework.beans.factory.config.BeanDefinition.SCOPE_PROTOTYPE;
@@ -159,7 +158,6 @@ public class DataImportJournalBatchConsumerVerticle extends AbstractVerticle {
       DI_SRS_MARC_AUTHORITY_RECORD_NOT_MATCHED.value(),
       DI_SRS_MARC_HOLDINGS_RECORD_NOT_MATCHED.value(),
       DI_SRS_MARC_HOLDINGS_RECORD_MATCHED.value(),
-      DI_MARC_FOR_UPDATE_RECEIVED.value(),
       DI_INVENTORY_INSTANCE_CREATED.value(),
       DI_INVENTORY_INSTANCE_UPDATED.value(),
       DI_INVENTORY_INSTANCE_NOT_MATCHED.value(),

--- a/mod-source-record-manager-server/src/main/java/org/folio/verticle/consumers/StoredRecordChunksKafkaHandler.java
+++ b/mod-source-record-manager-server/src/main/java/org/folio/verticle/consumers/StoredRecordChunksKafkaHandler.java
@@ -145,6 +145,7 @@ public class StoredRecordChunksKafkaHandler implements AsyncRecordHandler<String
   }
 
   private void saveCreatedRecordsInfoToDataImportLog(List<Record> storedRecords, String tenantId) {
+    LOGGER.debug("saveCreatedRecordsInfoToDataImportLog :: count: {}", storedRecords.size());
     MappingRuleCacheKey cacheKey = new MappingRuleCacheKey(tenantId, storedRecords.get(0).getRecordType());
 
     mappingRuleCache.get(cacheKey).onComplete(rulesAr -> {

--- a/mod-source-record-manager-server/src/main/java/org/folio/verticle/consumers/util/JournalParams.java
+++ b/mod-source-record-manager-server/src/main/java/org/folio/verticle/consumers/util/JournalParams.java
@@ -3,6 +3,7 @@ package org.folio.verticle.consumers.util;
 import static org.folio.rest.jaxrs.model.EntityType.EDIFACT_INVOICE;
 import static org.folio.rest.jaxrs.model.JournalRecord.ActionStatus.ERROR;
 import static org.folio.rest.jaxrs.model.JournalRecord.ActionType.CREATE;
+import static org.folio.rest.jaxrs.model.JournalRecord.ActionType.UPDATE;
 
 import java.util.Arrays;
 import java.util.Map;
@@ -114,6 +115,14 @@ public class JournalParams {
       public Optional<JournalParams> getJournalParams(DataImportEventPayload eventPayload) {
         return Optional.of(new JournalParams(JournalRecord.ActionType.NON_MATCH,
           JournalRecord.EntityType.MARC_HOLDINGS,
+          JournalRecord.ActionStatus.COMPLETED));
+      }
+    },
+    DI_MARC_FOR_UPDATE_RECEIVED {
+      @Override
+      public Optional<JournalParams> getJournalParams(DataImportEventPayload eventPayload) {
+        return Optional.of(new JournalParams(UPDATE,
+          JournalRecord.EntityType.MARC_BIBLIOGRAPHIC,
           JournalRecord.ActionStatus.COMPLETED));
       }
     },


### PR DESCRIPTION
## Purpose
DI log is not opened on UI and data is not written to the database

## Approach
Added DI_MARC_FOR_UPDATE_RECEIVED log message handling

## Is this change testable? If not - why?


## Checklist
- [x] I have updated NEWS.md.
- [ ] I have added javadocs to new methods.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation e.g. README.md.
- [ ] I have ran karate tests against this feature.

