### PR TITLE
MODSOURMAN-1266: FIX - Event DI_JOB_COMPLETED is not being sent upon the completion of the data import process on snapshot, snapshot-2

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,6 @@
 ## 2024-11-15 3.10.0-SNAPSHOT
 * [MODSOURMAN-1249](https://folio-org.atlassian.net/browse/MODSOURMAN-1249) Added DI_MARC_FOR_UPDATE_RECEIVED log message handling
+* [MODSOURMAN-1266](https://folio-org.atlassian.net/browse/MODSOURMAN-1266) Event DI_JOB_COMPLETED is not being sent upon the completion of the data import process on snapshot, snapshot-2
 
 ## 2024-10-29 v3.9.0
 * [MODSOURMAN-1232](https://folio-org.atlassian.net/browse/MODSOURMAN-1232) Add the option to exclude job profile names to GET "/metadata-provider/jobExecutions" endpoint

--- a/mod-source-record-manager-server/src/main/java/org/folio/verticle/JobExecutionProgressVerticle.java
+++ b/mod-source-record-manager-server/src/main/java/org/folio/verticle/JobExecutionProgressVerticle.java
@@ -232,6 +232,8 @@ public class JobExecutionProgressVerticle extends AbstractVerticle {
             return jobExecutionService.updateJobExecutionWithSnapshotStatus(jobExecution, params)
               .compose(updatedExecution -> {
                 if (updatedExecution.getSubordinationType().equals(JobExecution.SubordinationType.COMPOSITE_CHILD)) {
+                  LOGGER.info("COMPOSITE_CHILD subordination type for job {}. Processing...", updatedExecution.getId());
+
 
                   return jobExecutionService.getJobExecutionById(updatedExecution.getParentJobId(), params.getTenantId())
                     .map(v -> v.orElseThrow(() -> new IllegalStateException("Could not find parent job execution")))
@@ -263,6 +265,11 @@ public class JobExecutionProgressVerticle extends AbstractVerticle {
                         })
                     );
                 } else {
+                  if (updatedExecution.getSubordinationType().equals(JobExecution.SubordinationType.PARENT_SINGLE) ||
+                    updatedExecution.getSubordinationType().equals(JobExecution.SubordinationType.CHILD)) {
+                    LOGGER.info("{}  subordination type for job {}. Processing...", updatedExecution.getSubordinationType(), updatedExecution.getId());
+                    sendDiJobCompletedEvent(updatedExecution, params);
+                  }
                   return Future.succeededFuture(updatedExecution);
                 }
               })

--- a/mod-source-record-manager-server/src/test/java/org/folio/verticle/JobExecutionProgressVerticleTest.java
+++ b/mod-source-record-manager-server/src/test/java/org/folio/verticle/JobExecutionProgressVerticleTest.java
@@ -173,6 +173,87 @@ public class JobExecutionProgressVerticleTest extends AbstractRestTest {
       });
   }
 
+  @Test
+  public void testSingleProgressUpdateSplitFileDisabled(TestContext context) throws InterruptedException {
+    Async async = context.async();
+
+    // Arrange
+    // create job execution with CHILD subordination Type (simulating non split-files env)
+    JobExecution childJobExecution = new JobExecution()
+      .withId(UUID.randomUUID().toString())
+      .withHrId(1000)
+      .withParentJobId(jobExecutionId)
+      .withSubordinationType(JobExecution.SubordinationType.CHILD)
+      .withStatus(JobExecution.Status.NEW)
+      .withUiStatus(JobExecution.UiStatus.INITIALIZATION)
+      .withSourcePath("importMarc.mrc")
+      .withJobProfileInfo(new JobProfileInfo().withId(UUID.randomUUID().toString()).withName("Marc jobs profile"))
+      .withUserId(UUID.randomUUID().toString());
+
+    JobExecution parentJobExecution = new JobExecution()
+      .withId(jobExecutionId)
+      .withHrId(1000)
+      .withSubordinationType(JobExecution.SubordinationType.PARENT_SINGLE)
+      .withStatus(JobExecution.Status.NEW)
+      .withUiStatus(JobExecution.UiStatus.INITIALIZATION)
+      .withSourcePath("importMarc.mrc")
+      .withJobProfileInfo(new JobProfileInfo().withId(UUID.randomUUID().toString()).withName("Marc jobs profile"))
+      .withUserId(UUID.randomUUID().toString());
+    // create job execution progress
+    JobExecutionProgress jobExecutionProgress = new JobExecutionProgress().withJobExecutionId(jobExecutionId)
+      .withCurrentlyFailed(1)
+      .withCurrentlySucceeded(2)
+      .withTotal(3);
+    BatchableJobExecutionProgress batchableJobExecutionProgress = new BatchableJobExecutionProgress(
+      createOkapiConnectionParams(tenantId),
+      jobExecutionProgress);
+    // return appropriate objects for mocks
+    when(jobExecutionService.getJobExecutionById(eq(childJobExecution.getId()), any()))
+      .thenReturn(Future.succeededFuture(Optional.of(childJobExecution)));
+    when(jobExecutionService.getJobExecutionById(eq(parentJobExecution.getId()), any()))
+      .thenReturn(Future.succeededFuture(Optional.of(parentJobExecution)));
+    when(jobExecutionProgressDao.updateCompletionCounts(eq(jobExecutionId), anyInt(), anyInt(), any()))
+      .thenReturn(Future.succeededFuture(jobExecutionProgress));
+    when(jobExecutionService.updateJobExecutionWithSnapshotStatus(any(), any()))
+      .thenReturn(Future.succeededFuture(childJobExecution));
+    when(jobExecutionService.getJobExecutionCollectionByParentId(eq(parentJobExecution.getId()), anyInt(), anyInt(), any()))
+      .thenReturn(Future.succeededFuture(new JobExecutionDtoCollection()
+          .withJobExecutions(Collections.singletonList(
+            new JobExecutionDto()
+              .withId(childJobExecution.getId())
+              .withSubordinationType(JobExecutionDto.SubordinationType.COMPOSITE_CHILD)
+              .withUiStatus(JobExecutionDto.UiStatus.RUNNING_COMPLETE))
+          )
+        )
+      );
+    var topic = formatToKafkaTopicName(DI_JOB_COMPLETED.value());
+    var request = prepareWithSpecifiedEventPayload(Json.encode(parentJobExecution), topic);
+
+    kafkaCluster.send(request);
+
+    // Act
+    batchJobProgressProducer.write(batchableJobExecutionProgress)
+      .onComplete(ar -> {
+        if (ar.succeeded()) {
+          // Assert
+          try {
+            await()
+              .atMost(AWAIT_TIME, TimeUnit.SECONDS)
+              .untilAsserted(() -> verify(jobExecutionProgressDao)
+                .updateCompletionCounts(any(), eq(2), eq(1), eq(tenantId)));
+            kafkaCluster.observeValues(ObserveKeyValues.on(topic, 1)
+              .observeFor(30, TimeUnit.SECONDS)
+              .build());
+          } catch (Exception e) {
+            context.fail(e);
+          }
+          async.complete();
+        } else {
+          context.fail(ar.cause());
+        }
+      });
+  }
+
   private SendKeyValues<String, String> prepareWithSpecifiedEventPayload(String eventPayload, String topic) {
     Event event = new Event().withId(UUID.randomUUID().toString()).withEventPayload(eventPayload);
     KeyValue<String, String> kafkaRecord = new KeyValue<>("key", Json.encode(event));


### PR DESCRIPTION
## Purpose
The main goal is to send "DI_JOB_COMPLETED" event even if SPLIT_FILE is disabled on the environment.

## Approach
Additional condition on sending event added if subordination type for job = CHILD or PARENT_SINGLE
Test added.

JIRA: https://folio-org.atlassian.net/browse/MODSOURMAN-1266


