### PR TITLE
MODDATAIMP-1135 Log entries are empty for completed jobs

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,6 +129,10 @@ which are created during tenant initialization, the values of which can be custo
 and `DI_RAW_RECORDS_CHUNK_PARSED_PARTITIONS` env variables respectively.
 Default value - `1`.
 
+## Environment variables
+`MAX_NUM_EVENTS`:`100` - set max num events to consume
+
+
 #### Note:
 From v 3.1.3 there is a new property which defines limit for retrieving data to fill mapping parameters for the data-import mechanism: **"srm.mapping.parameters.settings.limit:1000"**
 

--- a/README.md
+++ b/README.md
@@ -132,7 +132,6 @@ Default value - `1`.
 ## Environment variables
 `MAX_NUM_EVENTS`:`100` - set max num events to consume
 
-
 #### Note:
 From v 3.1.3 there is a new property which defines limit for retrieving data to fill mapping parameters for the data-import mechanism: **"srm.mapping.parameters.settings.limit:1000"**
 

--- a/mod-source-record-manager-server/src/main/java/org/folio/dao/JournalRecordDaoImpl.java
+++ b/mod-source-record-manager-server/src/main/java/org/folio/dao/JournalRecordDaoImpl.java
@@ -137,8 +137,6 @@ import static org.folio.rest.persist.PostgresClient.convertToPsqlStandard;
 public class JournalRecordDaoImpl implements JournalRecordDao {
 
   private static final Logger LOGGER = LogManager.getLogger();
-  private static final int MAX_RETRIES = 3;
-  private static final long INITIAL_BACKOFF_MS = 50;
   public static final String SOURCE_RECORD_ENTITY_TYPE = "source_record_entity_type";
   public static final String ORDER_ENTITY_ID = "order_entity_id";
   public static final String INCOMING_RECORD_ID = "incoming_record_id";

--- a/mod-source-record-manager-server/src/main/java/org/folio/dao/JournalRecordDaoImpl.java
+++ b/mod-source-record-manager-server/src/main/java/org/folio/dao/JournalRecordDaoImpl.java
@@ -137,6 +137,8 @@ import static org.folio.rest.persist.PostgresClient.convertToPsqlStandard;
 public class JournalRecordDaoImpl implements JournalRecordDao {
 
   private static final Logger LOGGER = LogManager.getLogger();
+  private static final int MAX_RETRIES = 3;
+  private static final long INITIAL_BACKOFF_MS = 50;
   public static final String SOURCE_RECORD_ENTITY_TYPE = "source_record_entity_type";
   public static final String ORDER_ENTITY_ID = "order_entity_id";
   public static final String INCOMING_RECORD_ID = "incoming_record_id";
@@ -180,18 +182,80 @@ public class JournalRecordDaoImpl implements JournalRecordDao {
 
   @Override
   public Future<List<RowSet<Row>>> saveBatch(Collection<JournalRecord> journalRecords, String tenantId) {
-    LOGGER.info("saveBatch:: Trying to save list of JournalRecord entities to the {} table", JOURNAL_RECORDS_TABLE);
+    LOGGER.debug("saveBatch:: Starting batch save of {} JournalRecord entities", journalRecords.size());
     Promise<List<RowSet<Row>>> promise = Promise.promise();
+
     try {
-      List<Tuple> tupleList = journalRecords.stream().map(this::prepareInsertQueryParameters).collect(toList());
+      // Group records by jobExecutionId
+      Map<String, List<JournalRecord>> recordsByJobId = journalRecords.stream()
+        .collect(Collectors.groupingBy(JournalRecord::getJobExecutionId));
+
+      // Create the base SQL query
       String query = format(INSERT_SQL, convertToPsqlStandard(tenantId), JOURNAL_RECORDS_TABLE);
-      LOGGER.trace("saveBatch:: JournalRecordDaoImpl::saveBatch query = {}; tuples = {}", query, tupleList);
-      pgClientFactory.createInstance(tenantId).execute(query, tupleList, promise);
+
+      // Process groups sequentially using recursive helper
+      List<RowSet<Row>> allResults = new ArrayList<>();
+      processNextGroup(new ArrayList<>(recordsByJobId.entrySet()), 0, query, tenantId, allResults, promise);
+
     } catch (Exception e) {
       LOGGER.warn("saveBatch:: Error saving JournalRecord entities", e);
       promise.fail(e);
     }
-    return promise.future().onFailure(e -> LOGGER.warn("saveBatch:: Error saving JournalRecord entities", e));
+
+    return promise.future();
+  }
+
+  private void processNextGroup(List<Map.Entry<String, List<JournalRecord>>> groups,
+                                int currentIndex,
+                                String query,
+                                String tenantId,
+                                List<RowSet<Row>> accumulatedResults,
+                                Promise<List<RowSet<Row>>> finalPromise) {
+
+    // Base case - all groups processed
+    if (currentIndex >= groups.size()) {
+      finalPromise.complete(accumulatedResults);
+      return;
+    }
+
+    // Get current group
+    Map.Entry<String, List<JournalRecord>> currentGroup = groups.get(currentIndex);
+    List<Tuple> tuples = currentGroup.getValue().stream()
+      .map(this::prepareInsertQueryParameters)
+      .collect(toList());
+
+    LOGGER.debug("processNextGroup:: Processing group {} of {} for jobExecutionId: {}",
+      currentIndex + 1, groups.size(), currentGroup.getKey());
+
+    // Execute current group
+    Promise<List<RowSet<Row>>> groupPromise = Promise.promise();
+    executeGroup(query, tuples, tenantId, groupPromise);
+
+    groupPromise.future().onSuccess(results -> {
+      // Add results to accumulated list
+      accumulatedResults.addAll(results);
+      // Process next group
+      processNextGroup(groups, currentIndex + 1, query, tenantId, accumulatedResults, finalPromise);
+    }).onFailure(err -> {
+      LOGGER.error("processNextGroup:: Error processing group {} for jobExecutionId: {}",
+        currentIndex + 1, currentGroup.getKey(), err);
+      finalPromise.fail(err);
+    });
+  }
+
+  private void executeGroup(String query,
+                            List<Tuple> tuples,
+                            String tenantId,
+                            Promise<List<RowSet<Row>>> promise) {
+    pgClientFactory.createInstance(tenantId)
+      .execute(query, tuples, ar -> {
+        if (ar.succeeded()) {
+          promise.complete(ar.result());
+        } else {
+          LOGGER.warn("executeGroup:: Error saving group of JournalRecord entities", ar.cause());
+          promise.fail(ar.cause());
+        }
+      });
   }
 
   private Tuple prepareInsertQueryParameters(JournalRecord journalRecord) {

--- a/mod-source-record-manager-server/src/main/java/org/folio/verticle/DataImportJournalBatchConsumerVerticle.java
+++ b/mod-source-record-manager-server/src/main/java/org/folio/verticle/DataImportJournalBatchConsumerVerticle.java
@@ -1,7 +1,6 @@
 package org.folio.verticle;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
-import io.reactivex.rxjava3.core.BackpressureOverflowStrategy;
 import io.reactivex.rxjava3.core.Completable;
 import io.reactivex.rxjava3.core.Flowable;
 import io.reactivex.rxjava3.core.Scheduler;
@@ -269,9 +268,6 @@ public class DataImportJournalBatchConsumerVerticle extends AbstractVerticle {
       throw new IllegalStateException("KafkaConsumer not initialized");
     }
     return kafkaConsumer.toFlowable()
-      .onBackpressureBuffer(10_000,
-        () -> LOGGER.error("listenKafkaEvents:: Backpressure buffer full"),
-        BackpressureOverflowStrategy.DROP_OLDEST)
       .map(consumerRecord -> {
         try {
           Map<String, String> map = kafkaHeadersToMap(consumerRecord.headers());

--- a/mod-source-record-manager-server/src/main/java/org/folio/verticle/DataImportJournalBatchConsumerVerticle.java
+++ b/mod-source-record-manager-server/src/main/java/org/folio/verticle/DataImportJournalBatchConsumerVerticle.java
@@ -43,6 +43,7 @@ import org.folio.util.SharedDataUtil;
 import org.folio.verticle.consumers.util.EventTypeHandlerSelector;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Scope;
 import org.springframework.stereotype.Component;
 
@@ -107,7 +108,8 @@ public class DataImportJournalBatchConsumerVerticle extends AbstractVerticle {
 
   public static final String DATA_IMPORT_JOURNAL_BATCH_KAFKA_HANDLER_UUID = "ca0c6c56-e74e-4921-b4c9-7b2de53c43ec";
 
-  private static final int MAX_NUM_EVENTS = 100;
+  @Value("$${MAX_NUM_EVENTS:100}")
+  private int MAX_NUM_EVENTS;
 
   @Autowired
   @Qualifier("newKafkaConfig")
@@ -268,9 +270,6 @@ public class DataImportJournalBatchConsumerVerticle extends AbstractVerticle {
       throw new IllegalStateException("KafkaConsumer not initialized");
     }
     return kafkaConsumer.toFlowable()
-      .onBackpressureBuffer(10_000,
-        () -> LOGGER.error("listenKafkaEvents:: Backpressure buffer full"),
-        BackpressureOverflowStrategy.DROP_OLDEST)
       .map(consumerRecord -> {
         try {
           Map<String, String> map = kafkaHeadersToMap(consumerRecord.headers());


### PR DESCRIPTION
## Purpose
[MODDATAIMP-1135](https://folio-org.atlassian.net/browse/MODDATAIMP-1135) Log entries are empty for completed jobs

## Approach
 * save journal recs by job id
* group journal records by job execution id to reduce chances of deadlock in the database. 
* Also modified DataImportJournalBatchConsumerVerticle to be resilient to errors and continue processing without restarting the service.

