### PR TITLE
Remove polling when RebalanceInProgressException occured during consumption of events 

### DIFF
--- a/mod-source-record-manager-server/src/main/java/org/folio/verticle/DataImportJournalBatchConsumerVerticle.java
+++ b/mod-source-record-manager-server/src/main/java/org/folio/verticle/DataImportJournalBatchConsumerVerticle.java
@@ -422,8 +422,7 @@ public class DataImportJournalBatchConsumerVerticle extends AbstractVerticle {
       .onErrorResumeNext(error -> {
         if (error instanceof RebalanceInProgressException) {
           LOGGER.warn("Rebalance in progress. Waiting for the re-balance to complete...");
-          return Completable.timer(100, TimeUnit.MILLISECONDS)
-            .andThen(commitOffset(offsets));
+          return Completable.timer(1, TimeUnit.MILLISECONDS);
         }
         LOGGER.warn("Error committing offsets: {}. Retrying in 1 second...", error.getMessage());
         return Completable.timer(1, TimeUnit.SECONDS)

--- a/mod-source-record-manager-server/src/main/java/org/folio/verticle/DataImportJournalBatchConsumerVerticle.java
+++ b/mod-source-record-manager-server/src/main/java/org/folio/verticle/DataImportJournalBatchConsumerVerticle.java
@@ -422,7 +422,7 @@ public class DataImportJournalBatchConsumerVerticle extends AbstractVerticle {
       .onErrorResumeNext(error -> {
         if (error instanceof RebalanceInProgressException) {
           LOGGER.warn("Rebalance in progress. Waiting for the re-balance to complete...");
-          return Completable.timer(1, TimeUnit.MILLISECONDS);
+          return Completable.timer(1, TimeUnit.SECONDS);
         }
         LOGGER.warn("Error committing offsets: {}. Retrying in 1 second...", error.getMessage());
         return Completable.timer(1, TimeUnit.SECONDS)

--- a/mod-source-record-manager-server/src/main/java/org/folio/verticle/DataImportJournalBatchConsumerVerticle.java
+++ b/mod-source-record-manager-server/src/main/java/org/folio/verticle/DataImportJournalBatchConsumerVerticle.java
@@ -228,7 +228,7 @@ public class DataImportJournalBatchConsumerVerticle extends AbstractVerticle {
 
     Map<String, String> consumerProps = kafkaConfigWithDeserializer.getConsumerProps();
     // this is set so that this consumer can start where the non-batch consumer left off, when no previous offset is found.
-    consumerProps.put(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, "latest");
+    consumerProps.put(KafkaConfig.KAFKA_CONSUMER_AUTO_OFFSET_RESET_CONFIG, "latest");
     consumerProps.put(ConsumerConfig.MAX_POLL_INTERVAL_MS_CONFIG, "900000");
     consumerProps.put(ConsumerConfig.SESSION_TIMEOUT_MS_CONFIG, "60000");
     consumerProps.put(ConsumerConfig.HEARTBEAT_INTERVAL_MS_CONFIG, "20000");

--- a/mod-source-record-manager-server/src/main/java/org/folio/verticle/DataImportJournalBatchConsumerVerticle.java
+++ b/mod-source-record-manager-server/src/main/java/org/folio/verticle/DataImportJournalBatchConsumerVerticle.java
@@ -229,7 +229,7 @@ public class DataImportJournalBatchConsumerVerticle extends AbstractVerticle {
     Map<String, String> consumerProps = kafkaConfigWithDeserializer.getConsumerProps();
     // this is set so that this consumer can start where the non-batch consumer left off, when no previous offset is found.
     consumerProps.put(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, "latest");
-
+    consumerProps.put(ConsumerConfig.MAX_POLL_INTERVAL_MS_CONFIG, "900000");
     consumerProps.put(ConsumerConfig.SESSION_TIMEOUT_MS_CONFIG, "60000");
     consumerProps.put(ConsumerConfig.HEARTBEAT_INTERVAL_MS_CONFIG, "20000");
     consumerProps.put(ConsumerConfig.GROUP_ID_CONFIG, KafkaTopicNameHelper.formatGroupName("DATA_IMPORT_JOURNAL_BATCH",

--- a/mod-source-record-manager-server/src/main/java/org/folio/verticle/DataImportJournalBatchConsumerVerticle.java
+++ b/mod-source-record-manager-server/src/main/java/org/folio/verticle/DataImportJournalBatchConsumerVerticle.java
@@ -169,11 +169,6 @@ public class DataImportJournalBatchConsumerVerticle extends AbstractVerticle {
       // Dispose of all subscriptions
       disposables.dispose();
 
-      // Close Kafka consumer
-      if (kafkaConsumer != null) {
-        kafkaConsumer.close();
-      }
-
       // Close event bus consumer
       if (eventBusConsumer != null) {
         eventBusConsumer.unregister();

--- a/mod-source-record-manager-server/src/main/java/org/folio/verticle/DataImportJournalBatchConsumerVerticle.java
+++ b/mod-source-record-manager-server/src/main/java/org/folio/verticle/DataImportJournalBatchConsumerVerticle.java
@@ -21,7 +21,6 @@ import io.vertx.rxjava3.impl.AsyncResultSingle;
 import io.vertx.rxjava3.kafka.client.consumer.KafkaConsumer;
 import io.vertx.rxjava3.kafka.client.consumer.KafkaConsumerRecord;
 import io.vertx.rxjava3.kafka.client.producer.KafkaHeader;
-import java.time.Duration;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.tuple.Pair;
 import org.apache.kafka.clients.consumer.ConsumerConfig;

--- a/mod-source-record-manager-server/src/main/java/org/folio/verticle/DataImportJournalBatchConsumerVerticle.java
+++ b/mod-source-record-manager-server/src/main/java/org/folio/verticle/DataImportJournalBatchConsumerVerticle.java
@@ -425,7 +425,7 @@ public class DataImportJournalBatchConsumerVerticle extends AbstractVerticle {
           return Completable.timer(100, TimeUnit.MILLISECONDS)
             .andThen(commitOffset(offsets));
         }
-        LOGGER.error("Error committing offsets: {}. Retrying in 1 second...", error.getMessage());
+        LOGGER.warn("Error committing offsets: {}. Retrying in 1 second...", error.getMessage());
         return Completable.timer(1, TimeUnit.SECONDS)
           .andThen(commitOffset(offsets));
       })

--- a/mod-source-record-manager-server/src/main/java/org/folio/verticle/DataImportJournalBatchConsumerVerticle.java
+++ b/mod-source-record-manager-server/src/main/java/org/folio/verticle/DataImportJournalBatchConsumerVerticle.java
@@ -430,7 +430,7 @@ public class DataImportJournalBatchConsumerVerticle extends AbstractVerticle {
           return kafkaConsumer.rxPoll(Duration.ofMillis(100))
             .flatMapCompletable(records -> commitOffset(offsets));
         }
-        return Completable.error(error);
+        return Completable.complete();
       })
       .doOnComplete(() -> LOGGER.info("commitOffset:: Successfully committed offsets: {}", offsets))
       .doOnError(error -> LOGGER.error("commitOffset:: Failed to commit offsets: {}", offsets, error));

--- a/mod-source-record-manager-server/src/main/resources/log4j2-json.properties
+++ b/mod-source-record-manager-server/src/main/resources/log4j2-json.properties
@@ -34,7 +34,7 @@ logger.folio_kafka.level = debug
 logger.folio_kafka.additivity = false
 logger.folio_kafka.appenderRef.stdout.ref = STDOUT
 
-rootLogger.level = info
+rootLogger.level = ${sys:LOG_LEVEL:-INFO}
 rootLogger.appenderRefs = info
 rootLogger.appenderRef.stdout.ref = STDOUT
 

--- a/mod-source-record-manager-server/src/main/resources/log4j2.properties
+++ b/mod-source-record-manager-server/src/main/resources/log4j2.properties
@@ -18,7 +18,7 @@ logger.folio_kafka.level = debug
 logger.folio_kafka.additivity = false
 logger.folio_kafka.appenderRef.stdout.ref = STDOUT
 
-rootLogger.level = info
+rootLogger.level = ${sys:LOG_LEVEL:-INFO}
 rootLogger.appenderRefs = info
 rootLogger.appenderRef.stdout.ref = STDOUT
 


### PR DESCRIPTION
## Purpose
in the previous approach, we were waiting, polling, and then committing offsets if a  rebalance exception occurred in the commitOffsets logic 
now, we wait then retry commit without polling for new records
also other error are handled in similar fashion 