### PR TITLE
 MODSOURMAN-1323: Ensure holdings validation to check central ECS tenant

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,6 @@
 ## XXXX-XX-XX v3.1X.X
 * [MODSOURMAN-1304](https://folio-org.atlassian.net/browse/MODSOURMAN-1304) Handle journal records for MARC on Instance errors and COMPLETED INSTANCE/MARC_BIB events
+* [MODSOURMAN-1323](https://folio-org.atlassian.net/browse/MODSOURMAN-1323) Ensure holdings validation to check central ECS tenant
 
 ## 2025-03-13 v3.10.0
 * [MODSOURMAN-1246](https://folio-org.atlassian.net/browse/MODSOURMAN-1246) Added data import completion notifications

--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -855,6 +855,7 @@
       "permissions": [
         "source-storage.snapshots.put",
         "users.collection.get",
+        "user-tenants.collection.get",
         "inventory-storage.identifier-types.collection.get",
         "inventory-storage.classification-types.collection.get",
         "inventory-storage.instance-types.collection.get",

--- a/mod-source-record-manager-server/src/main/java/org/folio/services/ConsortiumDataCache.java
+++ b/mod-source-record-manager-server/src/main/java/org/folio/services/ConsortiumDataCache.java
@@ -1,0 +1,112 @@
+package org.folio.services;
+
+import static org.folio.services.util.ConsortiumUtil.DEFAULT_EXPIRATION_TIME_SECONDS;
+import static org.folio.services.util.ConsortiumUtil.EXPIRATION_TIME_PARAM;
+
+import com.github.benmanes.caffeine.cache.AsyncCache;
+import com.github.benmanes.caffeine.cache.Caffeine;
+import io.vertx.core.Future;
+import io.vertx.core.Promise;
+import io.vertx.core.Vertx;
+import io.vertx.core.http.HttpMethod;
+import io.vertx.core.json.JsonArray;
+import io.vertx.core.json.JsonObject;
+import java.util.Optional;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.TimeUnit;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.folio.dataimport.util.OkapiConnectionParams;
+import org.folio.dataimport.util.RestUtil;
+import org.folio.services.entity.ConsortiumConfiguration;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
+@Component
+public class ConsortiumDataCache {
+
+  private static final Logger LOG = LogManager.getLogger(ConsortiumDataCache.class);
+
+  private static final String USER_TENANTS_PATH = "/user-tenants";
+  private static final String LIMIT_PARAM = "limit=%d";
+  private static final String USER_TENANTS_FIELD = "userTenants";
+  private static final String CENTRAL_TENANT_ID_FIELD = "centralTenantId";
+  private static final String CONSORTIUM_ID_FIELD = "consortiumId";
+
+  private final Vertx vertx;
+  private final AsyncCache<String, Optional<ConsortiumConfiguration>> cache;
+
+  @Autowired
+  public ConsortiumDataCache(Vertx vertx) {
+    this.vertx = vertx;
+    int expirationTime = Integer.parseInt(System.getProperty(EXPIRATION_TIME_PARAM, DEFAULT_EXPIRATION_TIME_SECONDS));
+    this.cache = Caffeine.newBuilder()
+      .expireAfterWrite(expirationTime, TimeUnit.SECONDS)
+      .executor(task -> vertx.runOnContext(v -> task.run()))
+      .buildAsync();
+  }
+
+  /**
+   * Returns consortium data by specified connection params.
+   *
+   * @return future of Optional with consortium data for the specified connection params,
+   *   if the specified in connection params tenant is not included to any consortium,
+   *   then returns future with empty Optional
+   */
+  public Future<Optional<ConsortiumConfiguration>> getConsortiumData(OkapiConnectionParams params) {
+    var tenantId = params.getTenantId();
+    try {
+      // Ensure we're running in Vert.x context
+      if (Vertx.currentContext() == null) {
+        return vertx.executeBlocking(promise ->
+          cache.get(tenantId, (key, executor) -> loadData(params))
+            .thenAccept(promise::complete)
+            .exceptionally(e -> {
+              promise.fail(e);
+              return null;
+            })
+        );
+
+      }
+      return Future.fromCompletionStage(cache.get(tenantId, (key, executor) -> loadData(params)));
+    } catch (Exception e) {
+      LOG.warn("getConsortiumData:: Error loading consortium data, tenantId: '{}'", tenantId, e);
+      return Future.failedFuture(e);
+    }
+  }
+
+  private CompletableFuture<Optional<ConsortiumConfiguration>> loadData(OkapiConnectionParams params) {
+    Promise<Optional<ConsortiumConfiguration>> promise = Promise.promise();
+    RestUtil.doRequestWithSystemUser(params, USER_TENANTS_PATH + "?" + LIMIT_PARAM.formatted(1), HttpMethod.GET, null)
+      .onComplete(response -> {
+        try {
+          if (RestUtil.validateAsyncResult(response, promise)) {
+            JsonArray userTenants = response.result().getJson().getJsonArray(USER_TENANTS_FIELD);
+            if (userTenants.isEmpty()) {
+              promise.complete(Optional.empty());
+              return;
+            }
+
+            LOG.info("loadConsortiumData:: Consortium data was loaded, tenantId: '{}'", params.getTenantId());
+            JsonObject userTenant = userTenants.getJsonObject(0);
+            promise.complete(Optional.of(buildConsortiumConfig(userTenant)));
+          } else {
+            String msg = String.format("Error loading consortium data, tenantId: '%s'", params.getTenantId());
+            LOG.warn("loadConsortiumData:: {}", msg);
+            promise.fail((msg));
+          }
+        } catch (Exception e) {
+          LOG.warn("Error loading consortium data, tenantId: {}", params.getTenantId(), e);
+          promise.fail(e);
+        }
+      });
+    return promise.future().toCompletionStage().toCompletableFuture();
+  }
+
+  private ConsortiumConfiguration buildConsortiumConfig(JsonObject userTenant) {
+    return new ConsortiumConfiguration(
+      userTenant.getString(CENTRAL_TENANT_ID_FIELD),
+      userTenant.getString(CONSORTIUM_ID_FIELD)
+    );
+  }
+}

--- a/mod-source-record-manager-server/src/main/java/org/folio/services/entity/ConsortiumConfiguration.java
+++ b/mod-source-record-manager-server/src/main/java/org/folio/services/entity/ConsortiumConfiguration.java
@@ -1,0 +1,3 @@
+package org.folio.services.entity;
+
+public record ConsortiumConfiguration(String centralTenantId, String consortiumId) { }

--- a/mod-source-record-manager-server/src/main/java/org/folio/services/util/ConsortiumUtil.java
+++ b/mod-source-record-manager-server/src/main/java/org/folio/services/util/ConsortiumUtil.java
@@ -1,0 +1,8 @@
+package org.folio.services.util;
+
+public class ConsortiumUtil {
+  public static final String EXPIRATION_TIME_PARAM = "cache.consortium-data.expiration.time.seconds";
+  public static final String DEFAULT_EXPIRATION_TIME_SECONDS = "300";
+
+  private ConsortiumUtil() { }
+}

--- a/mod-source-record-manager-server/src/test/java/org/folio/rest/impl/changeManager/ChangeManagerAPITest.java
+++ b/mod-source-record-manager-server/src/test/java/org/folio/rest/impl/changeManager/ChangeManagerAPITest.java
@@ -233,6 +233,8 @@ public class ChangeManagerAPITest extends AbstractRestTest {
         WireMock.ok().withBody(Json.encode(new JsonObject("{\"invalidMarcBibIds\" : [ \"111111\", \"222222\" ]}")))));
     WireMock.stubFor(WireMock.get("/linking-rules/instance-authority")
       .willReturn(WireMock.ok().withBody(Json.encode(emptyList()))));
+    WireMock.stubFor(WireMock.get("/user-tenants?limit=1")
+      .willReturn(WireMock.ok().withBody("{\"userTenants\":[{\"centralTenantId\":\"consortium\"}]}")));
   }
 
   @Test
@@ -1755,7 +1757,7 @@ public class ChangeManagerAPITest extends AbstractRestTest {
   }
 
   @Test
-  public void shouldFillRecordOrderIfAtLeastOneMarcAuthorityRecordHasNoOrder(TestContext testContext) {
+  public void shouldFillInRecordOrderIfAtLeastOneMarcHoldingsRecordHasNoOrder(TestContext testContext) {
     fillInRecordOrderIfAtLeastOneRecordHasNoOrder(testContext, CORRECT_MARC_HOLDINGS_RAW_RECORD);
   }
 

--- a/mod-source-record-manager-server/src/test/java/org/folio/services/ConsortiumDataCacheTest.java
+++ b/mod-source-record-manager-server/src/test/java/org/folio/services/ConsortiumDataCacheTest.java
@@ -1,0 +1,110 @@
+package org.folio.services;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.get;
+
+import com.github.tomakehurst.wiremock.client.WireMock;
+import com.github.tomakehurst.wiremock.common.ConsoleNotifier;
+import com.github.tomakehurst.wiremock.core.WireMockConfiguration;
+import com.github.tomakehurst.wiremock.junit.WireMockRule;
+import io.vertx.core.Vertx;
+import io.vertx.core.json.JsonArray;
+import io.vertx.core.json.JsonObject;
+import io.vertx.ext.unit.Async;
+import io.vertx.ext.unit.TestContext;
+import io.vertx.ext.unit.junit.VertxUnitRunner;
+import java.util.Map;
+import java.util.UUID;
+import org.folio.dataimport.util.OkapiConnectionParams;
+import org.folio.okapi.common.XOkapiHeaders;
+import org.folio.services.entity.ConsortiumConfiguration;
+import org.junit.Before;
+import org.junit.ClassRule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+@RunWith(VertxUnitRunner.class)
+public class ConsortiumDataCacheTest {
+
+  @ClassRule
+  public static WireMockRule mockServer = new WireMockRule(WireMockConfiguration.wireMockConfig()
+    .notifier(new ConsoleNotifier(false))
+    .dynamicPort());
+
+  private static final String TENANT_ID = "diku";
+  private static final String USER_TENANTS_PATH = "/user-tenants?limit=1";
+  private static final String USER_TENANTS_FIELD = "userTenants";
+  private static final String CENTRAL_TENANT_ID_FIELD = "centralTenantId";
+  private static final String CONSORTIUM_ID_FIELD = "consortiumId";
+
+  private final Vertx vertx = Vertx.vertx();
+  private ConsortiumDataCache consortiumDataCache;
+  private Map<String, String> okapiHeaders;
+
+  @Before
+  public void setUp() {
+    consortiumDataCache = new ConsortiumDataCache(vertx);
+    okapiHeaders = Map.of(
+      XOkapiHeaders.TENANT.toLowerCase(), TENANT_ID,
+      XOkapiHeaders.TOKEN.toLowerCase(), "token",
+      XOkapiHeaders.URL.toLowerCase(), mockServer.baseUrl());
+  }
+
+  @Test
+  public void shouldReturnConsortiumData(TestContext context) {
+    Async async = context.async();
+    String expectedCentralTenantId = "mobius";
+    String expectedConsortiumId = UUID.randomUUID().toString();
+
+    JsonObject userTenantsCollection = new JsonObject()
+      .put(USER_TENANTS_FIELD, new JsonArray()
+        .add(new JsonObject()
+          .put(CENTRAL_TENANT_ID_FIELD, expectedCentralTenantId)
+          .put(CONSORTIUM_ID_FIELD, expectedConsortiumId)));
+
+    WireMock.stubFor(get(USER_TENANTS_PATH)
+      .willReturn(WireMock.ok().withBody(userTenantsCollection.encodePrettily())));
+
+    var future = consortiumDataCache.getConsortiumData(new OkapiConnectionParams(okapiHeaders, vertx));
+
+    future.onComplete(ar -> {
+      context.assertTrue(ar.succeeded());
+      context.assertTrue(ar.result().isPresent());
+      ConsortiumConfiguration consortiumConfig = ar.result().get();
+      context.assertEquals(expectedCentralTenantId, consortiumConfig.centralTenantId());
+      context.assertEquals(expectedConsortiumId, consortiumConfig.consortiumId());
+      async.complete();
+    });
+  }
+
+  @Test
+  public void shouldReturnEmptyOptionalIfSpecifiedTenantInHeadersIsNotInConsortium(TestContext context) {
+    Async async = context.async();
+    JsonObject emptyUserTenantsCollection = new JsonObject()
+      .put(USER_TENANTS_FIELD, JsonArray.of());
+
+    WireMock.stubFor(get(USER_TENANTS_PATH)
+      .willReturn(WireMock.ok().withBody(emptyUserTenantsCollection.encodePrettily())));
+
+    var future = consortiumDataCache.getConsortiumData(new OkapiConnectionParams(okapiHeaders, vertx));
+
+    future.onComplete(ar -> {
+      context.assertTrue(ar.succeeded());
+      context.assertTrue(ar.result().isEmpty());
+      async.complete();
+    });
+  }
+
+  @Test
+  public void shouldReturnFailedFutureWhenGetServerErrorOnConsortiumDataLoading(TestContext context) {
+    Async async = context.async();
+    WireMock.stubFor(get(USER_TENANTS_PATH).willReturn(WireMock.serverError()));
+
+    var future = consortiumDataCache.getConsortiumData(new OkapiConnectionParams(okapiHeaders, vertx))
+      .onComplete(context.asyncAssertFailure());
+
+    future.onComplete(ar -> {
+      context.assertTrue(ar.failed());
+      async.complete();
+    });
+  }
+}

--- a/mod-source-record-manager-server/src/test/java/org/folio/services/EventDrivenChunkProcessingServiceImplTest.java
+++ b/mod-source-record-manager-server/src/test/java/org/folio/services/EventDrivenChunkProcessingServiceImplTest.java
@@ -118,6 +118,9 @@ public class EventDrivenChunkProcessingServiceImplTest extends AbstractRestTest 
   @InjectMocks
   @Spy
   private IncomingRecordServiceImpl incomingRecordService;
+  @Spy
+  @InjectMocks
+  private ConsortiumDataCache consortiumDataCache;
   @InjectMocks
   @Spy
   private IncomingRecordDaoImpl incomingRecordDao;
@@ -197,7 +200,7 @@ public class EventDrivenChunkProcessingServiceImplTest extends AbstractRestTest 
       new DataImportPayloadContextBuilderImpl(marcRecordAnalyzer), kafkaConfig, emptyList());
     changeEngineService = new ChangeEngineServiceImpl(jobExecutionSourceChunkDao, jobExecutionService, marcRecordAnalyzer,
       hrIdFieldService, recordsPublishingService, mappingMetadataService, new JobProfileSnapshotValidationServiceImpl(), kafkaConfig,
-      fieldModificationService, incomingRecordService, vertx);
+      fieldModificationService, incomingRecordService, consortiumDataCache, vertx);
     ReflectionTestUtils.setField(changeEngineService, "maxDistributionNum", 10);
     ReflectionTestUtils.setField(changeEngineService, "batchSize", 100);
     ReflectionTestUtils.setField(recordsPublishingService, "maxDistributionNum", 100);

--- a/mod-source-record-manager-server/src/test/java/org/folio/services/RecordProcessedEventHandlingServiceImplTest.java
+++ b/mod-source-record-manager-server/src/test/java/org/folio/services/RecordProcessedEventHandlingServiceImplTest.java
@@ -150,6 +150,9 @@ public class RecordProcessedEventHandlingServiceImplTest extends AbstractRestTes
   private IncomingRecordServiceImpl incomingRecordService;
   @Spy
   @InjectMocks
+  private ConsortiumDataCache consortiumDataCache;
+  @Spy
+  @InjectMocks
   private JournalRecordServiceImpl journalRecordService;
   @Spy
   @InjectMocks
@@ -203,7 +206,7 @@ public class RecordProcessedEventHandlingServiceImplTest extends AbstractRestTes
       new DataImportPayloadContextBuilderImpl(marcRecordAnalyzer), kafkaConfig, emptyList());
     ChangeEngineService changeEngineService = new ChangeEngineServiceImpl(jobExecutionSourceChunkDao, jobExecutionService, marcRecordAnalyzer,
       hrIdFieldService, recordsPublishingService, mappingMetadataService, jobProfileSnapshotValidationService, kafkaConfig, fieldModificationService,
-      incomingRecordService, vertx);
+      incomingRecordService, consortiumDataCache, vertx);
     ReflectionTestUtils.setField(changeEngineService, "maxDistributionNum", 10);
     ReflectionTestUtils.setField(changeEngineService, "batchSize", 100);
     ReflectionTestUtils.setField(recordsPublishingService, "maxDistributionNum", 100);


### PR DESCRIPTION
## Purpose
Make it possible to create a MARC Holdings record for shared MARC Instance in ECS.

## Approach
Send validation request for both current tenant and central tenant when applicable.

## Checklist
- [x] I have updated NEWS.md.
- [x] I have added javadocs to new methods.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation e.g. README.md.
- [ ] I have ran karate tests against this feature.

