### PR TITLE
MODDATAIMP-1214 - Ensure permission that allows update of shared instance and MARC

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,7 @@
 ## XXXX-XX-XX v3.1X.X
 * [MODSOURMAN-1304](https://folio-org.atlassian.net/browse/MODSOURMAN-1304) Handle journal records for MARC on Instance errors and COMPLETED INSTANCE/MARC_BIB events
 * [MODSOURMAN-1323](https://folio-org.atlassian.net/browse/MODSOURMAN-1323) Ensure holdings validation to check central ECS tenant
+* [MODDATAIMP-1214](https://folio-org.atlassian.net/browse/MODDATAIMP-1214) Ensure permission that allows update of shared instance and MARC
 
 ## 2025-03-13 v3.10.0
 * [MODSOURMAN-1246](https://folio-org.atlassian.net/browse/MODSOURMAN-1246) Added data import completion notifications

--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -371,6 +371,7 @@
             "source-storage.records.put"
           ],
           "permissionsDesired": [
+            "consortia.data-import.central-record-update.execute",
             "invoices.acquisitions-units-assignments.assign",
             "orders.acquisitions-units-assignments.assign",
             "orders.acquisitions-units-assignments.manage",


### PR DESCRIPTION
## Purpose
to ensure permission that will allow update of shared instance/record through data import


## Learning
[MODDATAIMP-1214](https://issues.folio.org/browse/MODDATAIMP-1214)
