### PR TITLE
MODSOURMAN-1341 - Set groupInstanceId property during consumer wrapper creation

### DIFF
--- a/mod-source-record-manager-server/pom.xml
+++ b/mod-source-record-manager-server/pom.xml
@@ -195,7 +195,7 @@
     <dependency>
       <groupId>org.folio</groupId>
       <artifactId>folio-kafka-wrapper</artifactId>
-      <version>3.3.1</version>
+      <version>3.4.0-SNAPSHOT</version>
     </dependency>
     <dependency>
       <groupId>org.folio</groupId>

--- a/mod-source-record-manager-server/src/main/java/org/folio/verticle/AbstractConsumersVerticle.java
+++ b/mod-source-record-manager-server/src/main/java/org/folio/verticle/AbstractConsumersVerticle.java
@@ -19,6 +19,7 @@ import org.springframework.beans.factory.annotation.Value;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.UUID;
 
 import static org.folio.services.util.EventHandlingUtil.constructModuleName;
 
@@ -60,6 +61,7 @@ public abstract class AbstractConsumersVerticle<K, V> extends AbstractVerticle {
         .subscriptionDefinition(subscriptionDefinition)
         .processRecordErrorHandler(getErrorHandler())
         .backPressureGauge(getBackPressureGauge())
+        .groupInstanceId(getClass().getSimpleName() + "-" + UUID.randomUUID())
         .build();
       kafkaConsumersStorage.addConsumer(event, consumerWrapper);
 

--- a/mod-source-record-manager-server/src/main/java/org/folio/verticle/DataImportJournalBatchConsumerVerticle.java
+++ b/mod-source-record-manager-server/src/main/java/org/folio/verticle/DataImportJournalBatchConsumerVerticle.java
@@ -228,6 +228,7 @@ public class DataImportJournalBatchConsumerVerticle extends AbstractVerticle {
     consumerProps.put(ConsumerConfig.HEARTBEAT_INTERVAL_MS_CONFIG, "20000");
     consumerProps.put(ConsumerConfig.GROUP_ID_CONFIG, KafkaTopicNameHelper.formatGroupName("DATA_IMPORT_JOURNAL_BATCH",
       environment() + "_" + constructModuleName() + "_" + getClass().getSimpleName()));
+    consumerProps.put(ConsumerConfig.GROUP_INSTANCE_ID_CONFIG, getClass().getSimpleName() + "-" + UUID.randomUUID());
     if(SharedDataUtil.getIsTesting(vertx.getDelegate())) {
       // this will allow the consumer to retrieve messages faster during tests
       consumerProps.put(ConsumerConfig.METADATA_MAX_AGE_CONFIG, "1000");


### PR DESCRIPTION
## Purpose
to configure "group.instance.id" property during consumer wrapper creation


## Learning
[MODSOURMAN-1341](https://issues.folio.org/browse/MODSOURMAN-1341)