### PR TITLE
MODDICORE-456 Update 338 rule to add mapping of Format from $a

### DIFF
--- a/mod-source-record-manager-server/src/main/resources/rules/marc_bib_rules.json
+++ b/mod-source-record-manager-server/src/main/resources/rules/marc_bib_rules.json
@@ -2229,8 +2229,19 @@
       "target": "instanceFormatIds",
       "description": "Instance Format ID",
       "ignoreSubsequentSubfields": true,
+      "applyRulesOnConcatenatedData": true,
       "subfield": [
+        "a",
         "b"
+      ],
+      "subFieldDelimiter": [
+        {
+          "value": "~",
+          "subfields": [
+            "a",
+            "b"
+          ]
+        }
       ],
       "rules": [
         {

--- a/mod-source-record-manager-server/src/test/resources/org/folio/services/marc_bib_rules.json
+++ b/mod-source-record-manager-server/src/test/resources/org/folio/services/marc_bib_rules.json
@@ -2229,8 +2229,19 @@
       "target": "instanceFormatIds",
       "description": "Instance Format ID",
       "ignoreSubsequentSubfields": true,
+      "applyRulesOnConcatenatedData": true,
       "subfield": [
+        "a",
         "b"
+      ],
+      "subFieldDelimiter": [
+        {
+          "value": "~",
+          "subfields": [
+            "a",
+            "b"
+          ]
+        }
       ],
       "rules": [
         {


### PR DESCRIPTION
## Purpose
Add the ability to map Instance Format from 338$a if $b is not present

## Approach
Change mapping rules 
Tests are added in https://github.com/folio-org/data-import-processing-core/pull/409
