### PR TITLE
MODSOURCE-747 - Ensure jobExecutionId in headers for import run through SRM API for skipping events using jobExecutionId  from headers

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -4,6 +4,7 @@
 * [MODDATAIMP-1214](https://folio-org.atlassian.net/browse/MODDATAIMP-1214) Ensure permission that allows update of shared instance and MARC
 * [MODSOURMAN-1136](https://folio-org.atlassian.net/browse/MODSOURMAN-1136) Send Kafka event when JobExecution is cancelled
 * [MODSOURMAN-1353](https://folio-org.atlassian.net/browse/MODSOURMAN-1353) Remove GET /change-manager/parsedRecords endpoint
+* [MODSOURCE-747](https://folio-org.atlassian.net/browse/MODSOURCE-747) Ensure jobExecutionId in headers for import run through SRM API for skipping events using jobExecutionId from headers
 
 ## 2025-03-13 v3.10.0
 * [MODSOURMAN-1246](https://folio-org.atlassian.net/browse/MODSOURMAN-1246) Added data import completion notifications

--- a/mod-source-record-manager-server/src/main/java/org/folio/services/RecordsPublishingServiceImpl.java
+++ b/mod-source-record-manager-server/src/main/java/org/folio/services/RecordsPublishingServiceImpl.java
@@ -44,8 +44,9 @@ import static org.folio.services.util.EventHandlingUtil.sendEventToKafka;
   private static final Logger LOGGER = LogManager.getLogger();
   public static final String RECORD_ID_HEADER = "recordId";
   public static final String USER_ID_HEADER = "userId";
+  private static final String JOB_EXECUTION_ID_HEADER = "jobExecutionId";
   private static final AtomicInteger indexer = new AtomicInteger();
-  public static final String ERROR_KEY = "ERROR";
+  private static final String ERROR_KEY = "ERROR";
 
   @Value("${srm.kafka.CreatedRecordsKafkaHandler.maxDistributionNum:100}")
   private int maxDistributionNum;
@@ -89,6 +90,7 @@ import static org.folio.services.util.EventHandlingUtil.sendEventToKafka;
         if (record.getRecordType() != null && isParsedContentExists(record)) {
           DataImportEventPayload payload = prepareEventPayload(record, profileSnapshotWrapper, params, eventType, context);
           params.getHeaders().set(RECORD_ID_HEADER, record.getId());
+          params.getHeaders().set(JOB_EXECUTION_ID_HEADER, record.getSnapshotId());
           params.getHeaders().set(USER_ID_HEADER, jobExecution.getUserId());
           futures.add(sendEventToKafka(params.getTenantId(), Json.encode(payload),
             eventType, KafkaHeaderUtils.kafkaHeadersFromMultiMap(params.getHeaders()), kafkaConfig, key));

--- a/mod-source-record-manager-server/src/main/java/org/folio/services/progress/JobExecutionProgressServiceImpl.java
+++ b/mod-source-record-manager-server/src/main/java/org/folio/services/progress/JobExecutionProgressServiceImpl.java
@@ -65,8 +65,8 @@ public class JobExecutionProgressServiceImpl implements JobExecutionProgressServ
   @Override
   public Future<Void> updateCompletionCounts(String jobExecutionId, int successCountDelta, int errorCountDelta, OkapiConnectionParams params) {
     JobExecutionProgress jobExecutionProgress = new JobExecutionProgress().withJobExecutionId(jobExecutionId)
-        .withCurrentlySucceeded(successCountDelta)
-          .withCurrentlyFailed(errorCountDelta);
+      .withCurrentlySucceeded(successCountDelta)
+      .withCurrentlyFailed(errorCountDelta);
     BatchableJobExecutionProgress batchableJobExecutionProgress = new BatchableJobExecutionProgress(params, jobExecutionProgress);
     return jobExecutionProgressMessageProducer.write(batchableJobExecutionProgress);
   }

--- a/mod-source-record-manager-server/src/test/java/org/folio/rest/impl/AbstractRestTest.java
+++ b/mod-source-record-manager-server/src/test/java/org/folio/rest/impl/AbstractRestTest.java
@@ -575,7 +575,7 @@ public abstract class AbstractRestTest {
     JobExecution parent = RestAssured.given()
       .spec(spec)
       .body(JsonObject.mapFrom(requestDto).toString())
-      .when().post(JOB_EXECUTION_PATH).body().as(InitJobExecutionsRsDto.class).getJobExecutions().get(0);
+      .when().post(JOB_EXECUTION_PATH).body().as(InitJobExecutionsRsDto.class).getJobExecutions().getFirst();
 
     List<JobExecution> result = new ArrayList<>();
     result.add(parent);
@@ -593,7 +593,7 @@ public abstract class AbstractRestTest {
         RestAssured.given()
           .spec(spec)
           .body(JsonObject.mapFrom(childRequestDto).toString())
-          .when().post(JOB_EXECUTION_PATH).body().as(InitJobExecutionsRsDto.class).getJobExecutions().get(0)
+          .when().post(JOB_EXECUTION_PATH).body().as(InitJobExecutionsRsDto.class).getJobExecutions().getFirst()
       );
     }
 
@@ -657,7 +657,7 @@ public abstract class AbstractRestTest {
   }
 
   protected <V> ConsumerRecord<String, String> buildConsumerRecord(String topic, Event event) {
-    ConsumerRecord<java.lang.String, String> consumerRecord = new ConsumerRecord("folio", 0, 0, topic, Json.encode(event));
+    ConsumerRecord<java.lang.String, String> consumerRecord = new ConsumerRecord<>("folio", 0, 0, topic, Json.encode(event));
     consumerRecord.headers().add(new RecordHeader(OkapiConnectionParams.OKAPI_TENANT_HEADER, TENANT_ID.getBytes(StandardCharsets.UTF_8)));
     consumerRecord.headers().add(new RecordHeader(OKAPI_URL_HEADER, ("http://localhost:" + snapshotMockServer.port()).getBytes(StandardCharsets.UTF_8)));
     consumerRecord.headers().add(new RecordHeader(OKAPI_TOKEN_HEADER, (TOKEN).getBytes(StandardCharsets.UTF_8)));
@@ -665,7 +665,7 @@ public abstract class AbstractRestTest {
   }
 
   protected <V> ConsumerRecord<String, byte[]> buildConsumerRecordAsByteArray(String topic, Event event) {
-    ConsumerRecord<java.lang.String, byte[]> consumerRecord = new ConsumerRecord("folio", 0, 0, topic, Json.encode(event).getBytes(StandardCharsets.UTF_8));
+    ConsumerRecord<java.lang.String, byte[]> consumerRecord = new ConsumerRecord<>("folio", 0, 0, topic, Json.encode(event).getBytes(StandardCharsets.UTF_8));
     consumerRecord.headers().add(new RecordHeader(OkapiConnectionParams.OKAPI_TENANT_HEADER, TENANT_ID.getBytes(StandardCharsets.UTF_8)));
     consumerRecord.headers().add(new RecordHeader(OKAPI_URL_HEADER, ("http://localhost:" + snapshotMockServer.port()).getBytes(StandardCharsets.UTF_8)));
     consumerRecord.headers().add(new RecordHeader(OKAPI_TOKEN_HEADER, (TOKEN).getBytes(StandardCharsets.UTF_8)));

--- a/mod-source-record-manager-server/src/test/java/org/folio/rest/impl/changeManager/ChangeManagerAPITest.java
+++ b/mod-source-record-manager-server/src/test/java/org/folio/rest/impl/changeManager/ChangeManagerAPITest.java
@@ -18,6 +18,7 @@ import static org.folio.rest.jaxrs.model.DataImportEventTypes.DI_ERROR;
 import static org.folio.rest.jaxrs.model.DataImportEventTypes.DI_JOB_CANCELLED;
 import static org.folio.rest.jaxrs.model.DataImportEventTypes.DI_MARC_FOR_UPDATE_RECEIVED;
 import static org.folio.rest.jaxrs.model.DataImportEventTypes.DI_RAW_RECORDS_CHUNK_PARSED;
+import static org.folio.rest.jaxrs.model.EntityType.MARC_BIBLIOGRAPHIC;
 import static org.folio.rest.jaxrs.model.ProfileType.ACTION_PROFILE;
 import static org.folio.rest.jaxrs.model.ProfileType.JOB_PROFILE;
 import static org.folio.rest.jaxrs.model.ProfileType.MATCH_PROFILE;
@@ -62,6 +63,8 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.stream.Collectors;
 import org.apache.http.HttpStatus;
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.apache.kafka.common.header.Header;
 import org.folio.MatchProfile;
 import org.folio.TestUtil;
 import org.folio.dao.JournalRecordDao;
@@ -1154,17 +1157,13 @@ public class ChangeManagerAPITest extends AbstractRestTest {
   }
 
   @Test
-  public void shouldProcessChunkOfRawRecords(TestContext testContext) {
+  public void shouldProcessChunkOfRawRecords() {
     InitJobExecutionsRsDto response =
       constructAndPostInitJobExecutionRqDto(1);
     List<JobExecution> createdJobExecutions = response.getJobExecutions();
     assertThat(createdJobExecutions.size(), is(1));
     JobExecution jobExec = createdJobExecutions.getFirst();
 
-    WireMock.stubFor(post(RECORDS_SERVICE_URL)
-      .willReturn(created().withTransformers(RequestToResponseTransformer.NAME)));
-
-    Async async = testContext.async();
     RestAssured.given()
       .spec(spec)
       .body(new JobProfileInfo()
@@ -1175,9 +1174,7 @@ public class ChangeManagerAPITest extends AbstractRestTest {
       .put(JOB_EXECUTION_PATH + jobExec.getId() + JOB_PROFILE_PATH)
       .then()
       .statusCode(HttpStatus.SC_OK);
-    async.complete();
 
-    async = testContext.async();
     RestAssured.given()
       .spec(spec)
       .body(rawRecordsDto)
@@ -1185,9 +1182,7 @@ public class ChangeManagerAPITest extends AbstractRestTest {
       .post(JOB_EXECUTION_PATH + jobExec.getId() + RECORDS_PATH)
       .then()
       .statusCode(HttpStatus.SC_NO_CONTENT);
-    async.complete();
 
-    async = testContext.async();
     RestAssured.given()
       .spec(spec)
       .when()
@@ -1198,7 +1193,18 @@ public class ChangeManagerAPITest extends AbstractRestTest {
       .body("runBy.firstName", is("DIKU"))
       .body("progress.total", is(rawRecordsDto.getRecordsMetadata().getTotal()))
       .body("startedDate", notNullValue(Date.class)).log().all();
-    async.complete();
+
+    List<ConsumerRecord<String, String>> consumerRecords = checkKafkaEventSent(
+      formatToKafkaTopicName(DI_INCOMING_MARC_BIB_RECORD_PARSED.value()), 1);
+    assertEquals(1, consumerRecords.size());
+    Event event = Json.decodeValue(consumerRecords.getFirst().value(), Event.class);
+    DataImportEventPayload eventPayload = Json.decodeValue(event.getEventPayload(), DataImportEventPayload.class);
+    assertEquals(DI_INCOMING_MARC_BIB_RECORD_PARSED.value(), eventPayload.getEventType());
+    assertNotNull(eventPayload.getContext().get(MARC_BIBLIOGRAPHIC.value()));
+
+    Header jobExecutionIdHeader = consumerRecords.getFirst().headers().lastHeader(JOB_EXECUTION_ID_HEADER);
+    assertNotNull(jobExecutionIdHeader);
+    assertEquals(jobExec.getId(), new String(jobExecutionIdHeader.value()));
   }
 
   @Test


### PR DESCRIPTION
## Purpose
to ensure inclusion of jobExecutionId in the message headers for import processes initiated through the mod-source-record-manager API, to allow the skipping of messages related to canceled jobs using the jobExecutionId from the message headers.



## Learning
[MODSOURCE-747](https://issues.folio.org/browse/MODSOURCE-747)