### PR TITLE
fix(custom-migration) modify create_rule_migration_change_log_table.sql to ensure the insert is executed only once.

### DIFF
--- a/mod-source-record-manager-server/src/main/resources/templates/db_scripts/create_rule_migration_change_log_table.sql
+++ b/mod-source-record-manager-server/src/main/resources/templates/db_scripts/create_rule_migration_change_log_table.sql
@@ -1,4 +1,3 @@
-DROP TABLE IF EXISTS rule_migration_change_log CASCADE;
 CREATE TABLE IF NOT EXISTS rule_migration_change_log (
     id uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
     migration_id uuid UNIQUE,

--- a/mod-source-record-manager-server/src/main/resources/templates/db_scripts/create_rule_migration_change_log_table.sql
+++ b/mod-source-record-manager-server/src/main/resources/templates/db_scripts/create_rule_migration_change_log_table.sql
@@ -1,6 +1,7 @@
+DROP TABLE IF EXISTS rule_migration_change_log CASCADE;
 CREATE TABLE IF NOT EXISTS rule_migration_change_log (
     id uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
-    migration_id uuid,
+    migration_id uuid UNIQUE,
     record_type rule_type,
     file_name text,
     description text,
@@ -38,4 +39,4 @@ VALUES
 'Authority mapping rules: add rules for medium of performance term fields'),
 ('6d17fe92-39f3-494f-9e5f-e104fdabe78a', 'MARC_AUTHORITY', 'AuthorityMappingNamedEventCustomMigration',
 'Authority mapping rules: add rules for named event fields')
-ON CONFLICT DO NOTHING;
+ON CONFLICT (migration_id) DO NOTHING;


### PR DESCRIPTION
## Purpose
Modify `create_rule_migration_change_log_table.sql` to ensure the insert is executed only once.

## Approach
Add a check to ensure the `migration_id` value is unique in the table.

## Is this change testable? If not - why?


## Checklist
- [ ] I have updated NEWS.md.
- [ ] I have added javadocs to new methods.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation e.g. README.md.
- [ ] I have ran karate tests against this feature.

