### PR TITLE
use master branch from tc-module-eval repo

### DIFF
--- a/.github/workflows/tc-evaluation.yml
+++ b/.github/workflows/tc-evaluation.yml
@@ -5,4 +5,9 @@ on:
 
 jobs:
   evaluate:
-    uses: folio-org/tc-module-eval/.github/workflows/evaluate.yml@remote-eval
+    uses: folio-org/tc-module-eval/.github/workflows/evaluate.yml@master
+    with:
+      ref: ${{ inputs.ref }}
+      output_format: ${{ inputs.output_format }}
+      criteria_filter: ${{ inputs.criteria_filter }}
+      java_version: ${{ inputs.java_version }}


### PR DESCRIPTION
## Purpose
Use workflow file from master branch in tc-module-eval and include input parameters to the workflow in SRM repo

## Approach
Change reference to master. Add extra input params to the workflow.


