### PR TITLE
MODSOURMAN-1416: Add support for inventory post-processing event types in the journal params

### DIFF
--- a/mod-source-record-manager-server/src/main/java/org/folio/verticle/consumers/util/JournalParams.java
+++ b/mod-source-record-manager-server/src/main/java/org/folio/verticle/consumers/util/JournalParams.java
@@ -185,6 +185,38 @@ public class JournalParams {
           JournalRecord.ActionStatus.COMPLETED));
       }
     },
+    DI_INVENTORY_HOLDINGS_CREATED_READY_FOR_POST_PROCESSING {
+      @Override
+      public Optional<JournalParams> getJournalParams(DataImportEventPayload eventPayload) {
+        return Optional.of(new JournalParams(CREATE,
+          JournalRecord.EntityType.HOLDINGS,
+          JournalRecord.ActionStatus.COMPLETED));
+      }
+    },
+    DI_INVENTORY_HOLDINGS_UPDATED_READY_FOR_POST_PROCESSING {
+      @Override
+      public Optional<JournalParams> getJournalParams(DataImportEventPayload eventPayload) {
+        return Optional.of(new JournalParams(UPDATE,
+          JournalRecord.EntityType.HOLDINGS,
+          JournalRecord.ActionStatus.COMPLETED));
+      }
+    },
+    DI_INVENTORY_AUTHORITY_CREATED_READY_FOR_POST_PROCESSING {
+      @Override
+      public Optional<JournalParams> getJournalParams(DataImportEventPayload eventPayload) {
+        return Optional.of(new JournalParams(CREATE,
+          JournalRecord.EntityType.AUTHORITY,
+          JournalRecord.ActionStatus.COMPLETED));
+      }
+    },
+    DI_INVENTORY_AUTHORITY_UPDATED_READY_FOR_POST_PROCESSING {
+      @Override
+      public Optional<JournalParams> getJournalParams(DataImportEventPayload eventPayload) {
+        return Optional.of(new JournalParams(UPDATE,
+          JournalRecord.EntityType.AUTHORITY,
+          JournalRecord.ActionStatus.COMPLETED));
+      }
+    },
     DI_INVENTORY_INSTANCE_UPDATED {
       @Override
       public Optional<JournalParams> getJournalParams(DataImportEventPayload eventPayload) {

--- a/mod-source-record-manager-server/src/main/java/org/folio/verticle/consumers/util/JournalParams.java
+++ b/mod-source-record-manager-server/src/main/java/org/folio/verticle/consumers/util/JournalParams.java
@@ -185,7 +185,7 @@ public class JournalParams {
           JournalRecord.ActionStatus.COMPLETED));
       }
     },
-    DI_INVENTORY_HOLDINGS_CREATED_READY_FOR_POST_PROCESSING {
+    DI_INVENTORY_HOLDINGS_CREATED_READY_FOR_POST_PROCESSING { //added for correct processing of DI_ERROR event when Holdings record creation fails
       @Override
       public Optional<JournalParams> getJournalParams(DataImportEventPayload eventPayload) {
         return Optional.of(new JournalParams(CREATE,
@@ -193,7 +193,7 @@ public class JournalParams {
           JournalRecord.ActionStatus.COMPLETED));
       }
     },
-    DI_INVENTORY_HOLDINGS_UPDATED_READY_FOR_POST_PROCESSING {
+    DI_INVENTORY_HOLDINGS_UPDATED_READY_FOR_POST_PROCESSING { //added for correct processing of DI_ERROR event when Holdings record update fails
       @Override
       public Optional<JournalParams> getJournalParams(DataImportEventPayload eventPayload) {
         return Optional.of(new JournalParams(UPDATE,
@@ -201,7 +201,7 @@ public class JournalParams {
           JournalRecord.ActionStatus.COMPLETED));
       }
     },
-    DI_INVENTORY_AUTHORITY_CREATED_READY_FOR_POST_PROCESSING {
+    DI_INVENTORY_AUTHORITY_CREATED_READY_FOR_POST_PROCESSING { //added for correct processing of DI_ERROR event when Authority record creation fails
       @Override
       public Optional<JournalParams> getJournalParams(DataImportEventPayload eventPayload) {
         return Optional.of(new JournalParams(CREATE,
@@ -209,7 +209,7 @@ public class JournalParams {
           JournalRecord.ActionStatus.COMPLETED));
       }
     },
-    DI_INVENTORY_AUTHORITY_UPDATED_READY_FOR_POST_PROCESSING {
+    DI_INVENTORY_AUTHORITY_UPDATED_READY_FOR_POST_PROCESSING { //added for correct processing of DI_ERROR event when Authority record update fails
       @Override
       public Optional<JournalParams> getJournalParams(DataImportEventPayload eventPayload) {
         return Optional.of(new JournalParams(UPDATE,

--- a/mod-source-record-manager-server/src/test/java/org/folio/verticle/consumers/util/JournalParamsTest.java
+++ b/mod-source-record-manager-server/src/test/java/org/folio/verticle/consumers/util/JournalParamsTest.java
@@ -326,26 +326,6 @@ public class JournalParamsTest {
   }
 
   @Test
-  public void shouldPopulateEntityTypeHoldingsWhenEventTypeIsDiInventoryHoldingsCreatedReadyForPostProcessing() {
-    populateEntityTypeAndActionTypeByEventType(DI_INVENTORY_HOLDINGS_CREATED_READY_FOR_POST_PROCESSING, JournalRecord.EntityType.HOLDINGS, JournalRecord.ActionType.CREATE);
-  }
-
-  @Test
-  public void shouldPopulateEntityTypeHoldingsWhenEventTypeIsDiInventoryHoldingsUpdatedReadyForPostProcessing() {
-    populateEntityTypeAndActionTypeByEventType(DI_INVENTORY_HOLDINGS_UPDATED_READY_FOR_POST_PROCESSING, JournalRecord.EntityType.HOLDINGS, JournalRecord.ActionType.UPDATE);
-  }
-
-  @Test
-  public void shouldPopulateEntityTypeAuthorityWhenEventTypeIsDiInventoryAuthorityCreatedReadyForPostProcessing() {
-    populateEntityTypeAndActionTypeByEventType(DI_INVENTORY_AUTHORITY_CREATED_READY_FOR_POST_PROCESSING, JournalRecord.EntityType.AUTHORITY, JournalRecord.ActionType.CREATE);
-  }
-
-  @Test
-  public void shouldPopulateEntityTypeAuthorityWhenEventTypeIsDiInventoryAuthorityUpdatedReadyForPostProcessing() {
-    populateEntityTypeAndActionTypeByEventType(DI_INVENTORY_AUTHORITY_UPDATED_READY_FOR_POST_PROCESSING, JournalRecord.EntityType.AUTHORITY, JournalRecord.ActionType.UPDATE);
-  }
-
-  @Test
   public void shouldPopulateEntityTypeInstanceWhenEventTypeIsDiInventoryInstanceCreated() {
     populateEntityTypeAndActionTypeByEventType(DI_INVENTORY_INSTANCE_CREATED, JournalRecord.EntityType.INSTANCE, JournalRecord.ActionType.CREATE);
   }

--- a/mod-source-record-manager-server/src/test/java/org/folio/verticle/consumers/util/JournalParamsTest.java
+++ b/mod-source-record-manager-server/src/test/java/org/folio/verticle/consumers/util/JournalParamsTest.java
@@ -35,6 +35,10 @@ import static org.folio.rest.jaxrs.model.DataImportEventTypes.DI_SRS_MARC_BIB_RE
 import static org.folio.rest.jaxrs.model.DataImportEventTypes.DI_SRS_MARC_HOLDINGS_RECORD_MATCHED;
 import static org.folio.rest.jaxrs.model.DataImportEventTypes.DI_SRS_MARC_HOLDINGS_RECORD_UPDATED;
 import static org.folio.rest.jaxrs.model.DataImportEventTypes.DI_SRS_MARC_HOLDING_RECORD_CREATED;
+import static org.folio.rest.jaxrs.model.DataImportEventTypes.DI_INVENTORY_HOLDINGS_CREATED_READY_FOR_POST_PROCESSING;
+import static org.folio.rest.jaxrs.model.DataImportEventTypes.DI_INVENTORY_HOLDINGS_UPDATED_READY_FOR_POST_PROCESSING;
+import static org.folio.rest.jaxrs.model.DataImportEventTypes.DI_INVENTORY_AUTHORITY_CREATED_READY_FOR_POST_PROCESSING;
+import static org.folio.rest.jaxrs.model.DataImportEventTypes.DI_INVENTORY_AUTHORITY_UPDATED_READY_FOR_POST_PROCESSING;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
@@ -298,6 +302,26 @@ public class JournalParamsTest {
   }
 
   @Test
+  public void shouldPopulateEntityTypeHoldingsWhenEventTypeIsDiInventoryHoldingsCreatedReadyForPostProcessing() {
+    populateEntityTypeAndActionTypeByEventType(DI_INVENTORY_HOLDINGS_CREATED_READY_FOR_POST_PROCESSING, JournalRecord.EntityType.HOLDINGS, JournalRecord.ActionType.CREATE);
+  }
+
+  @Test
+  public void shouldPopulateEntityTypeHoldingsWhenEventTypeIsDiInventoryHoldingsUpdatedReadyForPostProcessing() {
+    populateEntityTypeAndActionTypeByEventType(DI_INVENTORY_HOLDINGS_UPDATED_READY_FOR_POST_PROCESSING, JournalRecord.EntityType.HOLDINGS, JournalRecord.ActionType.UPDATE);
+  }
+
+  @Test
+  public void shouldPopulateEntityTypeAuthorityWhenEventTypeIsDiInventoryAuthorityCreatedReadyForPostProcessing() {
+    populateEntityTypeAndActionTypeByEventType(DI_INVENTORY_AUTHORITY_CREATED_READY_FOR_POST_PROCESSING, JournalRecord.EntityType.AUTHORITY, JournalRecord.ActionType.CREATE);
+  }
+
+  @Test
+  public void shouldPopulateEntityTypeAuthorityWhenEventTypeIsDiInventoryAuthorityUpdatedReadyForPostProcessing() {
+    populateEntityTypeAndActionTypeByEventType(DI_INVENTORY_AUTHORITY_UPDATED_READY_FOR_POST_PROCESSING, JournalRecord.EntityType.AUTHORITY, JournalRecord.ActionType.UPDATE);
+  }
+
+  @Test
   public void shouldPopulateEntityTypeInstanceWhenEventTypeIsDiInventoryInstanceCreated() {
     populateEntityTypeAndActionTypeByEventType(DI_INVENTORY_INSTANCE_CREATED, JournalRecord.EntityType.INSTANCE, JournalRecord.ActionType.CREATE);
   }
@@ -344,6 +368,20 @@ public class JournalParamsTest {
 
   private void populateEntityTypeAndActionTypeByEventType(DataImportEventTypes eventType, JournalRecord.EntityType entityType, JournalRecord.ActionType actionType) {
     eventPayload.setEventType(eventType.value());
+
+    var journalParamsOptional =
+      JournalParams.JournalParamsEnum.getValue(eventPayload.getEventType()).getJournalParams(eventPayload);
+
+    var journalParams = journalParamsOptional.get();
+
+    Assert.assertEquals(entityType, journalParams.journalEntityType);
+    Assert.assertEquals(actionType, journalParams.journalActionType);
+    Assert.assertEquals(JournalRecord.ActionStatus.COMPLETED, journalParams.journalActionStatus);
+  }
+
+  private void populateEntityTypeAndActionTypeByEventType(String eventType, JournalRecord.EntityType entityType,
+                                                          JournalRecord.ActionType actionType) {
+    eventPayload.setEventType(eventType);
 
     var journalParamsOptional =
       JournalParams.JournalParamsEnum.getValue(eventPayload.getEventType()).getJournalParams(eventPayload);

--- a/mod-source-record-manager-server/src/test/java/org/folio/verticle/consumers/util/JournalParamsTest.java
+++ b/mod-source-record-manager-server/src/test/java/org/folio/verticle/consumers/util/JournalParamsTest.java
@@ -168,6 +168,30 @@ public class JournalParamsTest {
   }
 
   @Test
+  public void shouldPopulateHoldingsCreatedErrorParamsWhenEventChainEndsWithDiInventoryHoldingsCreatedReadyForPostProcessing() {
+    returnErrorJournalParamsByLastEventInChain(DI_INVENTORY_HOLDINGS_CREATED_READY_FOR_POST_PROCESSING,
+      JournalRecord.EntityType.HOLDINGS, JournalRecord.ActionType.CREATE);
+  }
+
+  @Test
+  public void shouldPopulateHoldingsUpdatedErrorParamsWhenEventChainEndsWithDiInventoryHoldingsUpdatedReadyForPostProcessing() {
+    returnErrorJournalParamsByLastEventInChain(DI_INVENTORY_HOLDINGS_UPDATED_READY_FOR_POST_PROCESSING,
+      JournalRecord.EntityType.HOLDINGS, JournalRecord.ActionType.UPDATE);
+  }
+
+  @Test
+  public void shouldPopulateAuthorityCreatedErrorParamsWhenEventChainEndsWithDiInventoryAuthorityCreatedReadyForPostProcessing() {
+    returnErrorJournalParamsByLastEventInChain(DI_INVENTORY_AUTHORITY_CREATED_READY_FOR_POST_PROCESSING,
+      JournalRecord.EntityType.AUTHORITY, JournalRecord.ActionType.CREATE);
+  }
+
+  @Test
+  public void shouldPopulateAuthorityUpdatedErrorParamsWhenEventChainEndsWithDiInventoryAuthorityUpdatedReadyForPostProcessing() {
+    returnErrorJournalParamsByLastEventInChain(DI_INVENTORY_AUTHORITY_UPDATED_READY_FOR_POST_PROCESSING,
+      JournalRecord.EntityType.AUTHORITY, JournalRecord.ActionType.UPDATE);
+  }
+
+  @Test
   public void shouldPopulateEntityTypeMarcAuthorityWhenEventTypeIsDiCompleted() {
     eventPayload.setEventType(DI_COMPLETED.value());
     context.put(EntityType.MARC_HOLDINGS.value(), new JsonObject().encode());
@@ -368,20 +392,6 @@ public class JournalParamsTest {
 
   private void populateEntityTypeAndActionTypeByEventType(DataImportEventTypes eventType, JournalRecord.EntityType entityType, JournalRecord.ActionType actionType) {
     eventPayload.setEventType(eventType.value());
-
-    var journalParamsOptional =
-      JournalParams.JournalParamsEnum.getValue(eventPayload.getEventType()).getJournalParams(eventPayload);
-
-    var journalParams = journalParamsOptional.get();
-
-    Assert.assertEquals(entityType, journalParams.journalEntityType);
-    Assert.assertEquals(actionType, journalParams.journalActionType);
-    Assert.assertEquals(JournalRecord.ActionStatus.COMPLETED, journalParams.journalActionStatus);
-  }
-
-  private void populateEntityTypeAndActionTypeByEventType(String eventType, JournalRecord.EntityType entityType,
-                                                          JournalRecord.ActionType actionType) {
-    eventPayload.setEventType(eventType);
 
     var journalParamsOptional =
       JournalParams.JournalParamsEnum.getValue(eventPayload.getEventType()).getJournalParams(eventPayload);


### PR DESCRIPTION
## Purpose
The JournalParamsEnum in JournalParams.java is missing several event types that are defined in the RAML schema (dataImportEventTypes.json). When a DI_ERROR event is processed with these event types in its event chain, the system throws an IllegalArgumentException because the enum doesn't recognize them. 

## Approach
Add support for 
- DI_INVENTORY_HOLDINGS_CREATED_READY_FOR_POST_PROCESSING
- DI_INVENTORY_HOLDINGS_UPDATED_READY_FOR_POST_PROCESSING
- DI_INVENTORY_AUTHORITY_CREATED_READY_FOR_POST_PROCESSING
- DI_INVENTORY_AUTHORITY_UPDATED_READY_FOR_POST_PROCESSING
