### PR TITLE
MODDATAIMP-1300: Fix journal_params for DI_MARC_FOR_UPDATE_RECEIVED message

### DIFF
--- a/mod-source-record-manager-server/src/main/java/org/folio/verticle/consumers/util/JournalParams.java
+++ b/mod-source-record-manager-server/src/main/java/org/folio/verticle/consumers/util/JournalParams.java
@@ -132,11 +132,15 @@ public class JournalParams {
     DI_MARC_FOR_UPDATE_RECEIVED {
       @Override
       public Optional<JournalParams> getJournalParams(DataImportEventPayload eventPayload) {
-        return Optional.of(new JournalParams(UPDATE,
-          eventPayload.getContext().containsKey(JournalRecord.EntityType.MARC_AUTHORITY.value()) ? JournalRecord.EntityType.MARC_AUTHORITY :
-            eventPayload.getContext().containsKey(JournalRecord.EntityType.MARC_HOLDINGS.value()) ? JournalRecord.EntityType.MARC_HOLDINGS :
-              JournalRecord.EntityType.MARC_BIBLIOGRAPHIC,
-          JournalRecord.ActionStatus.COMPLETED));
+        JournalRecord.EntityType sourceRecordType;
+        if (eventPayload.getContext().containsKey(JournalRecord.EntityType.MARC_AUTHORITY.value())) {
+          sourceRecordType = JournalRecord.EntityType.MARC_AUTHORITY;
+        } else if (eventPayload.getContext().containsKey(JournalRecord.EntityType.MARC_HOLDINGS.value())) {
+          sourceRecordType = JournalRecord.EntityType.MARC_HOLDINGS;
+        } else {
+          sourceRecordType = JournalRecord.EntityType.MARC_BIBLIOGRAPHIC;
+        }
+        return Optional.of(new JournalParams(UPDATE, sourceRecordType, JournalRecord.ActionStatus.COMPLETED));
       }
     },
     DI_INCOMING_MARC_BIB_RECORD_PARSED {

--- a/mod-source-record-manager-server/src/main/java/org/folio/verticle/consumers/util/JournalParams.java
+++ b/mod-source-record-manager-server/src/main/java/org/folio/verticle/consumers/util/JournalParams.java
@@ -133,7 +133,9 @@ public class JournalParams {
       @Override
       public Optional<JournalParams> getJournalParams(DataImportEventPayload eventPayload) {
         return Optional.of(new JournalParams(UPDATE,
-          JournalRecord.EntityType.MARC_BIBLIOGRAPHIC,
+          eventPayload.getContext().containsKey(JournalRecord.EntityType.MARC_AUTHORITY.value()) ? JournalRecord.EntityType.MARC_AUTHORITY :
+            eventPayload.getContext().containsKey(JournalRecord.EntityType.MARC_HOLDINGS.value()) ? JournalRecord.EntityType.MARC_HOLDINGS :
+              JournalRecord.EntityType.MARC_BIBLIOGRAPHIC,
           JournalRecord.ActionStatus.COMPLETED));
       }
     },

--- a/mod-source-record-manager-server/src/test/java/org/folio/verticle/consumers/util/JournalParamsTest.java
+++ b/mod-source-record-manager-server/src/test/java/org/folio/verticle/consumers/util/JournalParamsTest.java
@@ -35,6 +35,7 @@ import static org.folio.rest.jaxrs.model.DataImportEventTypes.DI_SRS_MARC_BIB_RE
 import static org.folio.rest.jaxrs.model.DataImportEventTypes.DI_SRS_MARC_HOLDINGS_RECORD_MATCHED;
 import static org.folio.rest.jaxrs.model.DataImportEventTypes.DI_SRS_MARC_HOLDINGS_RECORD_UPDATED;
 import static org.folio.rest.jaxrs.model.DataImportEventTypes.DI_SRS_MARC_HOLDING_RECORD_CREATED;
+import static org.folio.rest.jaxrs.model.DataImportEventTypes.DI_MARC_FOR_UPDATE_RECEIVED;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
@@ -437,4 +438,56 @@ public class JournalParamsTest {
     assertEquals(JournalRecord.ActionStatus.COMPLETED, journalParams.journalActionStatus);
   }
 
+  @Test
+  public void shouldPopulateEntityTypeMarcBibWhenEventTypeIsDiMarcForUpdateReceived() {
+    eventPayload.setEventType(DI_MARC_FOR_UPDATE_RECEIVED.value());
+    context.put(JournalRecord.EntityType.MARC_BIBLIOGRAPHIC.value(), new JsonObject().encode());
+    eventPayload.setContext(context);
+    var journalParamsOptional =
+      JournalParams.JournalParamsEnum.getValue(eventPayload.getEventType()).getJournalParams(eventPayload);
+    var journalParams = journalParamsOptional.get();
+    Assert.assertEquals(JournalRecord.EntityType.MARC_BIBLIOGRAPHIC, journalParams.journalEntityType);
+    Assert.assertEquals(JournalRecord.ActionType.UPDATE, journalParams.journalActionType);
+    Assert.assertEquals(JournalRecord.ActionStatus.COMPLETED, journalParams.journalActionStatus);
+  }
+
+  @Test
+  public void shouldPopulateEntityTypeMarcAuthorityWhenEventTypeIsDiMarcForUpdateReceived() {
+    eventPayload.setEventType(DI_MARC_FOR_UPDATE_RECEIVED.value());
+    context.put(JournalRecord.EntityType.MARC_AUTHORITY.value(), new JsonObject().encode());
+    eventPayload.setContext(context);
+    var journalParamsOptional =
+      JournalParams.JournalParamsEnum.getValue(eventPayload.getEventType()).getJournalParams(eventPayload);
+    var journalParams = journalParamsOptional.get();
+    Assert.assertEquals(JournalRecord.EntityType.MARC_AUTHORITY, journalParams.journalEntityType);
+    Assert.assertEquals(JournalRecord.ActionType.UPDATE, journalParams.journalActionType);
+    Assert.assertEquals(JournalRecord.ActionStatus.COMPLETED, journalParams.journalActionStatus);
+  }
+
+  @Test
+  public void shouldPopulateEntityTypeMarcHoldingsWhenEventTypeIsDiMarcForUpdateReceived() {
+    eventPayload.setEventType(DI_MARC_FOR_UPDATE_RECEIVED.value());
+    context.put(JournalRecord.EntityType.MARC_HOLDINGS.value(), new JsonObject().encode());
+    eventPayload.setContext(context);
+    var journalParamsOptional =
+      JournalParams.JournalParamsEnum.getValue(eventPayload.getEventType()).getJournalParams(eventPayload);
+    var journalParams = journalParamsOptional.get();
+    Assert.assertEquals(JournalRecord.EntityType.MARC_HOLDINGS, journalParams.journalEntityType);
+    Assert.assertEquals(JournalRecord.ActionType.UPDATE, journalParams.journalActionType);
+    Assert.assertEquals(JournalRecord.ActionStatus.COMPLETED, journalParams.journalActionStatus);
+  }
+
+  @Test
+  public void shouldPopulateEntityTypeMarcAuthorityWhenDiErrorWithMarcForUpdateReceivedInEventsChain() {
+    eventPayload.setEventType(DI_ERROR.value());
+    context.put(JournalRecord.EntityType.MARC_AUTHORITY.value(), new JsonObject().encode());
+    eventPayload.setContext(context);
+    eventPayload.setEventsChain(List.of(DI_MARC_FOR_UPDATE_RECEIVED.value()));
+    var journalParamsOptional =
+      JournalParams.JournalParamsEnum.getValue(eventPayload.getEventType()).getJournalParams(eventPayload);
+    var journalParams = journalParamsOptional.get();
+    Assert.assertEquals(JournalRecord.EntityType.MARC_AUTHORITY, journalParams.journalEntityType);
+    Assert.assertEquals(JournalRecord.ActionType.UPDATE, journalParams.journalActionType);
+    Assert.assertEquals(JournalRecord.ActionStatus.ERROR, journalParams.journalActionStatus);
+  }
 }

--- a/mod-source-record-manager-server/src/test/java/org/folio/verticle/consumers/util/JournalParamsTest.java
+++ b/mod-source-record-manager-server/src/test/java/org/folio/verticle/consumers/util/JournalParamsTest.java
@@ -467,42 +467,31 @@ public class JournalParamsTest {
   }
 
   @Test
-  public void shouldPopulateEntityTypeMarcBibWhenEventTypeIsDiMarcForUpdateReceived() {
-    eventPayload.setEventType(DI_MARC_FOR_UPDATE_RECEIVED.value());
+  public void shouldPopulateEntityTypeMarcBibWhenDiErrorWithMarcForUpdateReceivedInEventsChain() {
+    eventPayload.setEventType(DI_ERROR.value());
     context.put(JournalRecord.EntityType.MARC_BIBLIOGRAPHIC.value(), new JsonObject().encode());
     eventPayload.setContext(context);
+    eventPayload.setEventsChain(List.of(DI_MARC_FOR_UPDATE_RECEIVED.value()));
     var journalParamsOptional =
       JournalParams.JournalParamsEnum.getValue(eventPayload.getEventType()).getJournalParams(eventPayload);
     var journalParams = journalParamsOptional.get();
     Assert.assertEquals(JournalRecord.EntityType.MARC_BIBLIOGRAPHIC, journalParams.journalEntityType);
     Assert.assertEquals(JournalRecord.ActionType.UPDATE, journalParams.journalActionType);
-    Assert.assertEquals(JournalRecord.ActionStatus.COMPLETED, journalParams.journalActionStatus);
+    Assert.assertEquals(JournalRecord.ActionStatus.ERROR, journalParams.journalActionStatus);
   }
 
   @Test
-  public void shouldPopulateEntityTypeMarcAuthorityWhenEventTypeIsDiMarcForUpdateReceived() {
-    eventPayload.setEventType(DI_MARC_FOR_UPDATE_RECEIVED.value());
-    context.put(JournalRecord.EntityType.MARC_AUTHORITY.value(), new JsonObject().encode());
-    eventPayload.setContext(context);
-    var journalParamsOptional =
-      JournalParams.JournalParamsEnum.getValue(eventPayload.getEventType()).getJournalParams(eventPayload);
-    var journalParams = journalParamsOptional.get();
-    Assert.assertEquals(JournalRecord.EntityType.MARC_AUTHORITY, journalParams.journalEntityType);
-    Assert.assertEquals(JournalRecord.ActionType.UPDATE, journalParams.journalActionType);
-    Assert.assertEquals(JournalRecord.ActionStatus.COMPLETED, journalParams.journalActionStatus);
-  }
-
-  @Test
-  public void shouldPopulateEntityTypeMarcHoldingsWhenEventTypeIsDiMarcForUpdateReceived() {
-    eventPayload.setEventType(DI_MARC_FOR_UPDATE_RECEIVED.value());
+  public void shouldPopulateEntityTypeMarcHoldingsWhenDiErrorWithMarcForUpdateReceivedInEventsChain() {
+    eventPayload.setEventType(DI_ERROR.value());
     context.put(JournalRecord.EntityType.MARC_HOLDINGS.value(), new JsonObject().encode());
     eventPayload.setContext(context);
+    eventPayload.setEventsChain(List.of(DI_MARC_FOR_UPDATE_RECEIVED.value()));
     var journalParamsOptional =
       JournalParams.JournalParamsEnum.getValue(eventPayload.getEventType()).getJournalParams(eventPayload);
     var journalParams = journalParamsOptional.get();
     Assert.assertEquals(JournalRecord.EntityType.MARC_HOLDINGS, journalParams.journalEntityType);
     Assert.assertEquals(JournalRecord.ActionType.UPDATE, journalParams.journalActionType);
-    Assert.assertEquals(JournalRecord.ActionStatus.COMPLETED, journalParams.journalActionStatus);
+    Assert.assertEquals(JournalRecord.ActionStatus.ERROR, journalParams.journalActionStatus);
   }
 
   @Test

--- a/mod-source-record-manager-server/src/test/java/org/folio/verticle/consumers/util/MarcImportEventsHandlerTest.java
+++ b/mod-source-record-manager-server/src/test/java/org/folio/verticle/consumers/util/MarcImportEventsHandlerTest.java
@@ -13,6 +13,7 @@ import static org.folio.rest.jaxrs.model.DataImportEventTypes.DI_ORDER_CREATED_R
 import static org.folio.rest.jaxrs.model.DataImportEventTypes.DI_PENDING_ORDER_CREATED;
 import static org.folio.rest.jaxrs.model.DataImportEventTypes.DI_SRS_MARC_AUTHORITY_RECORD_CREATED;
 import static org.folio.rest.jaxrs.model.DataImportEventTypes.DI_INCOMING_MARC_BIB_RECORD_PARSED;
+import static org.folio.rest.jaxrs.model.DataImportEventTypes.DI_MARC_FOR_UPDATE_RECEIVED;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
@@ -361,6 +362,30 @@ public class MarcImportEventsHandlerTest {
     var actualJournalRecord = journalRecordCaptor.getValue().getJsonObject(0).mapTo(JournalRecord.class);
 
     assertEquals(expectedTitle, actualJournalRecord.getTitle());
+  }
+
+  @Test
+  public void testSaveAuthorityJournalRecordWithCorrectEntityTypeWhenDiErrorWithMarcForUpdateReceivedInEventsChain() throws JournalRecordMapperException {
+    when(mappingRuleCache.get(any())).thenReturn(Future.succeededFuture(Optional.of(new JsonObject())));
+    var marcRecord = marcFactory.newRecord();
+    var expectedTitleStart = "Authority Title";
+    marcRecord.addVariableField(marcFactory.newDataField("035", '0', '0', "a", "35488"));
+    marcRecord.addVariableField(marcFactory.newDataField("150", '0', '0', "a", expectedTitleStart));
+    var record = new Record()
+      .withId(UUID.randomUUID().toString())
+      .withParsedRecord(new ParsedRecord().withContent(marcRecordToJsonContent(marcRecord)));
+
+    HashMap<String, String> payloadContext = new HashMap<>();
+    payloadContext.put(JournalRecord.EntityType.MARC_AUTHORITY.value(), Json.encode(record));
+    payloadContext.put("ERROR", "Timeout waiting for connection");
+
+    var payload = new DataImportEventPayload()
+      .withEventType(DI_ERROR.value())
+      .withEventsChain(List.of(DI_MARC_FOR_UPDATE_RECEIVED.value()))
+      .withContext(payloadContext);
+    handler.handle(journalService, payload, TEST_TENANT);
+    verify(journalService).saveBatch(journalRecordCaptor.capture(), eq(TEST_TENANT));
+    var actualJournalRecord = journalRecordCaptor.getValue().getJsonObject(0).mapTo(JournalRecord.class);
   }
 
   private DataImportEventPayload constructMatchHoldingsPayload(org.marc4j.marc.Record marcRecord) {

--- a/mod-source-record-manager-server/src/test/java/org/folio/verticle/consumers/util/MarcImportEventsHandlerTest.java
+++ b/mod-source-record-manager-server/src/test/java/org/folio/verticle/consumers/util/MarcImportEventsHandlerTest.java
@@ -386,6 +386,10 @@ public class MarcImportEventsHandlerTest {
     handler.handle(journalService, payload, TEST_TENANT);
     verify(journalService).saveBatch(journalRecordCaptor.capture(), eq(TEST_TENANT));
     var actualJournalRecord = journalRecordCaptor.getValue().getJsonObject(0).mapTo(JournalRecord.class);
+    assertEquals(JournalRecord.EntityType.MARC_AUTHORITY, actualJournalRecord.getEntityType());
+    assertEquals(JournalRecord.ActionType.UPDATE, actualJournalRecord.getActionType());
+    assertEquals(JournalRecord.ActionStatus.ERROR, actualJournalRecord.getActionStatus());
+    assertEquals(expectedTitleStart, actualJournalRecord.getTitle());
   }
 
   private DataImportEventPayload constructMatchHoldingsPayload(org.marc4j.marc.Record marcRecord) {


### PR DESCRIPTION
## Purpose
In the case of the Timeout waiting for connection exception, the MARC Authority record is incorrectly saved into the journal_records table (SRM module) as a MARC Bibliographic record.

## Approach
Fix by type selection

## Learn
[MODDATAIMP-1300](https://folio-org.atlassian.net/browse/MODDATAIMP-1300)