### PR TITLE
MODSOURMAN-1428: Deadlocks During Large Data Import Jobs

### DIFF
--- a/mod-source-record-manager-server/src/main/java/org/folio/dao/JournalRecordDaoImpl.java
+++ b/mod-source-record-manager-server/src/main/java/org/folio/dao/JournalRecordDaoImpl.java
@@ -202,7 +202,10 @@ public class JournalRecordDaoImpl implements JournalRecordDao {
 
   private List<Tuple> prepareTupleList(Collection<JournalRecord> journalRecords) {
     return journalRecords.stream()
-      .sorted(Comparator.comparing(JournalRecord::getJobExecutionId))
+      .sorted(Comparator
+        .comparing(JournalRecord::getJobExecutionId)
+        .thenComparing(JournalRecord::getSourceRecordOrder, Comparator.nullsFirst(Comparator.naturalOrder()))
+        .thenComparing(JournalRecord::getSourceId, Comparator.nullsFirst(Comparator.naturalOrder())))
       .map(this::prepareInsertQueryParameters)
       .toList();
   }

--- a/mod-source-record-manager-server/src/main/java/org/folio/dao/JournalRecordDaoImpl.java
+++ b/mod-source-record-manager-server/src/main/java/org/folio/dao/JournalRecordDaoImpl.java
@@ -204,8 +204,8 @@ public class JournalRecordDaoImpl implements JournalRecordDao {
     return journalRecords.stream()
       .sorted(Comparator
         .comparing(JournalRecord::getJobExecutionId)
-        .thenComparing(JournalRecord::getSourceRecordOrder, Comparator.nullsFirst(Comparator.naturalOrder()))
-        .thenComparing(JournalRecord::getSourceId, Comparator.nullsFirst(Comparator.naturalOrder())))
+        .thenComparing(JournalRecord::getId)
+      )
       .map(this::prepareInsertQueryParameters)
       .toList();
   }


### PR DESCRIPTION
## Purpose
During high-volume data import runs in production, mod-source-record-manager can fail to persist some journal_records batches due to PostgreSQL deadlocks.

AWS Performance Insights showed the database wait event concentrated around Lock:transactionid during the affected import window. CloudWatch logs for mod-source-record-manager also showed repeated journal batch failures for the affected tenant, with errors similar to:
saveJournalRecords:: Error saving batch for tenant <tenant>
PgException: ERROR: deadlock detected (40P01)

Because the journal batch persistence error is logged during import processing, this can result in missing journal record entries for the affected data import job, even though the broader import may continue.

## Approach
Enhanced the sorting comparator in prepareTupleList() to use a three-level sort:
journalRecords.stream()
      .sorted(Comparator
        .comparing(JournalRecord::getJobExecutionId)
        .thenComparing(JournalRecord::getId) - PK
)

## Learn
[MODSOURMAN-1428](https://folio-org.atlassian.net/browse/MODSOURMAN-1428)

