### PR TITLE
MODSOURMAN-1433 - Data import log not sort issues

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,6 @@
+## 2026-mm-dd v4.1.0-SNAPSHOT
+* [MODSOURMAN-1433](https://folio-org.atlassian.net/browse/MODSOURMAN-1433) Data import log not sorted issues
+
 ## 2026-04-16 v4.0.0
 * [MODSOURMAN-1355](https://folio-org.atlassian.net/browse/MODSOURMAN-1355) Replace advisory lock with consistent record ordering to prevent deadlocks in journal record insertions
 * [MODSOURMAN-1304](https://folio-org.atlassian.net/browse/MODSOURMAN-1304) Handle journal records for MARC on Instance errors and COMPLETED INSTANCE/MARC_BIB events

--- a/mod-source-record-manager-server/src/main/java/org/folio/dao/JournalRecordDaoImpl.java
+++ b/mod-source-record-manager-server/src/main/java/org/folio/dao/JournalRecordDaoImpl.java
@@ -609,7 +609,6 @@ public class JournalRecordDaoImpl implements JournalRecordDao {
       entries.stream()
         .collect(Collectors.groupingBy(
           RecordProcessingLogDto::getIncomingRecordId,
-          LinkedHashMap::new,
           Collectors.mapping(RecordProcessingLogDto::getRelatedItemInfo,
             Collectors.flatMapping(List::stream, toList())
           )));

--- a/mod-source-record-manager-server/src/main/java/org/folio/dao/JournalRecordDaoImpl.java
+++ b/mod-source-record-manager-server/src/main/java/org/folio/dao/JournalRecordDaoImpl.java
@@ -41,6 +41,7 @@ import java.util.Collections;
 import java.util.Comparator;
 import java.util.Date;
 import java.util.HashSet;
+import java.util.LinkedHashMap;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
@@ -599,6 +600,7 @@ public class JournalRecordDaoImpl implements JournalRecordDao {
       entries.stream()
         .collect(Collectors.groupingBy(
           RecordProcessingLogDto::getIncomingRecordId,
+          LinkedHashMap::new,
           Collectors.mapping(RecordProcessingLogDto::getRelatedHoldingsInfo,
             Collectors.flatMapping(List::stream, toList())
           )));
@@ -607,6 +609,7 @@ public class JournalRecordDaoImpl implements JournalRecordDao {
       entries.stream()
         .collect(Collectors.groupingBy(
           RecordProcessingLogDto::getIncomingRecordId,
+          LinkedHashMap::new,
           Collectors.mapping(RecordProcessingLogDto::getRelatedItemInfo,
             Collectors.flatMapping(List::stream, toList())
           )));

--- a/mod-source-record-manager-server/src/test/java/org/folio/rest/impl/metadataProvider/MetaDataProviderRecordProcessingLogCollectionAPITest.java
+++ b/mod-source-record-manager-server/src/test/java/org/folio/rest/impl/metadataProvider/MetaDataProviderRecordProcessingLogCollectionAPITest.java
@@ -49,6 +49,7 @@ import static org.folio.rest.jaxrs.model.JournalRecord.EntityType.MARC_AUTHORITY
 import static org.folio.rest.jaxrs.model.JournalRecord.EntityType.MARC_BIBLIOGRAPHIC;
 import static org.folio.rest.jaxrs.model.JournalRecord.EntityType.MARC_HOLDINGS;
 import static org.folio.rest.jaxrs.model.JournalRecord.EntityType.PO_LINE;
+import static org.folio.rest.jaxrs.model.MetadataProviderJobLogEntriesJobExecutionIdGetOrder.ASC;
 import static org.hamcrest.Matchers.empty;
 import static org.hamcrest.Matchers.emptyOrNullString;
 import static org.hamcrest.Matchers.everyItem;
@@ -64,6 +65,9 @@ import static org.hamcrest.Matchers.oneOf;
 public class MetaDataProviderRecordProcessingLogCollectionAPITest extends AbstractRestTest {
 
   private static final String GET_JOB_EXECUTION_JOURNAL_RECORDS_PATH = "/metadata-provider/jobLogEntries";
+  private static final String SORT_BY_PARAM = "sortBy";
+  private static final String SORT_ORDER_PARAM = "order";
+
   @Spy
   Vertx vertx = Vertx.vertx();
   @Spy
@@ -2153,6 +2157,46 @@ public class MetaDataProviderRecordProcessingLogCollectionAPITest extends Abstra
         .body("entries[0].relatedInvoiceInfo.error", emptyOrNullString());
       async.complete();
     }));
+  }
+
+  @Test
+  public void shouldReturnEntriesInCorrectOrderWhenSourceRecordHasMultipleHoldingsAndItems(TestContext context) {
+    JobExecution jobExecution = constructAndPostInitJobExecutionRqDto(1).getJobExecutions().getFirst();
+    String recordTitle = "test title";
+    String[] sourceRecordIds = generateRandomUUIDs(3);
+    String[] instanceIds = generateRandomUUIDs(3);
+    String[] holdingsIds = generateRandomUUIDs(2);
+    String[] itemIds = generateRandomUUIDs(2);
+
+    Future<JournalRecord> future = Future.succeededFuture()
+      .compose(v -> createJournalRecord(jobExecution.getId(), sourceRecordIds[0], null, null, null, 0, PARSE, null, COMPLETED, null, null))
+      .compose(v -> createJournalRecord(jobExecution.getId(), sourceRecordIds[0], instanceIds[0], null, recordTitle, 0, CREATE, MARC_BIBLIOGRAPHIC, COMPLETED, null, null))
+      .compose(v -> createJournalRecord(jobExecution.getId(), sourceRecordIds[0], instanceIds[0], "i001", null, 0, CREATE, INSTANCE, COMPLETED, null, null))
+      .compose(v -> createJournalRecord(jobExecution.getId(), sourceRecordIds[1], null, null, null, 1, PARSE, null, COMPLETED, null, null))
+      .compose(v -> createJournalRecord(jobExecution.getId(), sourceRecordIds[1], instanceIds[1], null, recordTitle, 1, CREATE, MARC_BIBLIOGRAPHIC, COMPLETED, null, null))
+      .compose(v -> createJournalRecord(jobExecution.getId(), sourceRecordIds[1], instanceIds[1], "i002", null, 1, CREATE, INSTANCE, COMPLETED, null, null))
+      .compose(v -> createJournalRecordAllFields(jobExecution.getId(), sourceRecordIds[1], holdingsIds[0], "ho001", null, 1, CREATE, HOLDINGS, COMPLETED, null, null, instanceIds[1], holdingsIds[0], null))
+      .compose(v -> createJournalRecordAllFields(jobExecution.getId(), sourceRecordIds[1], holdingsIds[1], "ho002", null, 1, CREATE, HOLDINGS, COMPLETED, null, null, instanceIds[1], holdingsIds[0], null))
+      .compose(v -> createJournalRecordAllFields(jobExecution.getId(), sourceRecordIds[1], itemIds[0], "it001", null, 1, CREATE, ITEM, COMPLETED, null, null, instanceIds[1], holdingsIds[0], null))
+      .compose(v -> createJournalRecordAllFields(jobExecution.getId(), sourceRecordIds[1], itemIds[1], "it002", null, 1, CREATE, ITEM, COMPLETED, null, null, instanceIds[1], holdingsIds[1], null))
+      .compose(v -> createJournalRecord(jobExecution.getId(), sourceRecordIds[2], null, null, null, 2, PARSE, null, COMPLETED, null, null))
+      .compose(v -> createJournalRecord(jobExecution.getId(), sourceRecordIds[2], instanceIds[2], null, recordTitle, 2, CREATE, MARC_BIBLIOGRAPHIC, COMPLETED, null, null))
+      .compose(v -> createJournalRecord(jobExecution.getId(), sourceRecordIds[2], instanceIds[2], "i003", null, 2, CREATE, INSTANCE, COMPLETED, null, null));
+
+    future.onComplete(context.asyncAssertSuccess(v ->
+      RestAssured.given()
+        .spec(spec)
+        .when()
+        .queryParam(SORT_BY_PARAM, "source_record_order")
+        .queryParam(SORT_ORDER_PARAM, ASC.name())
+        .get(GET_JOB_EXECUTION_JOURNAL_RECORDS_PATH + "/" + jobExecution.getId())
+        .then()
+        .statusCode(HttpStatus.SC_OK)
+        .body("entries.size()", is(3))
+        .body("totalRecords", is(3))
+        .body("entries[0].sourceRecordOrder", is("0"))
+        .body("entries[1].sourceRecordOrder", is("1"))
+        .body("entries[2].sourceRecordOrder", is("2"))));
   }
 
   @Test


### PR DESCRIPTION
## Purpose
Clicking “Record” column on the data import logs page does not return logs entries in correct sorted order

## Approach
* use LinkedHashMap during multiple holdings and items data processing to preserve the order of log entries as they were returned by database
* add test


## Learning
[MODSOURMAN-1433](https://issues.folio.org/browse/MODSOURMAN-1433)