### PR TITLE
MODSOURMAN-1421: Data import - Logs page - Delete authority record

### DIFF
--- a/mod-source-record-manager-server/src/main/java/org/folio/services/ChangeEngineServiceImpl.java
+++ b/mod-source-record-manager-server/src/main/java/org/folio/services/ChangeEngineServiceImpl.java
@@ -256,12 +256,12 @@ public class ChangeEngineServiceImpl implements ChangeEngineService {
   }
 
   private ActionType getAction(List<Record> parsedRecords, JobExecution jobExecution) {
+    if (deleteMarcActionExists(jobExecution)) {
+      return ActionType.DELETE_RECORD;
+    }
     if (updateMarcActionExists(jobExecution) || updateInstanceActionExists(jobExecution)
       || isCreateOrUpdateItemOrHoldingsActionExists(jobExecution, parsedRecords) || isMarcAuthorityMatchProfile(jobExecution)) {
       return ActionType.UPDATE_RECORD;
-    }
-    if (deleteMarcActionExists(jobExecution)) {
-      return ActionType.DELETE_RECORD;
     }
     if (createOrderActionExists(jobExecution)) {
       return ActionType.CREATE_ORDER;

--- a/mod-source-record-manager-server/src/main/java/org/folio/services/journal/JournalUtil.java
+++ b/mod-source-record-manager-server/src/main/java/org/folio/services/journal/JournalUtil.java
@@ -59,9 +59,8 @@ public class JournalUtil {
   public static final String INSTANCE_ID_KEY = "instanceId";
   public static final String HRID_KEY = "hrid";
   public static final String MATCHED_ID_KEY = "matchedId";
-  // Set by mod-source-record-storage when it removes the SRS record, so the id of the
-  // deleted inventory authority is still available to the journal after the deletion.
   public static final String AUTHORITY_RECORD_ID_KEY = "AUTHORITY_RECORD_ID";
+  public static final String DELETED_MARC_AUTHORITY_KEY = "DELETED_MARC_AUTHORITY";
   private static final String NOT_MATCHED_NUMBER = "NOT_MATCHED_NUMBER";
   public static final String PERMANENT_LOCATION_ID_KEY = "permanentLocationId";
   private static final String CENTRAL_TENANT_ID_KEY = "CENTRAL_TENANT_ID";
@@ -144,7 +143,7 @@ public class JournalUtil {
         .withEntityType(entityType);
 
       if (isAuthorityDeletion(entityType, actionType)) {
-        return buildAuthorityDeleteJournalRecords(baseRecord, entityJsonString, actionStatus, actionType,
+        return buildAuthorityDeleteJournalRecords(baseRecord, actionStatus, actionType,
           sourceRecord, eventPayload, context, incomingRecordId);
       }
 
@@ -327,23 +326,23 @@ public class JournalUtil {
    * Builds the journal records for an authority removed by a delete job.
    * <p>
    * A deletion is reported by a single event, but it affects two entities the job log
-   * shows in separate columns, so both are journalled here: the SRS record, whose id is
-   * taken from the record still held in the payload context, and the authority,
-   * whose id is taken from {@link #AUTHORITY_RECORD_ID_KEY}. The authority itself is gone
-   * by this point, so its id is the only thing left to record.
+   * shows in separate columns, so both are journalled here. The SRS record id comes from
+   * the deleted record that mod-source-record-storage leaves under
+   * {@link #DELETED_MARC_AUTHORITY_KEY}, and the authority id from
+   * {@link #AUTHORITY_RECORD_ID_KEY}.
    *
    * @return a MARC_AUTHORITY record and an AUTHORITY record, both carrying the DELETE action
    */
   private static List<JournalRecord> buildAuthorityDeleteJournalRecords(JournalRecord baseRecord,
-                                                                        String entityJsonString,
                                                                         JournalRecord.ActionStatus actionStatus,
                                                                         JournalRecord.ActionType actionType,
                                                                         Record sourceRecord,
                                                                         DataImportEventPayload eventPayload,
                                                                         Map<String, String> context,
                                                                         String incomingRecordId) {
-    if (!isEmpty(entityJsonString)) {
-      baseRecord.setEntityId(new JsonObject(entityJsonString).getString(MATCHED_ID_KEY));
+    var deletedRecordJson = context.get(DELETED_MARC_AUTHORITY_KEY);
+    if (!isEmpty(deletedRecordJson)) {
+      baseRecord.setEntityId(new JsonObject(deletedRecordJson).getString(MATCHED_ID_KEY));
     }
 
     var authorityRecord = buildCommonJournalRecord(actionStatus, actionType, sourceRecord, eventPayload, context, incomingRecordId)

--- a/mod-source-record-manager-server/src/main/java/org/folio/services/journal/JournalUtil.java
+++ b/mod-source-record-manager-server/src/main/java/org/folio/services/journal/JournalUtil.java
@@ -31,6 +31,7 @@ import static org.apache.commons.lang3.StringUtils.EMPTY;
 import static org.apache.commons.lang3.StringUtils.isEmpty;
 import static org.folio.rest.jaxrs.model.DataImportEventTypes.DI_ERROR;
 import static org.folio.rest.jaxrs.model.JournalRecord.ActionType.CREATE;
+import static org.folio.rest.jaxrs.model.JournalRecord.ActionType.DELETE;
 import static org.folio.rest.jaxrs.model.JournalRecord.ActionType.MATCH;
 import static org.folio.rest.jaxrs.model.JournalRecord.ActionType.NON_MATCH;
 import static org.folio.rest.jaxrs.model.JournalRecord.ActionType.UPDATE;
@@ -58,6 +59,9 @@ public class JournalUtil {
   public static final String INSTANCE_ID_KEY = "instanceId";
   public static final String HRID_KEY = "hrid";
   public static final String MATCHED_ID_KEY = "matchedId";
+  // Set by mod-source-record-storage when it removes the SRS record, so the id of the
+  // deleted inventory authority is still available to the journal after the deletion.
+  public static final String AUTHORITY_RECORD_ID_KEY = "AUTHORITY_RECORD_ID";
   private static final String NOT_MATCHED_NUMBER = "NOT_MATCHED_NUMBER";
   public static final String PERMANENT_LOCATION_ID_KEY = "permanentLocationId";
   private static final String CENTRAL_TENANT_ID_KEY = "CENTRAL_TENANT_ID";
@@ -138,6 +142,11 @@ public class JournalUtil {
 
       var baseRecord = buildCommonJournalRecord(actionStatus, actionType, sourceRecord, eventPayload, context, incomingRecordId)
         .withEntityType(entityType);
+
+      if (isAuthorityDeletion(entityType, actionType)) {
+        return buildAuthorityDeleteJournalRecords(baseRecord, entityJsonString, actionStatus, actionType,
+          sourceRecord, eventPayload, context, incomingRecordId);
+      }
 
       if (isRelatedEntityRecordNeeded(entityType, actionType)) {
         var relatedRecord = buildCommonJournalRecord(actionStatus, actionType, sourceRecord, eventPayload, context, incomingRecordId)
@@ -308,6 +317,40 @@ public class JournalUtil {
 
   private static String getIncomingRecordId(Map<String, String> context, Record sourceRecord) {
     return context.get(INCOMING_RECORD_ID) != null ? context.get(INCOMING_RECORD_ID) : sourceRecord.getId();
+  }
+
+  private static boolean isAuthorityDeletion(JournalRecord.EntityType entityType, JournalRecord.ActionType actionType) {
+    return actionType == DELETE && entityType == MARC_AUTHORITY;
+  }
+
+  /**
+   * Builds the journal records for an authority removed by a delete job.
+   * <p>
+   * A deletion is reported by a single event, but it affects two entities the job log
+   * shows in separate columns, so both are journalled here: the SRS record, whose id is
+   * taken from the record still held in the payload context, and the authority,
+   * whose id is taken from {@link #AUTHORITY_RECORD_ID_KEY}. The authority itself is gone
+   * by this point, so its id is the only thing left to record.
+   *
+   * @return a MARC_AUTHORITY record and an AUTHORITY record, both carrying the DELETE action
+   */
+  private static List<JournalRecord> buildAuthorityDeleteJournalRecords(JournalRecord baseRecord,
+                                                                        String entityJsonString,
+                                                                        JournalRecord.ActionStatus actionStatus,
+                                                                        JournalRecord.ActionType actionType,
+                                                                        Record sourceRecord,
+                                                                        DataImportEventPayload eventPayload,
+                                                                        Map<String, String> context,
+                                                                        String incomingRecordId) {
+    if (!isEmpty(entityJsonString)) {
+      baseRecord.setEntityId(new JsonObject(entityJsonString).getString(MATCHED_ID_KEY));
+    }
+
+    var authorityRecord = buildCommonJournalRecord(actionStatus, actionType, sourceRecord, eventPayload, context, incomingRecordId)
+      .withEntityType(AUTHORITY)
+      .withEntityId(context.get(AUTHORITY_RECORD_ID_KEY));
+
+    return Lists.newArrayList(baseRecord, authorityRecord);
   }
 
   private static boolean isRelatedEntityRecordNeeded(JournalRecord.EntityType entityType, JournalRecord.ActionType actionType) {

--- a/mod-source-record-manager-server/src/main/java/org/folio/services/util/ParsedRecordUtil.java
+++ b/mod-source-record-manager-server/src/main/java/org/folio/services/util/ParsedRecordUtil.java
@@ -72,7 +72,14 @@ public final class ParsedRecordUtil {
   }
 
   private static JsonArray getFields(ParsedRecord parsedRecord) {
-    JsonObject parsedContent = new JsonObject(parsedRecord.getContent().toString());
+    Object content = parsedRecord.getContent();
+    if (content == null) {
+      return null;
+    }
+
+    JsonObject parsedContent = content instanceof String contentAsString
+      ? new JsonObject(contentAsString)
+      : JsonObject.mapFrom(content);
     return parsedContent.getJsonArray("fields");
   }
 }

--- a/mod-source-record-manager-server/src/main/java/org/folio/verticle/consumers/util/JournalParams.java
+++ b/mod-source-record-manager-server/src/main/java/org/folio/verticle/consumers/util/JournalParams.java
@@ -143,6 +143,14 @@ public class JournalParams {
         return Optional.of(new JournalParams(UPDATE, sourceRecordType, JournalRecord.ActionStatus.COMPLETED));
       }
     },
+    DI_MARC_FOR_DELETE_RECEIVED { //added for correct processing of DI_ERROR event raised before the record was deleted
+      @Override
+      public Optional<JournalParams> getJournalParams(DataImportEventPayload eventPayload) {
+        return Optional.of(new JournalParams(DELETE,
+          JournalRecord.EntityType.MARC_AUTHORITY,
+          JournalRecord.ActionStatus.COMPLETED));
+      }
+    },
     DI_INCOMING_MARC_BIB_RECORD_PARSED {
       @Override
       public Optional<JournalParams> getJournalParams(DataImportEventPayload eventPayload) {

--- a/mod-source-record-manager-server/src/main/java/org/folio/verticle/consumers/util/MarcImportEventsHandler.java
+++ b/mod-source-record-manager-server/src/main/java/org/folio/verticle/consumers/util/MarcImportEventsHandler.java
@@ -137,9 +137,13 @@ public class MarcImportEventsHandler implements SpecificEventHandler {
             log.warn("transform:: Error during build of journal records", e);
             return Future.failedFuture(e);
           }
-          return Future.all(improveJournalRecordsIfNeeded(journalService, eventPayload, tenantId, journalRecords))
-            .onFailure(th -> log.warn("transform:: Error during journal record improve", th))
-            .map(ar -> ar.result().list());
+          Future<Collection<JournalRecord>> improvedRecords =
+            Future.all(improveJournalRecordsIfNeeded(journalService, eventPayload, tenantId, journalRecords))
+              .map(ar -> ar.result().list());
+          return improvedRecords.recover(th -> {
+            log.warn("transform:: Error during journal record improve, journal records are saved without it", th);
+            return Future.succeededFuture(journalRecords);
+          });
         }
         return Future.succeededFuture(new ArrayList<>());
   }

--- a/mod-source-record-manager-server/src/main/java/org/folio/verticle/consumers/util/MarcImportEventsHandler.java
+++ b/mod-source-record-manager-server/src/main/java/org/folio/verticle/consumers/util/MarcImportEventsHandler.java
@@ -30,6 +30,7 @@ import java.util.Optional;
 import java.util.function.BiFunction;
 import java.util.stream.IntStream;
 
+import static org.folio.rest.jaxrs.model.JournalRecord.ActionType.DELETE;
 import static org.folio.rest.jaxrs.model.JournalRecord.EntityType.HOLDINGS;
 import static org.folio.rest.jaxrs.model.JournalRecord.EntityType.INSTANCE;
 import static org.folio.rest.jaxrs.model.JournalRecord.EntityType.ITEM;
@@ -174,7 +175,7 @@ public class MarcImportEventsHandler implements SpecificEventHandler {
 
     if (entityType == MARC_BIBLIOGRAPHIC || entityType == MARC_AUTHORITY) {
       journalRecord.setTitle(NO_TITLE_MESSAGE);
-      String recordAsString = eventPayload.getContext().get(entityType.value());
+      String recordAsString = extractRecordForTitle(journalRecord, entityType, eventPayload);
       if (StringUtils.isNotBlank(recordAsString)) {
         var parsedRecord = Json.decodeValue(recordAsString, Record.class).getParsedRecord();
         return mappingRuleCache.get(new MappingRuleCacheKey(eventPayload.getTenant(), entityType))
@@ -197,5 +198,24 @@ public class MarcImportEventsHandler implements SpecificEventHandler {
       }
     }
     return Future.succeededFuture(journalRecord);
+  }
+
+  /**
+   * Chooses the record the log title is read from.
+   * <p>
+   * The log should show the title of the record that was actually
+   * deleted rather than the vendor's version of it. Falls back to the incoming record when
+   * the deleted one is unavailable.
+   */
+  private String extractRecordForTitle(JournalRecord journalRecord, JournalRecord.EntityType entityType,
+                                       DataImportEventPayload eventPayload) {
+    var context = eventPayload.getContext();
+    if (journalRecord.getActionType() == DELETE && entityType == MARC_AUTHORITY) {
+      var deletedRecord = context.get(JournalUtil.DELETED_MARC_AUTHORITY_KEY);
+      if (StringUtils.isNotBlank(deletedRecord)) {
+        return deletedRecord;
+      }
+    }
+    return context.get(entityType.value());
   }
 }

--- a/mod-source-record-manager-server/src/main/resources/templates/db_scripts/create_get_job_log_entries_function.sql
+++ b/mod-source-record-manager-server/src/main/resources/templates/db_scripts/create_get_job_log_entries_function.sql
@@ -70,10 +70,11 @@ v_sortingField text DEFAULT sortingfield;      -- for bottomSQL | originalSQL
           WHEN ''%5$s'' = ''sort_source_action'' THEN
             (SELECT
                CASE
-                 WHEN MAX(error) != '''' OR bool_or(action_type = ''NON_MATCH'') THEN ''2'' -- DISCARDED
+                 WHEN MAX(error) != '''' OR bool_or(action_type = ''NON_MATCH'') THEN ''3'' -- DISCARDED
                  WHEN bool_or(action_type = ''CREATE'') THEN ''1'' -- CREATED
-                 WHEN bool_or(action_type = ''UPDATE'') THEN ''3'' -- UPDATED
-                 ELSE ''4''
+                 WHEN bool_or(action_type = ''DELETE'') THEN ''2'' -- DELETED
+                 WHEN bool_or(action_type = ''UPDATE'') THEN ''4'' -- UPDATED
+                 ELSE ''5''
                END
              FROM journal_records
              WHERE source_id = qualifying_source_ids.source_id
@@ -97,6 +98,7 @@ v_sortingField text DEFAULT sortingfield;      -- for bottomSQL | originalSQL
              WHEN entity_type = ''PO_LINE'' AND action_status = ''ERROR'' THEN ''DISCARDED''
              WHEN action_type = ''NON_MATCH'' THEN ''DISCARDED''
              WHEN action_type = ''CREATE'' THEN ''CREATED''
+             WHEN action_type = ''DELETE'' THEN ''DELETED''
              WHEN action_type = ''UPDATE'' THEN ''UPDATED''
              WHEN action_type = ''MODIFY'' THEN ''UPDATED''
            END AS action_type,
@@ -111,7 +113,7 @@ v_sortingField text DEFAULT sortingfield;      -- for bottomSQL | originalSQL
                ELSE
                  CASE action_status WHEN ''ERROR'' THEN 1 ELSE 2 END
                END,
-               array_position(array[''NON_MATCH'', ''CREATE'', ''UPDATE'', ''MODIFY''], action_type)))[1] AS id_max
+               array_position(array[''NON_MATCH'', ''CREATE'', ''UPDATE'', ''MODIFY'', ''DELETE''], action_type)))[1] AS id_max
       FROM relevant_records
       WHERE entity_type NOT IN (''EDIFACT'', ''INVOICE'') AND action_type != ''MATCH''
       GROUP BY entity_type, entity_id, source_id
@@ -256,6 +258,7 @@ originalSQL TEXT := '
                WHEN entity_type = ''PO_LINE'' AND action_status = ''ERROR'' THEN ''DISCARDED''
                WHEN action_type = ''NON_MATCH'' THEN ''DISCARDED''
                WHEN action_type = ''CREATE'' THEN ''CREATED''
+               WHEN action_type = ''DELETE'' THEN ''DELETED''
                WHEN action_type = ''UPDATE'' THEN ''UPDATED''
                WHEN action_type = ''MODIFY'' THEN ''UPDATED''
                END AS action_type,
@@ -269,7 +272,7 @@ originalSQL TEXT := '
                  ELSE
                    CASE action_status WHEN ''ERROR'' THEN 1 ELSE 2 END
                  END,
-                 array_position(array[''NON_MATCH'', ''CREATE'', ''UPDATE'', ''MODIFY''], action_type)))[1] AS id_max
+                 array_position(array[''NON_MATCH'', ''CREATE'', ''UPDATE'', ''MODIFY'', ''DELETE''], action_type)))[1] AS id_max
         FROM journal_records
         WHERE job_execution_id = ''%1$s'' AND entity_type NOT IN (''EDIFACT'', ''INVOICE'') AND action_type != ''MATCH''
         GROUP BY entity_type, entity_id, source_id

--- a/mod-source-record-manager-server/src/main/resources/templates/db_scripts/create_get_record_processing_log_function.sql
+++ b/mod-source-record-manager-server/src/main/resources/templates/db_scripts/create_get_record_processing_log_function.sql
@@ -17,6 +17,7 @@ BEGIN
                        WHEN journal_records.entity_type != 'PO_LINE' AND (action_type_by_source.error_max != '' OR journal_records.action_type = 'NON_MATCH') THEN 'DISCARDED'
                        WHEN journal_records.entity_type = 'PO_LINE' AND journal_records.action_status = 'ERROR' THEN 'DISCARDED'
                        WHEN journal_records.action_type = 'CREATE' THEN 'CREATED'
+                       WHEN journal_records.action_type = 'DELETE' THEN 'DELETED'
                        WHEN journal_records.action_type = 'UPDATE' THEN 'UPDATED'
                    END AS action_type,
                    journal_records.action_status,
@@ -40,7 +41,7 @@ BEGIN
                            ELSE
                                CASE action_status WHEN 'ERROR' THEN 1 ELSE 2 END
                            END,
-                           array_position(array['CREATE', 'UPDATE', 'NON_MATCH'], action_type)))[1] AS id_max,
+                           array_position(array['CREATE', 'UPDATE', 'NON_MATCH', 'DELETE'], action_type)))[1] AS id_max,
                        MAX(journal_records.title) AS title
                 FROM journal_records
                 WHERE journal_records.job_execution_id = jobExecutionId

--- a/mod-source-record-manager-server/src/main/resources/templates/db_scripts/schema.json
+++ b/mod-source-record-manager-server/src/main/resources/templates/db_scripts/schema.json
@@ -320,6 +320,16 @@
       "run": "after",
       "snippetPath": "create_get_job_log_entries_function.sql",
       "fromModuleVersion": "mod-source-record-manager-4.0.0"
+    },
+    {
+      "run": "after",
+      "snippetPath": "create_get_job_log_entries_function.sql",
+      "fromModuleVersion": "mod-source-record-manager-4.1.0"
+    },
+    {
+      "run": "after",
+      "snippetPath": "create_get_record_processing_log_function.sql",
+      "fromModuleVersion": "mod-source-record-manager-4.1.0"
     }
   ]
 }

--- a/mod-source-record-manager-server/src/test/java/org/folio/rest/impl/metadataProvider/MetaDataProviderJobLogEntriesAPITest.java
+++ b/mod-source-record-manager-server/src/test/java/org/folio/rest/impl/metadataProvider/MetaDataProviderJobLogEntriesAPITest.java
@@ -3,6 +3,7 @@ package org.folio.rest.impl.metadataProvider;
 import static org.folio.rest.jaxrs.model.JournalRecord.ActionStatus.COMPLETED;
 import static org.folio.rest.jaxrs.model.JournalRecord.ActionStatus.ERROR;
 import static org.folio.rest.jaxrs.model.JournalRecord.ActionType.CREATE;
+import static org.folio.rest.jaxrs.model.JournalRecord.ActionType.DELETE;
 import static org.folio.rest.jaxrs.model.JournalRecord.ActionType.MATCH;
 import static org.folio.rest.jaxrs.model.JournalRecord.ActionType.MODIFY;
 import static org.folio.rest.jaxrs.model.JournalRecord.ActionType.NON_MATCH;
@@ -19,6 +20,7 @@ import static org.folio.rest.jaxrs.model.JournalRecord.EntityType.MARC_BIBLIOGRA
 import static org.folio.rest.jaxrs.model.JournalRecord.EntityType.MARC_HOLDINGS;
 import static org.folio.rest.jaxrs.model.JournalRecord.EntityType.PO_LINE;
 import static org.folio.rest.jaxrs.model.MetadataProviderJobLogEntriesJobExecutionIdGetOrder.ASC;
+import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.empty;
 import static org.hamcrest.Matchers.emptyOrNullString;
 import static org.hamcrest.Matchers.in;
@@ -1068,6 +1070,141 @@ public class MetaDataProviderJobLogEntriesAPITest extends AbstractRestTest {
         .body("entries[0].sourceRecordId", is(marcAuthorityId))
         .body("entries[0].sourceRecordTitle", is(recordTitle))
         .body("entries[0].sourceRecordOrder", is("0"));
+      async.complete();
+    }));
+  }
+
+  @Test
+  public void shouldReturnAuthorityDataIfAuthorityWasDeleted(TestContext context) {
+    Async async = context.async();
+    JobExecution createdJobExecution = constructAndPostInitJobExecutionRqDto(1).getJobExecutions().getFirst();
+    String incomingRecordId = UUID.randomUUID().toString();
+    String marcAuthorityId = UUID.randomUUID().toString();
+    String authorityId = UUID.randomUUID().toString();
+    String recordTitle = "test title";
+
+    Future<JournalRecord> future = Future.succeededFuture()
+      .compose(v -> createJournalRecord(createdJobExecution.getId(), incomingRecordId, null, null, null, 0, PARSE, null, COMPLETED, null, null))
+      .compose(v -> createJournalRecord(createdJobExecution.getId(), incomingRecordId, marcAuthorityId, null, recordTitle, 0, DELETE, MARC_AUTHORITY, COMPLETED, null, null))
+      .compose(v -> createJournalRecord(createdJobExecution.getId(), incomingRecordId, authorityId, null, null, 0, DELETE, AUTHORITY, COMPLETED, null, null))
+      .onFailure(context::fail);
+
+    future.onComplete(ar -> context.verify(v -> {
+      RestAssured.given()
+        .spec(spec)
+        .when()
+        .get(GET_JOB_EXECUTION_JOURNAL_RECORDS_PATH + "/" + createdJobExecution.getId() + "/records/" + incomingRecordId)
+        .then()
+        .statusCode(HttpStatus.SC_OK)
+        .body("jobExecutionId", is(createdJobExecution.getId()))
+        .body("incomingRecordId", is(incomingRecordId))
+        .body("sourceRecordId", is(marcAuthorityId))
+        .body("sourceRecordTitle", is(recordTitle))
+        .body("sourceRecordOrder", is("0"))
+        .body("sourceRecordActionStatus", is(ActionStatus.DELETED.value()))
+        .body("relatedAuthorityInfo.actionStatus", is(ActionStatus.DELETED.value()))
+        .body("relatedAuthorityInfo.idList[0]", is(authorityId))
+        .body("relatedAuthorityInfo.error", emptyOrNullString())
+        .body("error", emptyOrNullString());
+      async.complete();
+    }));
+  }
+
+  @Test
+  public void shouldReturnOneLogEntryAuthorityDataIfAuthorityWasDeleted(TestContext context) {
+    Async async = context.async();
+    JobExecution createdJobExecution = constructAndPostInitJobExecutionRqDto(1).getJobExecutions().getFirst();
+    String incomingRecordId = UUID.randomUUID().toString();
+    String marcAuthorityId = UUID.randomUUID().toString();
+    String authorityId = UUID.randomUUID().toString();
+    String recordTitle = "test title";
+
+    Future<JournalRecord> future = Future.succeededFuture()
+      .compose(v -> createJournalRecord(createdJobExecution.getId(), incomingRecordId, null, null, null, 0, PARSE, null, COMPLETED, null, null))
+      .compose(v -> createJournalRecord(createdJobExecution.getId(), incomingRecordId, marcAuthorityId, null, recordTitle, 0, DELETE, MARC_AUTHORITY, COMPLETED, null, null))
+      .compose(v -> createJournalRecord(createdJobExecution.getId(), incomingRecordId, authorityId, null, null, 0, DELETE, AUTHORITY, COMPLETED, null, null))
+      .onFailure(context::fail);
+
+    future.onComplete(ar -> context.verify(v -> {
+      RestAssured.given()
+        .spec(spec)
+        .when()
+        .get(GET_JOB_EXECUTION_JOURNAL_RECORDS_PATH + "/" + createdJobExecution.getId() + "?limit=100&order=asc")
+        .then()
+        .statusCode(HttpStatus.SC_OK)
+        .body("totalRecords", is(1))
+        .body("entries[0].incomingRecordId", is(incomingRecordId))
+        .body("entries[0].sourceRecordId", is(marcAuthorityId))
+        .body("entries[0].sourceRecordTitle", is(recordTitle))
+        .body("entries[0].sourceRecordOrder", is("0"))
+        .body("entries[0].sourceRecordActionStatus", is(ActionStatus.DELETED.value()))
+        .body("entries[0].relatedAuthorityInfo.actionStatus", is(ActionStatus.DELETED.value()))
+        .body("entries[0].relatedAuthorityInfo.idList[0]", is(authorityId));
+      async.complete();
+    }));
+  }
+
+  @Test
+  public void shouldReturnDiscardedWhenAuthorityDeletionFailed(TestContext context) {
+    Async async = context.async();
+    JobExecution createdJobExecution = constructAndPostInitJobExecutionRqDto(1).getJobExecutions().getFirst();
+    String incomingRecordId = UUID.randomUUID().toString();
+    String marcAuthorityId = UUID.randomUUID().toString();
+    String recordTitle = "test title";
+    String errorMessage = "Error while deleting MARC record, record is not found";
+
+    Future<JournalRecord> future = Future.succeededFuture()
+      .compose(v -> createJournalRecord(createdJobExecution.getId(), incomingRecordId, null, null, null, 0, PARSE, null, COMPLETED, null, null))
+      .compose(v -> createJournalRecord(createdJobExecution.getId(), incomingRecordId, marcAuthorityId, null, recordTitle, 0, DELETE, MARC_AUTHORITY, ERROR, errorMessage, null))
+      .compose(v -> createJournalRecord(createdJobExecution.getId(), incomingRecordId, null, null, null, 0, DELETE, AUTHORITY, ERROR, errorMessage, null))
+      .onFailure(context::fail);
+
+    future.onComplete(ar -> context.verify(v -> {
+      RestAssured.given()
+        .spec(spec)
+        .when()
+        .get(GET_JOB_EXECUTION_JOURNAL_RECORDS_PATH + "/" + createdJobExecution.getId() + "?limit=100&order=asc")
+        .then()
+        .statusCode(HttpStatus.SC_OK)
+        .body("totalRecords", is(1))
+        .body("entries[0].incomingRecordId", is(incomingRecordId))
+        .body("entries[0].sourceRecordActionStatus", is(ActionStatus.DISCARDED.value()))
+        .body("entries[0].relatedAuthorityInfo.actionStatus", is(ActionStatus.DISCARDED.value()))
+        // both the SRS record and the authority carry the failure, so the entry aggregates them
+        .body("entries[0].error", containsString(errorMessage));
+      async.complete();
+    }));
+  }
+
+  @Test
+  public void shouldSortEntriesByActionStatusWithDeletedBetweenCreatedAndDiscarded(TestContext context) {
+    Async async = context.async();
+    JobExecution createdJobExecution = constructAndPostInitJobExecutionRqDto(1).getJobExecutions().getFirst();
+    String createdRecordId = UUID.randomUUID().toString();
+    String deletedRecordId = UUID.randomUUID().toString();
+    String discardedRecordId = UUID.randomUUID().toString();
+    String recordTitle = "test title";
+    String errorMessage = "Error while deleting MARC record, record is not found";
+
+    // inserted out of order, so the assertion below reflects the sort rather than the insertion order
+    Future<JournalRecord> future = Future.succeededFuture()
+      .compose(v -> createJournalRecord(createdJobExecution.getId(), deletedRecordId, UUID.randomUUID().toString(), null, recordTitle, 1, DELETE, MARC_AUTHORITY, COMPLETED, null, null))
+      .compose(v -> createJournalRecord(createdJobExecution.getId(), discardedRecordId, UUID.randomUUID().toString(), null, recordTitle, 2, DELETE, MARC_AUTHORITY, ERROR, errorMessage, null))
+      .compose(v -> createJournalRecord(createdJobExecution.getId(), createdRecordId, UUID.randomUUID().toString(), null, recordTitle, 0, CREATE, MARC_AUTHORITY, COMPLETED, null, null))
+      .onFailure(context::fail);
+
+    future.onComplete(ar -> context.verify(v -> {
+      RestAssured.given()
+        .spec(spec)
+        .when()
+        .get(GET_JOB_EXECUTION_JOURNAL_RECORDS_PATH + "/" + createdJobExecution.getId()
+          + "?limit=100&sortBy=source_record_action_status&order=asc")
+        .then()
+        .statusCode(HttpStatus.SC_OK)
+        .body("totalRecords", is(3))
+        .body("entries[0].sourceRecordActionStatus", is(ActionStatus.CREATED.value()))
+        .body("entries[1].sourceRecordActionStatus", is(ActionStatus.DELETED.value()))
+        .body("entries[2].sourceRecordActionStatus", is(ActionStatus.DISCARDED.value()));
       async.complete();
     }));
   }

--- a/mod-source-record-manager-server/src/test/java/org/folio/services/ChangeEngineServiceImplTest.java
+++ b/mod-source-record-manager-server/src/test/java/org/folio/services/ChangeEngineServiceImplTest.java
@@ -5,11 +5,13 @@ import static org.folio.rest.jaxrs.model.ActionProfile.FolioRecord.AUTHORITY;
 import static org.folio.rest.jaxrs.model.ActionProfile.FolioRecord.MARC_AUTHORITY;
 import static org.folio.rest.jaxrs.model.DataImportEventTypes.DI_INCOMING_MARC_BIB_FOR_ORDER_PARSED;
 import static org.folio.rest.jaxrs.model.DataImportEventTypes.DI_INCOMING_MARC_BIB_RECORD_PARSED;
+import static org.folio.rest.jaxrs.model.DataImportEventTypes.DI_MARC_FOR_DELETE_RECEIVED;
 import static org.folio.rest.jaxrs.model.DataImportEventTypes.DI_MARC_FOR_UPDATE_RECEIVED;
 import static org.folio.rest.jaxrs.model.ProfileType.ACTION_PROFILE;
 import static org.folio.rest.jaxrs.model.ProfileType.JOB_PROFILE;
 import static org.folio.rest.jaxrs.model.ProfileType.MAPPING_PROFILE;
 import static org.folio.rest.jaxrs.model.ProfileType.MATCH_PROFILE;
+import static org.folio.rest.jaxrs.model.ReactToType.MATCH;
 import static org.folio.rest.jaxrs.model.ReactToType.NON_MATCH;
 import static org.folio.services.ChangeEngineServiceImpl.RECORD_ID_HEADER;
 import static org.folio.verticle.consumers.StoredRecordChunksKafkaHandler.ACTION_FIELD;
@@ -313,6 +315,39 @@ public class ChangeEngineServiceImplTest {
     assertThat(actual, hasSize(1));
     assertThat(actual.getFirst().getRecordType(), equalTo(Record.RecordType.MARC_AUTHORITY));
     assertThat(actual.getFirst().getErrorRecord(), nullValue());
+  }
+
+  @Test
+  public void shouldSendDeleteEventWhenDeleteActionIsReachedThroughMatchProfile() {
+    RawRecordsDto rawRecordsDto = getTestRawRecordsDto(MARC_AUTHORITY_REC_VALID);
+    JobExecution jobExecution = getTestJobExecution();
+    jobExecution.setJobProfileSnapshotWrapper(new ProfileSnapshotWrapper()
+      .withChildSnapshotWrappers(List.of(new ProfileSnapshotWrapper()
+        .withContentType(MATCH_PROFILE)
+        .withContent(new JsonObject(Json.encode(new MatchProfile()
+          .withExistingRecordType(EntityType.MARC_AUTHORITY)
+          .withIncomingRecordType(EntityType.MARC_AUTHORITY))).getMap())
+        .withChildSnapshotWrappers(List.of(new ProfileSnapshotWrapper()
+          .withContentType(ACTION_PROFILE)
+          .withReactTo(MATCH)
+          .withContent(new JsonObject(Json.encode(new ActionProfile()
+            .withAction(ActionProfile.Action.DELETE)
+            .withFolioRecord(MARC_AUTHORITY))).getMap())))))
+    );
+
+    when(marcRecordAnalyzer.process(any())).thenReturn(MarcRecordType.AUTHORITY);
+    when(jobExecutionSourceChunkDao.getById(any(), any()))
+      .thenReturn(Future.succeededFuture(Optional.of(new JobExecutionSourceChunk())));
+    when(jobExecutionSourceChunkDao.update(any(), any())).thenReturn(Future.succeededFuture(new JobExecutionSourceChunk()));
+    when(recordsPublishingService.sendEventsWithRecords(any(), any(), any(), any(), any()))
+      .thenReturn(Future.succeededFuture(true));
+
+    executeWithKafkaMock(rawRecordsDto, jobExecution, Future.succeededFuture(true));
+
+    verify(recordsPublishingService).sendEventsWithRecords(any(), any(), any(),
+      eq(DI_MARC_FOR_DELETE_RECEIVED.value()), any());
+    verify(recordsPublishingService, never()).sendEventsWithRecords(any(), any(), any(),
+      eq(DI_MARC_FOR_UPDATE_RECEIVED.value()), any());
   }
 
   @Test

--- a/mod-source-record-manager-server/src/test/java/org/folio/services/JournalUtilTest.java
+++ b/mod-source-record-manager-server/src/test/java/org/folio/services/JournalUtilTest.java
@@ -41,6 +41,7 @@ import static org.folio.rest.jaxrs.model.JournalRecord.EntityType.MARC_BIBLIOGRA
 import static org.folio.rest.jaxrs.model.JournalRecord.EntityType.MARC_HOLDINGS;
 import static org.folio.rest.jaxrs.model.JournalRecord.EntityType.PO_LINE;
 import static org.folio.services.journal.JournalUtil.AUTHORITY_RECORD_ID_KEY;
+import static org.folio.services.journal.JournalUtil.DELETED_MARC_AUTHORITY_KEY;
 import static org.folio.services.journal.JournalUtil.ERROR_KEY;
 import static org.folio.services.journal.JournalUtil.MARC_BIB_RECORD_CREATED;
 
@@ -1596,12 +1597,18 @@ public class JournalUtilTest {
 
     JsonObject recordJson = new JsonObject()
       .put("id", recordId)
+      .put("snapshotId", snapshotId)
+      .put("order", 1);
+
+    JsonObject deletedRecordJson = new JsonObject()
+      .put("id", UUID.randomUUID().toString())
       .put("matchedId", matchedId)
       .put("snapshotId", snapshotId)
       .put("order", 1);
 
     HashMap<String, String> context = new HashMap<>();
     context.put(MARC_AUTHORITY.value(), recordJson.encode());
+    context.put(DELETED_MARC_AUTHORITY_KEY, deletedRecordJson.encode());
     context.put(INCOMING_RECORD_ID, incomingRecordId);
     context.put(AUTHORITY_RECORD_ID_KEY, authorityId);
 
@@ -1639,14 +1646,12 @@ public class JournalUtilTest {
   @Test
   public void shouldBuildJournalRecordsForFailedMarcAuthorityDeletion() throws JournalRecordMapperException {
     String recordId = UUID.randomUUID().toString();
-    String matchedId = UUID.randomUUID().toString();
     String snapshotId = UUID.randomUUID().toString();
     String incomingRecordId = UUID.randomUUID().toString();
     String errorMessage = "Error while deleting MARC record, record is not found";
 
     JsonObject recordJson = new JsonObject()
       .put("id", recordId)
-      .put("matchedId", matchedId)
       .put("snapshotId", snapshotId)
       .put("order", 1);
 
@@ -1670,9 +1675,8 @@ public class JournalUtilTest {
     Assert.assertEquals(DELETE, journalRecordMarcAuthority.getActionType());
     Assert.assertEquals(ERROR, journalRecordMarcAuthority.getActionStatus());
     Assert.assertEquals(errorMessage, journalRecordMarcAuthority.getError());
-    Assert.assertEquals(matchedId, journalRecordMarcAuthority.getEntityId());
+    Assert.assertNull(journalRecordMarcAuthority.getEntityId());
 
-    // the deletion never got far enough for mod-source-record-storage to report the authority id
     JournalRecord journalRecordAuthority = journalRecords.get(1);
     Assert.assertEquals(AUTHORITY, journalRecordAuthority.getEntityType());
     Assert.assertEquals(DELETE, journalRecordAuthority.getActionType());

--- a/mod-source-record-manager-server/src/test/java/org/folio/services/JournalUtilTest.java
+++ b/mod-source-record-manager-server/src/test/java/org/folio/services/JournalUtilTest.java
@@ -40,6 +40,7 @@ import static org.folio.rest.jaxrs.model.JournalRecord.EntityType.MARC_AUTHORITY
 import static org.folio.rest.jaxrs.model.JournalRecord.EntityType.MARC_BIBLIOGRAPHIC;
 import static org.folio.rest.jaxrs.model.JournalRecord.EntityType.MARC_HOLDINGS;
 import static org.folio.rest.jaxrs.model.JournalRecord.EntityType.PO_LINE;
+import static org.folio.services.journal.JournalUtil.AUTHORITY_RECORD_ID_KEY;
 import static org.folio.services.journal.JournalUtil.ERROR_KEY;
 import static org.folio.services.journal.JournalUtil.MARC_BIB_RECORD_CREATED;
 
@@ -1583,6 +1584,101 @@ public class JournalUtilTest {
     Assert.assertEquals(COMPLETED, journalRecordAuthority.getActionStatus());
     Assert.assertNull(journalRecordAuthority.getEntityId());
     Assert.assertNotNull(journalRecordAuthority.getActionDate());
+  }
+
+  @Test
+  public void shouldBuildJournalRecordsForDeletedMarcAuthority() throws JournalRecordMapperException {
+    String recordId = UUID.randomUUID().toString();
+    String matchedId = UUID.randomUUID().toString();
+    String snapshotId = UUID.randomUUID().toString();
+    String incomingRecordId = UUID.randomUUID().toString();
+    String authorityId = UUID.randomUUID().toString();
+
+    JsonObject recordJson = new JsonObject()
+      .put("id", recordId)
+      .put("matchedId", matchedId)
+      .put("snapshotId", snapshotId)
+      .put("order", 1);
+
+    HashMap<String, String> context = new HashMap<>();
+    context.put(MARC_AUTHORITY.value(), recordJson.encode());
+    context.put(INCOMING_RECORD_ID, incomingRecordId);
+    context.put(AUTHORITY_RECORD_ID_KEY, authorityId);
+
+    DataImportEventPayload eventPayload = new DataImportEventPayload()
+      .withEventType("DI_SRS_MARC_AUTHORITY_RECORD_DELETED")
+      .withContext(context);
+
+    List<JournalRecord> journalRecords = JournalUtil.buildJournalRecordsByEvent(eventPayload,
+      DELETE, MARC_AUTHORITY, COMPLETED);
+
+    Assert.assertNotNull(journalRecords);
+    Assert.assertEquals(2, journalRecords.size());
+
+    JournalRecord journalRecordMarcAuthority = journalRecords.get(0);
+    Assert.assertEquals(snapshotId, journalRecordMarcAuthority.getJobExecutionId());
+    Assert.assertEquals(incomingRecordId, journalRecordMarcAuthority.getSourceId());
+    Assert.assertEquals(1, journalRecordMarcAuthority.getSourceRecordOrder().intValue());
+    Assert.assertEquals(MARC_AUTHORITY, journalRecordMarcAuthority.getEntityType());
+    Assert.assertEquals(DELETE, journalRecordMarcAuthority.getActionType());
+    Assert.assertEquals(COMPLETED, journalRecordMarcAuthority.getActionStatus());
+    Assert.assertEquals(matchedId, journalRecordMarcAuthority.getEntityId());
+    Assert.assertNotNull(journalRecordMarcAuthority.getActionDate());
+
+    JournalRecord journalRecordAuthority = journalRecords.get(1);
+    Assert.assertEquals(snapshotId, journalRecordAuthority.getJobExecutionId());
+    Assert.assertEquals(incomingRecordId, journalRecordAuthority.getSourceId());
+    Assert.assertEquals(1, journalRecordAuthority.getSourceRecordOrder().intValue());
+    Assert.assertEquals(AUTHORITY, journalRecordAuthority.getEntityType());
+    Assert.assertEquals(DELETE, journalRecordAuthority.getActionType());
+    Assert.assertEquals(COMPLETED, journalRecordAuthority.getActionStatus());
+    Assert.assertEquals(authorityId, journalRecordAuthority.getEntityId());
+    Assert.assertNotNull(journalRecordAuthority.getActionDate());
+  }
+
+  @Test
+  public void shouldBuildJournalRecordsForFailedMarcAuthorityDeletion() throws JournalRecordMapperException {
+    String recordId = UUID.randomUUID().toString();
+    String matchedId = UUID.randomUUID().toString();
+    String snapshotId = UUID.randomUUID().toString();
+    String incomingRecordId = UUID.randomUUID().toString();
+    String errorMessage = "Error while deleting MARC record, record is not found";
+
+    JsonObject recordJson = new JsonObject()
+      .put("id", recordId)
+      .put("matchedId", matchedId)
+      .put("snapshotId", snapshotId)
+      .put("order", 1);
+
+    HashMap<String, String> context = new HashMap<>();
+    context.put(MARC_AUTHORITY.value(), recordJson.encode());
+    context.put(INCOMING_RECORD_ID, incomingRecordId);
+    context.put(ERROR_KEY, errorMessage);
+
+    DataImportEventPayload eventPayload = new DataImportEventPayload()
+      .withEventType(DI_ERROR.value())
+      .withContext(context);
+
+    List<JournalRecord> journalRecords = JournalUtil.buildJournalRecordsByEvent(eventPayload,
+      DELETE, MARC_AUTHORITY, ERROR);
+
+    Assert.assertNotNull(journalRecords);
+    Assert.assertEquals(2, journalRecords.size());
+
+    JournalRecord journalRecordMarcAuthority = journalRecords.get(0);
+    Assert.assertEquals(MARC_AUTHORITY, journalRecordMarcAuthority.getEntityType());
+    Assert.assertEquals(DELETE, journalRecordMarcAuthority.getActionType());
+    Assert.assertEquals(ERROR, journalRecordMarcAuthority.getActionStatus());
+    Assert.assertEquals(errorMessage, journalRecordMarcAuthority.getError());
+    Assert.assertEquals(matchedId, journalRecordMarcAuthority.getEntityId());
+
+    // the deletion never got far enough for mod-source-record-storage to report the authority id
+    JournalRecord journalRecordAuthority = journalRecords.get(1);
+    Assert.assertEquals(AUTHORITY, journalRecordAuthority.getEntityType());
+    Assert.assertEquals(DELETE, journalRecordAuthority.getActionType());
+    Assert.assertEquals(ERROR, journalRecordAuthority.getActionStatus());
+    Assert.assertEquals(errorMessage, journalRecordAuthority.getError());
+    Assert.assertNull(journalRecordAuthority.getEntityId());
   }
 
   @Test

--- a/mod-source-record-manager-server/src/test/java/org/folio/verticle/consumers/util/JournalParamsTest.java
+++ b/mod-source-record-manager-server/src/test/java/org/folio/verticle/consumers/util/JournalParamsTest.java
@@ -35,7 +35,9 @@ import static org.folio.rest.jaxrs.model.DataImportEventTypes.DI_SRS_MARC_BIB_RE
 import static org.folio.rest.jaxrs.model.DataImportEventTypes.DI_SRS_MARC_HOLDINGS_RECORD_MATCHED;
 import static org.folio.rest.jaxrs.model.DataImportEventTypes.DI_SRS_MARC_HOLDINGS_RECORD_UPDATED;
 import static org.folio.rest.jaxrs.model.DataImportEventTypes.DI_SRS_MARC_HOLDING_RECORD_CREATED;
+import static org.folio.rest.jaxrs.model.DataImportEventTypes.DI_MARC_FOR_DELETE_RECEIVED;
 import static org.folio.rest.jaxrs.model.DataImportEventTypes.DI_MARC_FOR_UPDATE_RECEIVED;
+import static org.folio.rest.jaxrs.model.DataImportEventTypes.DI_SRS_MARC_AUTHORITY_RECORD_DELETED;
 import static org.folio.rest.jaxrs.model.DataImportEventTypes.DI_INVENTORY_HOLDINGS_CREATED_READY_FOR_POST_PROCESSING;
 import static org.folio.rest.jaxrs.model.DataImportEventTypes.DI_INVENTORY_HOLDINGS_UPDATED_READY_FOR_POST_PROCESSING;
 import static org.folio.rest.jaxrs.model.DataImportEventTypes.DI_INVENTORY_AUTHORITY_CREATED_READY_FOR_POST_PROCESSING;
@@ -518,6 +520,38 @@ public class JournalParamsTest {
     var journalParams = journalParamsOptional.get();
     Assert.assertEquals(JournalRecord.EntityType.MARC_AUTHORITY, journalParams.journalEntityType);
     Assert.assertEquals(JournalRecord.ActionType.UPDATE, journalParams.journalActionType);
+    Assert.assertEquals(JournalRecord.ActionStatus.ERROR, journalParams.journalActionStatus);
+  }
+
+  @Test
+  public void shouldPopulateDeleteParamsWhenEventChainEndsWithMarcAuthorityRecordDeleted() {
+    eventPayload.setEventType(DI_COMPLETED.value());
+    context.put(JournalRecord.EntityType.MARC_AUTHORITY.value(), new JsonObject().encode());
+    eventPayload.setContext(context);
+    eventPayload.setEventsChain(List.of(DI_SRS_MARC_AUTHORITY_RECORD_DELETED.value()));
+
+    var journalParamsOptional =
+      JournalParams.JournalParamsEnum.getValue(eventPayload.getEventType()).getJournalParams(eventPayload);
+
+    var journalParams = journalParamsOptional.get();
+    Assert.assertEquals(JournalRecord.EntityType.MARC_AUTHORITY, journalParams.journalEntityType);
+    Assert.assertEquals(JournalRecord.ActionType.DELETE, journalParams.journalActionType);
+    Assert.assertEquals(JournalRecord.ActionStatus.COMPLETED, journalParams.journalActionStatus);
+  }
+
+  @Test
+  public void shouldPopulateDeleteErrorParamsWhenDiErrorWithMarcForDeleteReceivedInEventsChain() {
+    eventPayload.setEventType(DI_ERROR.value());
+    context.put(JournalRecord.EntityType.MARC_AUTHORITY.value(), new JsonObject().encode());
+    eventPayload.setContext(context);
+    eventPayload.setEventsChain(List.of(DI_MARC_FOR_DELETE_RECEIVED.value()));
+
+    var journalParamsOptional =
+      JournalParams.JournalParamsEnum.getValue(eventPayload.getEventType()).getJournalParams(eventPayload);
+
+    var journalParams = journalParamsOptional.get();
+    Assert.assertEquals(JournalRecord.EntityType.MARC_AUTHORITY, journalParams.journalEntityType);
+    Assert.assertEquals(JournalRecord.ActionType.DELETE, journalParams.journalActionType);
     Assert.assertEquals(JournalRecord.ActionStatus.ERROR, journalParams.journalActionStatus);
   }
 }

--- a/mod-source-record-manager-server/src/test/java/org/folio/verticle/consumers/util/MarcImportEventsHandlerTest.java
+++ b/mod-source-record-manager-server/src/test/java/org/folio/verticle/consumers/util/MarcImportEventsHandlerTest.java
@@ -12,8 +12,11 @@ import static org.folio.rest.jaxrs.model.DataImportEventTypes.DI_ORDER_CREATED;
 import static org.folio.rest.jaxrs.model.DataImportEventTypes.DI_ORDER_CREATED_READY_FOR_POST_PROCESSING;
 import static org.folio.rest.jaxrs.model.DataImportEventTypes.DI_PENDING_ORDER_CREATED;
 import static org.folio.rest.jaxrs.model.DataImportEventTypes.DI_SRS_MARC_AUTHORITY_RECORD_CREATED;
+import static org.folio.rest.jaxrs.model.DataImportEventTypes.DI_SRS_MARC_AUTHORITY_RECORD_DELETED;
 import static org.folio.rest.jaxrs.model.DataImportEventTypes.DI_INCOMING_MARC_BIB_RECORD_PARSED;
+import static org.folio.rest.jaxrs.model.DataImportEventTypes.DI_MARC_FOR_DELETE_RECEIVED;
 import static org.folio.rest.jaxrs.model.DataImportEventTypes.DI_MARC_FOR_UPDATE_RECEIVED;
+import static org.folio.rest.jaxrs.model.DataImportEventTypes.DI_SRS_MARC_AUTHORITY_RECORD_NOT_MATCHED;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
@@ -60,6 +63,7 @@ import org.folio.rest.jaxrs.model.JournalRecord;
 import org.folio.services.MappingRuleCache;
 import org.folio.services.journal.JournalRecordMapperException;
 import org.folio.services.journal.JournalService;
+import org.folio.services.journal.JournalUtil;
 
 @RunWith(VertxUnitRunner.class)
 public class MarcImportEventsHandlerTest {
@@ -425,6 +429,111 @@ public class MarcImportEventsHandlerTest {
     assertEquals(JournalRecord.ActionType.UPDATE, actualJournalRecord.getActionType());
     assertEquals(JournalRecord.ActionStatus.ERROR, actualJournalRecord.getActionStatus());
     assertEquals(expectedTitleStart, actualJournalRecord.getTitle());
+  }
+
+  @Test
+  public void testSaveAuthorityJournalRecordWithTitleOfDeletedRecord() throws JournalRecordMapperException {
+    when(mappingRuleCache.get(any())).thenReturn(Future.succeededFuture(Optional.of(new JsonObject())));
+
+    var incomingMarcRecord = marcFactory.newRecord();
+    incomingMarcRecord.addVariableField(marcFactory.newDataField("150", '0', '0', "a", "Heading from the file"));
+
+    var deletedTitle = "Heading of the deleted record";
+    var deletedMarcRecord = marcFactory.newRecord();
+    deletedMarcRecord.addVariableField(marcFactory.newDataField("150", '0', '0', "a", deletedTitle));
+
+    var payload = constructAuthorityDeletePayload(incomingMarcRecord, deletedMarcRecord);
+
+    handler.handle(journalService, payload, TEST_TENANT);
+
+    verify(journalService).saveBatch(journalRecordCaptor.capture(), eq(TEST_TENANT));
+    var actualJournalRecord = journalRecordCaptor.getValue().getJsonObject(0).mapTo(JournalRecord.class);
+
+    assertEquals(JournalRecord.EntityType.MARC_AUTHORITY, actualJournalRecord.getEntityType());
+    assertEquals(JournalRecord.ActionType.DELETE, actualJournalRecord.getActionType());
+    assertEquals(deletedTitle, actualJournalRecord.getTitle());
+  }
+
+  @Test
+  public void testSaveAuthorityJournalRecordWithIncomingTitleWhenDeletedRecordIsAbsent() throws JournalRecordMapperException {
+    when(mappingRuleCache.get(any())).thenReturn(Future.succeededFuture(Optional.of(new JsonObject())));
+
+    var incomingTitle = "Heading from the file";
+    var incomingMarcRecord = marcFactory.newRecord();
+    incomingMarcRecord.addVariableField(marcFactory.newDataField("150", '0', '0', "a", incomingTitle));
+
+    var payload = constructAuthorityDeletePayload(incomingMarcRecord, null);
+
+    handler.handle(journalService, payload, TEST_TENANT);
+
+    verify(journalService).saveBatch(journalRecordCaptor.capture(), eq(TEST_TENANT));
+    var actualJournalRecord = journalRecordCaptor.getValue().getJsonObject(0).mapTo(JournalRecord.class);
+
+    assertEquals(JournalRecord.ActionType.DELETE, actualJournalRecord.getActionType());
+    assertEquals(incomingTitle, actualJournalRecord.getTitle());
+  }
+
+  @Test
+  public void testSaveAuthorityJournalRecordsForMultipleMatchesDuringDeletion() throws JournalRecordMapperException {
+    when(mappingRuleCache.get(any())).thenReturn(Future.succeededFuture(Optional.of(new JsonObject())));
+
+    var incomingTitle = "Heading from the file";
+    var incomingMarcRecord = marcFactory.newRecord();
+    incomingMarcRecord.addVariableField(marcFactory.newDataField("150", '0', '0', "a", incomingTitle));
+
+    var incomingRecord = new Record()
+      .withId(UUID.randomUUID().toString())
+      .withParsedRecord(new ParsedRecord().withContent(marcRecordToJsonContent(incomingMarcRecord)));
+
+    HashMap<String, String> payloadContext = new HashMap<>();
+    payloadContext.put(JournalRecord.EntityType.MARC_AUTHORITY.value(), Json.encode(incomingRecord));
+    payloadContext.put(ERROR_KEY, "Found multiple records matching specified conditions");
+
+    var payload = new DataImportEventPayload()
+      .withEventType(DI_ERROR.value())
+      .withEventsChain(List.of(DI_MARC_FOR_DELETE_RECEIVED.value(), DI_SRS_MARC_AUTHORITY_RECORD_NOT_MATCHED.value()))
+      .withContext(payloadContext);
+
+    handler.handle(journalService, payload, TEST_TENANT);
+
+    verify(journalService).saveBatch(journalRecordCaptor.capture(), eq(TEST_TENANT));
+    var journalRecords = journalRecordCaptor.getValue();
+    assertEquals(2, journalRecords.size());
+
+    var marcAuthorityRecord = journalRecords.getJsonObject(0).mapTo(JournalRecord.class);
+    assertEquals(JournalRecord.EntityType.MARC_AUTHORITY, marcAuthorityRecord.getEntityType());
+    assertEquals(JournalRecord.ActionType.NON_MATCH, marcAuthorityRecord.getActionType());
+    assertEquals(JournalRecord.ActionStatus.ERROR, marcAuthorityRecord.getActionStatus());
+    assertNotNull(marcAuthorityRecord.getError());
+    assertEquals(incomingTitle, marcAuthorityRecord.getTitle());
+
+    var authorityRecord = journalRecords.getJsonObject(1).mapTo(JournalRecord.class);
+    assertEquals(JournalRecord.EntityType.AUTHORITY, authorityRecord.getEntityType());
+    assertEquals(JournalRecord.ActionType.NON_MATCH, authorityRecord.getActionType());
+    assertEquals(JournalRecord.ActionStatus.ERROR, authorityRecord.getActionStatus());
+    assertNotNull(authorityRecord.getError());
+  }
+
+  private DataImportEventPayload constructAuthorityDeletePayload(org.marc4j.marc.Record incomingMarcRecord,
+                                                                 org.marc4j.marc.Record deletedMarcRecord) {
+    var incomingRecord = new Record()
+      .withId(UUID.randomUUID().toString())
+      .withParsedRecord(new ParsedRecord().withContent(marcRecordToJsonContent(incomingMarcRecord)));
+
+    HashMap<String, String> payloadContext = new HashMap<>();
+    payloadContext.put(JournalRecord.EntityType.MARC_AUTHORITY.value(), Json.encode(incomingRecord));
+    if (deletedMarcRecord != null) {
+      var deletedRecord = new Record()
+        .withId(UUID.randomUUID().toString())
+        .withMatchedId(UUID.randomUUID().toString())
+        .withParsedRecord(new ParsedRecord().withContent(marcRecordToJsonContent(deletedMarcRecord)));
+      payloadContext.put(JournalUtil.DELETED_MARC_AUTHORITY_KEY, Json.encode(deletedRecord));
+    }
+
+    return new DataImportEventPayload()
+      .withEventType(DI_COMPLETED.value())
+      .withEventsChain(List.of(DI_SRS_MARC_AUTHORITY_RECORD_DELETED.value()))
+      .withContext(payloadContext);
   }
 
   private DataImportEventPayload constructMatchHoldingsPayload(org.marc4j.marc.Record marcRecord) {


### PR DESCRIPTION
### Purpose
When a delete authority records job completes with no errors, the Data import Logs page must display status = Completed, and every processed record must appear in the job log with a Deleted action status for the SRS MARC and Authority columns.

### Approach
JournalUtil builds both a MARC_AUTHORITY and an AUTHORITY journal record from the single delete event.
get_job_log_entries and get_record_processing_log map DELETE to the new DELETED action status. 

### Related Issues
https://folio-org.atlassian.net/browse/MODSOURMAN-1421
